### PR TITLE
Append .xhtml to viewIds 

### DIFF
--- a/tck/faces-tck/src/com/sun/ts/tests/jsf/api/jakarta_faces/application/viewhandler/TestServlet.java
+++ b/tck/faces-tck/src/com/sun/ts/tests/jsf/api/jakarta_faces/application/viewhandler/TestServlet.java
@@ -100,7 +100,7 @@ public final class TestServlet extends HttpTCKServlet {
   public void viewHandlerCreateViewTest(HttpServletRequest request,
       HttpServletResponse response) throws ServletException, IOException {
     PrintWriter out = response.getWriter();
-    String viewId = "/viewId";
+    String viewId = "/viewId.xhtml";
     UIViewRoot root = getApplication().getViewHandler()
         .createView(getFacesContext(), viewId);
     if (root == null) {
@@ -123,7 +123,7 @@ public final class TestServlet extends HttpTCKServlet {
 
     getFacesContext().setViewRoot(root);
 
-    String newViewId = "/newViewId";
+    String newViewId = "/newViewId.xhtml";
 
     UIViewRoot root2 = getApplication().getViewHandler()
         .createView(getFacesContext(), newViewId);
@@ -273,7 +273,7 @@ public final class TestServlet extends HttpTCKServlet {
 
     JSFTestUtil.checkForNPE(getApplication().getViewHandler().getClass(),
         "createView", new Class<?>[] { FacesContext.class, String.class },
-        new Object[] { null, "/viewId" }, out);
+        new Object[] { null, "/viewId.xhtml" }, out);
   }
 
   // ViewHandler.calculateRenderKitId(FacesContext) throws

--- a/tck/faces-tck/src/com/sun/ts/tests/jsf/api/jakarta_faces/component/html/htmlselectmanycheckbox/TestServlet.java
+++ b/tck/faces-tck/src/com/sun/ts/tests/jsf/api/jakarta_faces/component/html/htmlselectmanycheckbox/TestServlet.java
@@ -89,7 +89,7 @@ public final class TestServlet extends
     UIInput input = (UIInput) createComponent();
     input.setRendererType(null);
     UIViewRoot root = facesContext.getApplication().getViewHandler()
-        .createView(facesContext, "/root");
+        .createView(facesContext, "/root.xhtml");
     root.getChildren().add(input);
     ValueChangeEvent event = new ValueChangeEvent(input, null, null);
     event.setPhaseId(PhaseId.PROCESS_VALIDATIONS);

--- a/tck/faces-tck/src/com/sun/ts/tests/jsf/api/jakarta_faces/component/uiinput/TestServlet.java
+++ b/tck/faces-tck/src/com/sun/ts/tests/jsf/api/jakarta_faces/component/uiinput/TestServlet.java
@@ -112,7 +112,7 @@ public class TestServlet extends BaseComponentTestServlet {
     FacesContext facesContext = getFacesContext();
     UIInput input = (UIInput) createComponent();
     UIViewRoot root = facesContext.getApplication().getViewHandler()
-        .createView(facesContext, "/root");
+        .createView(facesContext, "/root.xhtml");
     root.getChildren().add(input);
     ValueChangeEvent event = new ValueChangeEvent(input, null, null);
     event.setPhaseId(PhaseId.PROCESS_VALIDATIONS);
@@ -363,7 +363,7 @@ public class TestServlet extends BaseComponentTestServlet {
     UIInput input = (UIInput) createComponent();
     FacesContext context = getFacesContext();
     UIViewRoot root = getApplication().getViewHandler().createView(context,
-        "/root");
+        "/root.xhtml");
     context.setViewRoot(root);
     root.getChildren().add(input);
 
@@ -402,7 +402,7 @@ public class TestServlet extends BaseComponentTestServlet {
     UIInput input = (UIInput) createComponent();
     FacesContext context = getFacesContext();
     UIViewRoot root = getApplication().getViewHandler().createView(context,
-        "/root");
+        "/root.xhtml");
     context.setViewRoot(root);
     root.getChildren().add(input);
 
@@ -476,7 +476,7 @@ public class TestServlet extends BaseComponentTestServlet {
     UIInput input = (UIInput) createComponent();
     FacesContext context = getFacesContext();
     UIViewRoot root = getApplication().getViewHandler().createView(context,
-        "/root");
+        "/root.xhtml");
     context.setViewRoot(root);
     root.getChildren().add(input);
 
@@ -537,7 +537,7 @@ public class TestServlet extends BaseComponentTestServlet {
     UIInput input = (UIInput) createComponent();
     FacesContext context = getFacesContext();
     UIViewRoot root = getApplication().getViewHandler().createView(context,
-        "/root");
+        "/root.xhtml");
     context.setViewRoot(root);
     root.getChildren().add(input);
 
@@ -607,7 +607,7 @@ public class TestServlet extends BaseComponentTestServlet {
     UIInput input = (UIInput) createComponent();
     FacesContext context = getFacesContext();
     UIViewRoot root = getApplication().getViewHandler().createView(context,
-        "/root");
+        "/root.xhtml");
     context.setViewRoot(root);
     root.getChildren().add(input);
 
@@ -676,7 +676,7 @@ public class TestServlet extends BaseComponentTestServlet {
     input.setRendererType(null);
     FacesContext context = getFacesContext();
     UIViewRoot root = getApplication().getViewHandler().createView(context,
-        "/root");
+        "/root.xhtml");
     context.setViewRoot(root);
     root.getChildren().add(input);
 
@@ -723,7 +723,7 @@ public class TestServlet extends BaseComponentTestServlet {
     input.setRendererType(null);
     FacesContext context = getFacesContext();
     Application application = getApplication();
-    UIViewRoot root = application.getViewHandler().createView(context, "/root");
+    UIViewRoot root = application.getViewHandler().createView(context, "/root.xhtml");
     context.setViewRoot(root);
     root.getChildren().add(input);
 

--- a/tck/faces-tck/src/com/sun/ts/tests/jsf/api/jakarta_faces/component/uiselectboolean/TestServlet.java
+++ b/tck/faces-tck/src/com/sun/ts/tests/jsf/api/jakarta_faces/component/uiselectboolean/TestServlet.java
@@ -133,7 +133,7 @@ public class TestServlet
     UIInput input = (UIInput) createComponent();
     input.setRendererType(null);
     UIViewRoot root = facesContext.getApplication().getViewHandler()
-        .createView(facesContext, "/root");
+        .createView(facesContext, "/root.xhtml");
     root.getChildren().add(input);
     ValueChangeEvent event = new ValueChangeEvent(input, null, null);
     event.setPhaseId(PhaseId.PROCESS_VALIDATIONS);
@@ -216,7 +216,7 @@ public class TestServlet
     UIInput input = (UIInput) createComponent();
     FacesContext context = getFacesContext();
     UIViewRoot root = getApplication().getViewHandler().createView(context,
-        "/root");
+        "/root.xhtml");
     context.setViewRoot(root);
     root.getChildren().add(input);
 
@@ -277,7 +277,7 @@ public class TestServlet
     UIInput input = (UIInput) createComponent();
     FacesContext context = getFacesContext();
     UIViewRoot root = getApplication().getViewHandler().createView(context,
-        "/root");
+        "/root.xhtml");
     context.setViewRoot(root);
     root.getChildren().add(input);
 
@@ -347,7 +347,7 @@ public class TestServlet
     UIInput input = (UIInput) createComponent();
     FacesContext context = getFacesContext();
     UIViewRoot root = getApplication().getViewHandler().createView(context,
-        "/root");
+        "/root.xhtml");
     context.setViewRoot(root);
     root.getChildren().add(input);
 

--- a/tck/faces-tck/src/com/sun/ts/tests/jsf/api/jakarta_faces/component/uiselectmany/TestServlet.java
+++ b/tck/faces-tck/src/com/sun/ts/tests/jsf/api/jakarta_faces/component/uiselectmany/TestServlet.java
@@ -137,7 +137,7 @@ public class TestServlet
     UIInput input = (UIInput) createComponent();
     input.setRendererType(null);
     UIViewRoot root = facesContext.getApplication().getViewHandler()
-        .createView(facesContext, "/root");
+        .createView(facesContext, "/root.xhtml");
     root.getChildren().add(input);
     ValueChangeEvent event = new ValueChangeEvent(input, null, null);
     event.setPhaseId(PhaseId.PROCESS_VALIDATIONS);
@@ -230,7 +230,7 @@ public class TestServlet
     input.getChildren().add(item3);
     FacesContext context = getFacesContext();
     UIViewRoot root = getApplication().getViewHandler().createView(context,
-        "/root");
+        "/root.xhtml");
     context.setViewRoot(root);
     root.getChildren().add(input);
 
@@ -299,7 +299,7 @@ public class TestServlet
     input.getChildren().add(item3);
     FacesContext context = getFacesContext();
     UIViewRoot root = getApplication().getViewHandler().createView(context,
-        "/root");
+        "/root.xhtml");
     context.setViewRoot(root);
     root.getChildren().add(input);
 
