### PR TITLE
Change wrong section titles to unnumbered titles, figure/table captions

### DIFF
--- a/spec/src/main/asciidoc/ApplicationIntegration.adoc
+++ b/spec/src/main/asciidoc/ApplicationIntegration.adoc
@@ -2706,7 +2706,7 @@ metadata should be extracted.
 to support argument _viewId_ being a JSP markup file. In this case,
 _null_ must be returned from this method.[P1-end]
 
-===== ViewMetadata Contract
+.ViewMetadata Contract
 
 [width="100%",cols="100%",]
 |===

--- a/spec/src/main/asciidoc/ExpressionLanguageAndManagedBeanFacility.adoc
+++ b/spec/src/main/asciidoc/ExpressionLanguageAndManagedBeanFacility.adoc
@@ -162,7 +162,7 @@ Here is the set of component properties that
 currently support _MethodBinding_ , and the method signatures to which
 they must point:
 
-=== component properties whose type is DEPRECATED MethodBinding
+.component properties whose type is DEPRECATED MethodBinding
 
 component property
 
@@ -204,7 +204,7 @@ listener interface, allowing the wrapped expression to be added as a
 strongly typed listener, using the normal _add*()_ pattern Here is the
 list of such wrapper classes:
 
-=== MethodExpression wrappers to take the place of DEPRECATED MethodBinding properties
+.MethodExpression wrappers to take the place of DEPRECATED MethodBinding properties
 
 component listener property
 
@@ -772,7 +772,7 @@ In addition to managed beans being injectable
 in this manner, the following JSF artifacts are also injectable.
 
 [[a2541]]
-==== JSF Artifacts Eligible for Injection
+.JSF Artifacts Eligible for Injection
 
 Artifact Type
 
@@ -1238,7 +1238,7 @@ methods do indeed get called on a user-provided VariableResolver or
 PropertyResolver.] [P1-end]
 
 [[a2670]]
-==== Faces ELResolver for JSP Pages
+.Faces ELResolver for JSP Pages
 
 
 
@@ -1256,7 +1256,7 @@ This resolver relies on the presence of
 another, JSP specific, implicit object ELResolver in the chain by only
 resolving the “facesContext” and “view” implicit objects.
 
-===== Faces ImplicitObjectELResolver for JSP
+.Faces ImplicitObjectELResolver for JSP
 
 [width="100%",cols="50%,50%",options="header",]
 |===
@@ -1369,7 +1369,7 @@ This is the means by which the managed bean
 creation facility described in _<<ExpressionLanguageAndManagedBeanFacility.adoc#a2406,See The
 Managed Bean Facility>>_ is called into play during EL resolution.
 
-===== ManagedBeanELResolver
+.ManagedBeanELResolver
 
 [width="100%",cols="50%,50%",options="header",]
 |===
@@ -1462,7 +1462,7 @@ This is the means by which resource bundles
 defined in the application configuration resources are called into play
 during EL resolution.
 
-===== ResourceBundleELResolver
+.ResourceBundleELResolver
 
 [width="100%",cols="50%,50%",options="header",]
 |===
@@ -1585,7 +1585,7 @@ The semantics of the ELResolver that
 functions as the VariableResolver chain wrapper are described in the
 following table.
 
-===== ELResolver that is the VariableResolver Chain Wrapper
+.ELResolver that is the VariableResolver Chain Wrapper
 
 [width="100%",cols="50%,50%",options="header",]
 |===
@@ -1663,7 +1663,7 @@ The semantics of the ELResolver that
 functions as the property resolver chain wrapper are described in the
 following table.
 
-===== ELResolver that is the PropertyResolver Chain Wrapper
+.ELResolver that is the PropertyResolver Chain Wrapper
 
 [width="100%",cols="50%,50%",options="header",]
 |===
@@ -1743,7 +1743,7 @@ section is covered by the tests in 5.6.1][P1-end]
 
 
 [[a2827]]
-====  _ELResolver_ for Facelets and Programmatic Access
+._ELResolver_ for Facelets and Programmatic Access
 
 
 
