### PR TITLE
Set renderKitId within initFaces()

### DIFF
--- a/tck/faces-tck/src/com/sun/ts/tests/jsf/common/servlets/HttpTCKServlet.java
+++ b/tck/faces-tck/src/com/sun/ts/tests/jsf/common/servlets/HttpTCKServlet.java
@@ -219,6 +219,11 @@ public abstract class HttpTCKServlet extends HttpServlet {
       // Set up references to the application and facesContext objects
       application = facesContext.getApplication();
       facesContext.setViewRoot(createViewRoot());
+
+      // Set up RenderKit
+      String renderKitId = facesContext.getApplication().getViewHandler().calculateRenderKitId(facesContext);
+      facesContext.getViewRoot().setRenderKitId(renderKitId);
+
     } else {
       throw new IllegalStateException(
           "Unable to obtain FacesContextFactory instance.");


### PR DESCRIPTION
Previously when `application.getViewHandler().createView(facesContext, viewId);` was called, the renderKitId was set within createView. (Please correct me if I'm wrong) 

https://github.com/eclipse-ee4j/mojarra/blob/3.0.2/impl/src/main/java/com/sun/faces/application/ViewHandlerImpl.java#L314-L356

My proposed solution is to set the renderKitId during the setup phase in the test instead.   Everything I tried failed because ViewHandlingStrategyNotFoundException was thrown. The viewId is null here, so  there's not strategy that can returned. 

In my testing, `HTML_BASIC` was set.

I think this would be best solution. Also, can anyone run a build to verify? 

@arjantijms @alwin-joseph 