@@ -377,7 +377,7 @@ public class TestServlet
     input.getChildren().add(item3);
     FacesContext context = getFacesContext();
     UIViewRoot root = getApplication().getViewHandler().createView(context,
-        "/root");
+        "/root.xhtml");
     context.setViewRoot(root);
     root.getChildren().add(input);
 
@@ -452,7 +452,7 @@ public class TestServlet
     input.getChildren().add(item3);
     FacesContext context = getFacesContext();
     UIViewRoot root = getApplication().getViewHandler().createView(context,
-        "/root");
+        "/root.xhtml");
     root.getChildren().add(input);
 
     // lastly, if the item selected doens't match the list of

--- a/tck/faces-tck/src/com/sun/ts/tests/jsf/api/jakarta_faces/component/uiselectone/TestServlet.java
+++ b/tck/faces-tck/src/com/sun/ts/tests/jsf/api/jakarta_faces/component/uiselectone/TestServlet.java
@@ -94,7 +94,7 @@ public class TestServlet
     input.getChildren().add(item2);
     FacesContext context = getFacesContext();
     UIViewRoot root = getApplication().getViewHandler().createView(context,
-        "/root");
+        "/root.xhtml");
     context.setViewRoot(root);
     root.getChildren().add(input);
 
@@ -161,7 +161,7 @@ public class TestServlet
     input.getChildren().add(item2);
     FacesContext context = getFacesContext();
     UIViewRoot root = getApplication().getViewHandler().createView(context,
-        "/root");
+        "/root.xhtml");
     context.setViewRoot(root);
     root.getChildren().add(input);
 