@@ -1764,7 +1764,7 @@ JSP>> in that it must resolve all of the implicit objects, not just
 _facesContext_ and _view_
 
 [[a2832]]
-===== ImplicitObjectELResolver for Programmatic Access
+.ImplicitObjectELResolver for Programmatic Access
 
 [width="100%",cols="50%,50%",options="header",]
 |===
@@ -1984,7 +1984,7 @@ on it and the result is returned as the evaluation of the expression.
 Otherwise, if the value is _not_ a _ValueExpression_ the value itself is
 returned as the evaluation of the expression.”
 
-===== Composite Component Attributes ELResolver
+.Composite Component Attributes ELResolver
 
 [width="100%",cols="50%,50%",options="header",]
 |===
@@ -2091,7 +2091,7 @@ resource request from the browser can be satisfied using the
 ResourceHandler as described in _<<RequestProcessingLifecycle.adoc#a746,See
 Resource Handling>>_ .
 
-===== ResourceELResolver
+.ResourceELResolver
 
 [width="100%",cols="50%,50%",options="header",]
 |===
@@ -2190,7 +2190,7 @@ This ELResolver is responsible for doing the
 scoped lookup that makes it possible for expressions to pick up anything
 stored in the request, session, or application scopes by name.
 
-===== Scoped Attribute ELResolver
+.Scoped Attribute ELResolver
 
 [width="100%",cols="50%,50%",options="header",]
 |===
@@ -2520,13 +2520,13 @@ pertinent to JSF.
 It must be possible to inject the following
 JSF objects into other objects using _@Inject_ .
 
-==== Maps Returned by Various JSF Accessors
+.Maps Returned by Various JSF Accessors
 
 The annotations in package
 _jakarta.faces.annotation_ are used to cause _@Inject_ injection of the
 corresponding _Map_ into a field. Generics may be used.
 
-==== JSF Objects
+.JSF Objects
 
 It must be possible to _@Inject_ the
 following JSF and Jakarta EE objects into CDI beans.
@@ -2541,7 +2541,7 @@ following JSF and Jakarta EE objects into CDI beans.
 
 - jakarta.servlet.http._HttpSession_
 
-==== Support for Injection into JSF Managed Objects
+.Support for Injection into JSF Managed Objects
 
 It must be possible to use _@Inject_ when
 specifying the following kinds of JSF managed objects.

--- a/spec/src/main/asciidoc/FaceletsAndWebApplications.adoc
+++ b/spec/src/main/asciidoc/FaceletsAndWebApplications.adoc
@@ -28,7 +28,7 @@ following table lists some of the differences between Facelets and JSP
 
 
 
-==== Comparison of Facelets and JSP
+.Comparison of Facelets and JSP
 
 Feature Name
 
@@ -123,7 +123,7 @@ Facelets in JSF 2.0 provides tag libraries
 that are compatible with the following libraries already found in pre
 JSF 2.0 Facelets.
 
-==== Taglibs in pre JSF 2.0 Facelets that are available in Facelets in JSF 2.0
+.Taglibs in pre JSF 2.0 Facelets that are available in Facelets in JSF 2.0
 
 Common prefix
 
@@ -1088,7 +1088,7 @@ associate an Ajax action with that component. If this tag is placed
 around a group of components it will associate an Ajax action with all
 components that support the “events” attribute. In there is an outer
 
-===== Syntax
+.Syntax
 
 <f:ajax [event=”Literal”] [execute=”Literal |
 Value Expression”] [render=”Literal | Value Expression”]
@@ -1096,11 +1096,11 @@ Value Expression”] [render=”Literal | Value Expression”]
 Expression”] | [listener=”Method Expression”] [disabled=”Literal|Value
 Expression”] [immediate=”Literal|ValueExpression]/>
 
-===== Body Content
+.Body Content
 
 empty.
 
-===== Attributes
+.Attributes
 
 The following optional attributes are
 available:
@@ -1201,7 +1201,7 @@ If “true” behavior events generated from this
 behavior are broadcast during Apply Request Values phase. Otherwise, the
 events will be broadcast during Invoke Aplications phase.
 
