### PR TITLE
Old Faces TCK : add option to deploy and run single test

### DIFF
--- a/tck/faces-tck/pom-bundle.xml
+++ b/tck/faces-tck/pom-bundle.xml
@@ -36,7 +36,7 @@
         <tck.tests.home>${tck.home}/src/com/sun/ts/tests/jsf</tck.tests.home> 
         <tck.mode>standalone</tck.mode>
         <glassfish.home>${project.build.directory}/glassfish7</glassfish.home>
-        <glassfish.version>7.0.0-M2</glassfish.version>
+        <glassfish.version>7.0.0-M4</glassfish.version>
         <glassfish.asadmin>${glassfish.home}/glassfish/bin/asadmin</glassfish.asadmin>
        
         <jacoco.includes>org/glassfish/**\:com/sun/enterprise/**</jacoco.includes>
@@ -373,7 +373,7 @@
                             <goal>run</goal>
                         </goals>
                         <configuration>
-                            <target>
+                            <target xmlns:if="ant:if" xmlns:unless="ant:unless">
                                 <replace file="${glassfish.home}/glassfish/domains/domain1/config/domain.xml" 
                                     token="-Xmx512m" value="-Xmx1024m" />
                                     
@@ -385,10 +385,24 @@
                                     </exec>
                                 </limit>
                                 
-                                <exec executable="${ant.home}/bin/ant" dir="${tck.tests.home}">
-                                    <arg value="-Dutil.dir=${tck.home}"  />
-                                    <arg value="deploy.all"  />
-                                </exec>
+                                <!-- Deploy single test -->
+                                <sequential if:set="run.test" >
+                                	<dirname property="test.dir" file="${tck.home}/src/${run.test}"/>
+                                	<echo>Deploying from ${test.dir}</echo>
+                                	
+                                	<exec executable="${ant.home}/bin/ant" dir="${test.dir}">
+                                    	<arg value="deploy"  />
+                                	</exec>
+                                </sequential>
+                                
+                                <!-- Deploy all tests -->
+                                <sequential unless:set="run.test" >
+                                    <echo>Deploying all archives</echo>
+                                	<exec executable="${ant.home}/bin/ant" dir="${tck.tests.home}">
+                                        <arg value="-Dutil.dir=${tck.home}"  />
+                                    	<arg value="deploy.all"  />
+                                	</exec>
+                                </sequential>
                             </target>
                         </configuration>
                     </execution>
@@ -410,7 +424,8 @@
                                 <exec executable="${ant.home}/bin/ant" dir="${tck.tests.home}" resultproperty="testResult">
                                     <arg value="-Dutil.dir=${tck.home}"  />
                                     <arg value="-Dmultiple.tests=${run.test}" if:set="run.test" />
-                                    <arg value="runclient"/>
+                                    <arg value="run.all" unless:set="run.test"/>
+                                    <arg value="runclient" if:set="run.test" />
                                     <env key="LC_ALL" value="C" />
                                 </exec>
 

--- a/tck/faces-tck/pom.xml
+++ b/tck/faces-tck/pom.xml
@@ -36,7 +36,7 @@
         <tck.tests.home>${tck.home}/src/com/sun/ts/tests/jsf</tck.tests.home>         
         <tck.mode>standalone</tck.mode>         
         <glassfish.home>${project.build.directory}/glassfish7</glassfish.home>
-        <glassfish.version>7.0.0-M2</glassfish.version>
+        <glassfish.version>7.0.0-M4</glassfish.version>
         <glassfish.asadmin>${glassfish.home}/glassfish/bin/asadmin</glassfish.asadmin>
        
         <jacoco.includes>org/glassfish/**\:com/sun/enterprise/**</jacoco.includes>
@@ -410,7 +410,7 @@
                             <goal>run</goal>
                         </goals>
                         <configuration>
-                            <target>
+                            <target xmlns:if="ant:if" xmlns:unless="ant:unless">
                                 <replace file="${glassfish.home}/glassfish/domains/domain1/config/domain.xml" 
                                     token="-Xmx512m" value="-Xmx1024m" />
                                     
@@ -421,11 +421,25 @@
                                         <arg value="start-domain"/>
                                     </exec>
                                 </limit>
+
+                                <!-- Deploy single test -->
+                                <sequential if:set="run.test" >
+                                	<dirname property="test.dir" file="${tck.home}/src/${run.test}"/>
+                                	<echo>Deploying from ${test.dir}</echo>
+                                	
+                                	<exec executable="${ant.home}/bin/ant" dir="${test.dir}">
+                                    	<arg value="deploy"  />
+                                	</exec>
+                                </sequential>
                                 
-                                <exec executable="${ant.home}/bin/ant" dir="${tck.tests.home}">
-                                    <arg value="-Dutil.dir=${tck.home}"  />
-                                    <arg value="deploy.all"  />
-                                </exec>
+                                <!-- Deploy all tests -->
+                                <sequential unless:set="run.test" >
+                                    <echo>Deploying all archives</echo>
+                                	<exec executable="${ant.home}/bin/ant" dir="${tck.tests.home}">
+                                        <arg value="-Dutil.dir=${tck.home}"  />
+                                    	<arg value="deploy.all"  />
+                                	</exec>
+                                </sequential>
                             </target>
                         </configuration>
                     </execution>
@@ -447,10 +461,10 @@
                                 <exec executable="${ant.home}/bin/ant" dir="${tck.tests.home}" resultproperty="testResult">
                                     <arg value="-Dutil.dir=${tck.home}"  />
                                     <arg value="-Dmultiple.tests=${run.test}" if:set="run.test" />
-                                    <arg value="runclient"/>
+                                    <arg value="run.all" unless:set="run.test"/>
+                                    <arg value="runclient" if:set="run.test" />
                                     <env key="LC_ALL" value="C" />
                                 </exec>
-
                                 <if>
                                     <not>
                                         <equals arg1="${testResult}" arg2="0" />

--- a/tck/faces-tck/src/com/sun/ts/tests/jsf/common/beans.xml
+++ b/tck/faces-tck/src/com/sun/ts/tests/jsf/common/beans.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2022 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+
+<beans xmlns="https://jakarta.ee/xml/ns/jakartaee" 
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_4_0.xsd" 
+        bean-discovery-mode="all">
+</beans>

--- a/tck/faces-tck/src/com/sun/ts/tests/jsf/spec/flows/common/beans.xml
+++ b/tck/faces-tck/src/com/sun/ts/tests/jsf/spec/flows/common/beans.xml
@@ -20,5 +20,6 @@
 <beans xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
    xsi:schemaLocation="
         https://jakarta.ee/xml/ns/jakartaee 
-        https://jakarta.ee/xml/ns/jakartaee/beans_4_0.xsd">
+        https://jakarta.ee/xml/ns/jakartaee/beans_4_0.xsd" 
+    bean-discovery-mode="all">
 </beans>


### PR DESCRIPTION
1. Add option to deploy and run a single test in old tck : 
As suggested at https://github.com/jakartaee/faces/issues/1600#issuecomment-1102719382 & https://github.com/jakartaee/faces/issues/1600#issuecomment-1104376030.
Followed the example at https://github.com/eclipse-ee4j/glassfish/blob/master/appserver/tests/tck/pages/pom.xml

Usage eg : `mvn verify -Drun.test=com/sun/ts/tests/jsf/api/jakarta_faces/facesexception/URLClient.java`  

2. Also set bean-discovery-mode=all for 2 empty beans.xml files.

@arjantijms 