@@ -237,7 +237,7 @@ public class TestServlet
     input.getChildren().add(item2);
     FacesContext context = getFacesContext();
     UIViewRoot root = getApplication().getViewHandler().createView(context,
-        "/root");
+        "/root.xhtml");
     context.setViewRoot(root);
     root.getChildren().add(input);
 
@@ -312,7 +312,7 @@ public class TestServlet
     input.getChildren().add(item2);
     FacesContext context = getFacesContext();
     UIViewRoot root = getApplication().getViewHandler().createView(context,
-        "/root");
+        "/root.xhtml");
     context.setViewRoot(root);
     root.getChildren().add(input);
 
@@ -366,7 +366,7 @@ public class TestServlet
     input.getChildren().add(item2);
     FacesContext context = getFacesContext();
     Application application = getApplication();
-    UIViewRoot root = application.getViewHandler().createView(context, "/root");
+    UIViewRoot root = application.getViewHandler().createView(context, "/root.xhtml");
     context.setViewRoot(root);
     root.getChildren().add(input);
 
@@ -427,7 +427,7 @@ public class TestServlet
     input.getChildren().add(item2);
     FacesContext context = getFacesContext();
     UIViewRoot root = getApplication().getViewHandler().createView(context,
-        "/root");
+        "/root.xhtml");
     root.getChildren().add(input);
 
     // if the item selected doens't match the list of


### PR DESCRIPTION
When "/viewId" or "/root" are used, the ViewHandlingStrategyManager doesn't know what view handler to use. Therefore, the ViewHandlingStrategyNotFoundException is thrown.  This is because FaceletViewHandlingStrategy#handlesViewId returns false. 

The solution, as I see it, is to append ".xhtml" to the viewIds. 

Code for Reference: 

ViewHandlingStrategyManager#getStrategy:
https://github.com/eclipse-ee4j/mojarra/blob/8a2124c7a5c66642f898ff32924887f55990bc5b/impl/src/main/java/com/sun/faces/application/view/ViewHandlingStrategyManager.java#L53-L58

We see that the default strategy is the FaceletViewHandlingStrategy: 
https://github.com/eclipse-ee4j/mojarra/blob/8a2124c7a5c66642f898ff32924887f55990bc5b/impl/src/main/java/com/sun/faces/application/view/ViewHandlingStrategyManager.java#L35


handlesViewId function. The comment here said: `return <code>true</code> if assuming a default configuration and the view ID's extension is <code>.xhtml</code>`
https://github.com/eclipse-ee4j/mojarra/blob/8a2124c7a5c66642f898ff32924887f55990bc5b/impl/src/main/java/com/sun/faces/application/view/FaceletViewHandlingStrategy.java#L785-L793

I may have not caught all of the viewIds, but please test this PR to verify the current changes work. Thanks!

@alwin-joseph @arjantijms 