-===== Specifying “execute”/”render” Identifiers
+.Specifying “execute”/”render” Identifiers
 
 {empty}The String value for identifiers
 specified for execute and render may be specified as a search expression
@@ -1209,7 +1209,7 @@ as outlined in the JavaDocs for UIComponent.findComponent.
 [P1_start_execrenderIds]The implementation must resolve these
 identifiers as specified for UIComponent.findComponent.[P1_end]
 
-===== Constraints
+.Constraints
 
 This tag may be nested within any of the
 standard HTML components. It may also be nested within any custom
@@ -1354,7 +1354,7 @@ attached to “button1”. the outer <f:ajax> Ajax behavior will also get
 applied to “button1”. But it will be applied *after* the “greet”
 behavior.
 
-===== Description
+.Description
 
 Enable one or more components in the view to
 perform Ajax operations. This tag handler must create an instance of
@@ -1383,7 +1383,7 @@ instance must be added as a Behavior to the component. Please refer to
 the Javadocs for the core tag handler AjaxHandler for additional
 requirements.
 
-===== Examples
+.Examples
 
 Apply Ajax to “button1” and “text1”:
 
@@ -1526,7 +1526,7 @@ _ <!-- other input components here --> +
 </f:validateBean> +
 </h:form>
 
-===== Body Content
+.Body Content
 
 Empty in the case when the Bean Validator is
 to be registered on a parent component.
@@ -1619,7 +1619,7 @@ Syntax
 
 <f:validateRequired/>
 
-===== Body Content
+.Body Content
 
 empty
 
@@ -1708,7 +1708,7 @@ model object --> +
 <f:validateWholeBean value=_ " _#\{model}_ " _ +
 validationGroups=_ " _fully.qualified.class.Name_ " _/>_
 
-===== Body Content
+.Body Content
 
 empty
 
@@ -1771,7 +1771,7 @@ has among others the advantage of maintaining the JSF view state, the
 HTTP session and, critically, all security constraints on business
 service methods.
 
-===== Syntax
+.Syntax
 
 _<f:websocket [binding=_ " _ValueExpression_
 " _] [id=_ " _Literal|ValueExpression_ " _] +
@@ -1783,12 +1783,12 @@ _Literal|ValueExpression_ " _] +
 _Literal|ValueExpression_ " _] +
 [rendered=_ " _Literal|ValueExpression_ " _] />_
 
-===== Body Content
+.Body Content
 
 Empty, or one or more _<f:ajax>_ tags with
 the _event_ attribute set to exactly the push message content.
 
-===== Attributes
+.Attributes
 
 The following required attribute must be set:
 
@@ -1894,7 +1894,7 @@ property bound to the component instance for the UIComponent created by
 this tag.
 |===
 
-===== Configuration
+.Configuration
 
 First, enable the websocket endpoint using
 the context parameter:
@@ -1920,7 +1920,7 @@ integer context parameter in web.xml to explicitly specify the port.
 </context-param>
 |===
 
-===== Usage (client)
+.Usage (client)
 
 Declare <f:websocket> tag in the JSF view
 with at least a channel name and an onmessage JavaScript listener
@@ -1972,7 +1972,7 @@ will not auto-reconnect when the very first connection attempt already
 fails. The websocket will be implicitly closed once the document is
 unloaded.
 
-===== Usage (server)
+.Usage (server)
 
 On the Java programming side, you can inject
 a PushContext via @Push annotation on the given channel name in any
@@ -2010,7 +2010,7 @@ listener function associated with the channel name. It can be a plain
 vanilla String, but it can also be a collection, map and even a Java
 bean.
 
-===== Scopes and Users
+.Scopes and Users
 
 By default the websocket is application
 scoped, i.e. any view/session throughout the web application having the
@@ -2104,7 +2104,7 @@ someChannel.send(message, recipientUserIds); +
 }
 |===
 
-===== Conditionally Connecting
+.Conditionally Connecting
 
 You can use the optional connected attribute
 to control whether to auto-connect the websocket or not..
@@ -2149,7 +2149,7 @@ jsf.push.close('foo'); +
 }
 |===
 
-===== Events (client)
+.Events (client)
 
 The optional onopen JavaScript listener
 function can be used to listen on open of a websocket in client side.
@@ -2218,7 +2218,7 @@ automatically closed with close reason code 1000 by the server (and thus
 not manually by the client via jsf.push.close(clientId)), then it means
 that the session or view has expired.
 
-===== Events (server)
+.Events (server)
 
 When a session or view scoped socket is
 automatically closed with close reason code 1000 by the server (and thus
@@ -2252,7 +2252,7 @@ CloseCode code = event.getCloseCode(); +
 
 |===
 
-===== Security Considerations
+.Security Considerations
 
 If the socket is declared in a page which is
 only restricted to logged-in users with a specific role, then you may
@@ -2316,7 +2316,7 @@ CloseCodes.NORMAL_CLOSURE (1000). Only application scoped sockets remain
 open and are still reachable from server end even when the session or
 view associated with the page in client side is expired.
 
-===== Ajax Support
+.Ajax Support
 
 In case you’d like to perform complex UI
 updates depending on the received push message, then you can nest
@@ -2378,7 +2378,7 @@ to the ones defined in the other section.
 
 
 
-==== Renderers Unique to Facelets
+.Renderers Unique to Facelets
 
 [width="100%",cols="34%,33%,33%",options="header",]
 |===
@@ -2418,7 +2418,7 @@ the normative specification.
 
 ---
 
-Assertions relating to the construction of the view
+=== Assertions relating to the construction of the view
 hierarchy
 
 [P1-start processListenerForAnnotation] When

--- a/spec/src/main/asciidoc/IntegrationWithJSP.adoc
+++ b/spec/src/main/asciidoc/IntegrationWithJSP.adoc
@@ -47,7 +47,7 @@ example, assume the existence of a concrete _RenderKit_ ,
 _HTMLRenderKit_ , which supports three _Renderer_ types for the
 _UIInput_ component:
 
-=== Example Renderer Types
+.Example Renderer Types
 
 RendererType
 
@@ -1604,14 +1604,14 @@ action.
 
 ===== Syntax
 
-===== Syntax 1: Unnamed value
+.Syntax 1: Unnamed value
 
 <f:param
 [id=”componentIdOrImmediateExpression”] value=”parameter-value”
 
 [binding=” _componentReference”]_ />
 
-===== Syntax 2: Named value
+.Syntax 2: Named value
 
 {empty}<f:param
 [id=”componentIdOrImmediateExpression”]
@@ -1752,7 +1752,7 @@ action.
 
 ===== Syntax
 
-===== Syntax 1: Directly Specified Value
+.Syntax 1: Directly Specified Value
 
 {empty}<f:selectItem
 [id=”componentIdOrImmediateExpression”]
@@ -1767,7 +1767,7 @@ itemLabel=” _itemLabel”_
 
 [itemDescription=” _itemDescription”]_ />
 
-===== Syntax 2: Indirectly Specified Value
+.Syntax 2: Indirectly Specified Value
 
 {empty}<f:selectItem
 [id=”componentIdOrImmediateExpression”]
@@ -2262,17 +2262,17 @@ custom action.
 
 ===== Syntax
 
-===== Syntax 1: Maximum only specified
+.Syntax 1: Maximum only specified
 
 <f:validateDoubleRange maximum=”543.21”
 binding=”VB Expression”/>
 
-===== Syntax 2: Minimum only specified
+.Syntax 2: Minimum only specified
 
 <f:validateDoubleRange minimum=”123.45”
 binding=”VB Expression”/>
 
-===== Syntax 3: Both maximum and minimum are specified
+.Syntax 3: Both maximum and minimum are specified
 
 <f:validateDoubleRange maximum=”543.21”
 minimum=”123.45” binding=”VB Expression”/>
@@ -2374,17 +2374,17 @@ action.
 
 ===== Syntax
 
-===== Syntax 1: Maximum length only specified
+.Syntax 1: Maximum length only specified
 
 <f:validateLength maximum=”10” binding=”VB
 Expression”/>
 
-===== Syntax 2: Minimum only specified
+.Syntax 2: Minimum only specified
 
 <f:validateLength minimum=”1” binding=”VB
 Expression”/>
 
-===== Syntax 3: Both maximum and minimum are specified
+.Syntax 3: Both maximum and minimum are specified
 
 <f:validateLength maximum=”10” minimum=”1”
 binding=”VB Expression”/>
@@ -2565,17 +2565,17 @@ custom action.
 
 ===== Syntax
 
-===== Syntax 1: Maximum only specified
+.Syntax 1: Maximum only specified
 
 <f:validateLongRange maximum=”543”
 binding=”VB Expression”/>
 
-===== Syntax 2: Minimum only specified
+.Syntax 2: Minimum only specified
 
 <f:validateLongRange minimum=”123”
 binding=”VB Expression”/>
 
-===== Syntax 3: Both maximum and minimum are specified
+.Syntax 3: Both maximum and minimum are specified
 
 <f:validateLongRange maximum=”543”
 minimum=”123” binding=”VB Expression”/>
@@ -3032,7 +3032,7 @@ actions defined in this tag library must specify the following return
 values for the _getComponentType()_ and _getRendererType()_ methods,
 respectively:.
 
-=== Standard HTML RenderKit Tag Library
+.Standard HTML RenderKit Tag Library
 
 getComponentType()
 

--- a/spec/src/main/asciidoc/JSFMetadata.adoc
+++ b/spec/src/main/asciidoc/JSFMetadata.adoc
@@ -97,7 +97,7 @@ applications already using the JSP document syntax (also known as JSPX
 syntax). The affect on the processing of files in each of these three
 modes is specified in the following table.
 
-===== Valid _<process-as>_ values and their implications on the processing of Facelet VDL files.
+.Valid _<process-as>_ values and their implications on the processing of Facelet VDL files.
 
 
 

--- a/spec/src/main/asciidoc/JavaScriptAPI.adoc
+++ b/spec/src/main/asciidoc/JavaScriptAPI.adoc
@@ -111,7 +111,7 @@ associative object array that may contain the following name/value
 pairs:
 
 [[a6871]]
-==== request OPTIONS
+.request OPTIONS
 
 Name
 
@@ -152,7 +152,7 @@ parameters to include in the request.
 The following keywords can be used for the
 value of the “execute” and “render” attributes:
 
-==== Execute / Render Keywords
+.Execute / Render Keywords
 
 Keyword
 
@@ -318,7 +318,7 @@ an existing JavaScript function that will handle the events. The events
 that can be handled are:
 
 [[a6936]]
-==== Events
+.Events
 
 Event Name
 
@@ -347,7 +347,7 @@ The callback function has access to the
 following “data payload”:.
 
 [[a6947]]
-==== Event Data Payload
+.Event Data Payload
 
 Name
 
@@ -430,7 +430,7 @@ The callback argument must be a reference to
 an existing JavaScript function that will handle errors from the server.
 
 [[a6976]]
-==== Errors
+.Errors
 
 Error Name
 
@@ -460,7 +460,7 @@ The callback function has access to the
 following “data payload”:.
 
 [[a6988]]
-==== Error Data Payload
+.Error Data Payload
 
 Name
 

--- a/spec/src/main/asciidoc/RenderingModel.adoc
+++ b/spec/src/main/asciidoc/RenderingModel.adoc
@@ -286,7 +286,7 @@ interface _._
 ClientBehaviorRenderer implementations may be
 registered in the JSF faces-config.xml or with an annotation.
 
-==== XML Registration
+.XML Registration
 
 
 
@@ -309,7 +309,7 @@ a|
 
 |===
 
-==== Registration By Annotation
+.Registration By Annotation
 
 JSF provides the
 _jakarta.faces.render.FacesBehaviorRenderer annotation._
@@ -484,7 +484,7 @@ _Behavior attached to them. Refer to_
 <<UserInterfaceComponentModel.adoc#a1707,See Component
 Behavior Model>> __ for additional details.
 
-=== Concrete HTML Component Classes
+.Concrete HTML Component Classes
 
 jakarta.faces.component class
 

--- a/spec/src/main/asciidoc/RequestProcessingLifecycle.adoc
+++ b/spec/src/main/asciidoc/RequestProcessingLifecycle.adoc
@@ -258,7 +258,7 @@ _facesContext.renderResponse()_ . If it turns out that the previous call
 to _createViewMetadata()_ did not create a _UIViewRoot_ instance, call
 _createView()_ on the _ViewHandler_ .
 
-==== View Protection
+.View Protection
 
 Call
 ViewHandler.getProtectedViewsUnmodifiable() to determine if the view for
@@ -713,7 +713,7 @@ rendered, Render the state using the algorithm described below in
 _endDocument()_ on the _PartialResponseWriter_ and return.
 
 [[a487]]
-===== Partial State Rendering
+.Partial State Rendering
 
 This section describes the requirements for
 rendering the _<update>_ elements pertaining to view state and window id
@@ -1531,7 +1531,7 @@ author. However, the complexity has to live somewhere, and the JSF
 implementor is the lucky role. Here is an overview of the key players.
 Please see the javadocs for each individual class for more information.
 
-===== Key Players in State Management
+.Key Players in State Management
 
 _StateHelper_ the helper class that defines
 a _Map_ -like contract that makes it easier for components to implement

--- a/spec/src/main/asciidoc/StandardUserInterfaceComponents.adoc
+++ b/spec/src/main/asciidoc/StandardUserInterfaceComponents.adoc
@@ -51,7 +51,7 @@ The following UML class diagram shows the
 classes and interfaces in the package _jakarta.faces.component._
 
 [[a1834]]
-=== The _jakarta.faces.component_ package
+.The _jakarta.faces.component_ package
 
 image:SF-22.png[image]
 

--- a/spec/src/main/asciidoc/UserInterfaceComponentModel.adoc
+++ b/spec/src/main/asciidoc/UserInterfaceComponentModel.adoc
@@ -642,7 +642,7 @@ interface. [P1-end]
 [[a1006]]
 ===== Special Attributes
 
-===== UIComponent Constants
+.UIComponent Constants
 
 [width="100%",cols="100%",]
 |===
@@ -3377,7 +3377,7 @@ requirements for the composite component runtime, or pointers to other
 parts of the specification that articulate those requirements in the
 appropriate context.
 
-===== References to Composite Component Requirements in Context
+.References to Composite Component Requirements in Context
 
 Section
 
@@ -3514,7 +3514,7 @@ The list of attached object targets would
 consist of instances of implementations of the following interfaces from
 the package _javax.faces.webapp.vdl_ .
 
-===== EditableValueHolderAttachedObjectTarget
+EditableValueHolderAttachedObjectTarget
 
 ActionSource2AttachedObjectTarget
 
@@ -3913,7 +3913,7 @@ classes described in the previous section the specification supports an
 event listener model for broadcasting and handling _AjaxBehavior_
 events.
 
-===== jakarta.faces.event.AjaxBehaviorEvent
+._jakarta.faces.event.AjaxBehaviorEvent_
 
 This event type extends from
 _jakarta.faces.event.BehaviorEvent_ and it is broadcast from an
@@ -3924,7 +3924,7 @@ responsible for invoking the method implementation of
 _jakarta.faces.event.AjaxBehaviorListener.processAjaxBehavior._ Refer to
 the javadocs for more complete details about this class.
 
-===== jakarta.faces.event.AjaxBehaviorListener
+._jakarta.faces.event.AjaxBehaviorListener_
 
 This listener type extends from
 _jakarta.faces.event.BehaviorListener_ and it is invoked in response to


### PR DESCRIPTION
Signed-off-by: Akira Kawauchi <kasabuta4@gmail.com>

There are some section titles which are not section titles in JSF2.3 spec document.
I change them to unnumbered titles, figure/table captions.