### PR TITLE
Get Wrapped Viewhandler (Avoids  java.lang.InstantiationException: org.jboss.weld.module.jsf.ConversationAwareViewHandler)

### DIFF
--- a/tck/faces-tck/src/com/sun/ts/tests/jsf/api/jakarta_faces/application/viewhandler/TestServlet.java
+++ b/tck/faces-tck/src/com/sun/ts/tests/jsf/api/jakarta_faces/application/viewhandler/TestServlet.java
@@ -35,6 +35,7 @@ import com.sun.ts.tests.jsf.common.util.JSFTestUtil;
 import jakarta.faces.FactoryFinder;
 import jakarta.faces.application.Application;
 import jakarta.faces.application.ViewHandler;
+import jakarta.faces.application.ViewHandlerWrapper;
 import jakarta.faces.component.UIViewRoot;
 import jakarta.faces.context.ExternalContext;
 import jakarta.faces.context.FacesContext;
@@ -172,11 +173,11 @@ public final class TestServlet extends HttpTCKServlet {
       HttpServletResponse response) throws ServletException, IOException {
     PrintWriter out = response.getWriter();
 
-    JSFTestUtil.checkForNPE(getApplication().getViewHandler().getClass(),
+    JSFTestUtil.checkForNPE(((ViewHandlerWrapper)getApplication().getViewHandler()).getWrapped().getClass(),
         "renderView", new Class<?>[] { FacesContext.class, UIViewRoot.class },
         new Object[] { null, new UIViewRoot() }, out);
 
-    JSFTestUtil.checkForNPE(getApplication().getViewHandler().getClass(),
+    JSFTestUtil.checkForNPE(((ViewHandlerWrapper)getApplication().getViewHandler()).getWrapped().getClass(),
         "renderView", new Class<?>[] { FacesContext.class, UIViewRoot.class },
         new Object[] { getFacesContext(), null }, out);
   }
@@ -261,7 +262,7 @@ public final class TestServlet extends HttpTCKServlet {
       HttpServletResponse response) throws ServletException, IOException {
     PrintWriter out = response.getWriter();
 
-    JSFTestUtil.checkForNPE(getApplication().getViewHandler().getClass(),
+    JSFTestUtil.checkForNPE(((ViewHandlerWrapper)getApplication().getViewHandler()).getWrapped().getClass(),
         "calculateLocale", new Class<?>[] { FacesContext.class },
         new Object[] { null }, out);
   }
@@ -271,7 +272,7 @@ public final class TestServlet extends HttpTCKServlet {
       HttpServletResponse response) throws ServletException, IOException {
     PrintWriter out = response.getWriter();
 
-    JSFTestUtil.checkForNPE(getApplication().getViewHandler().getClass(),
+    JSFTestUtil.checkForNPE(((ViewHandlerWrapper)getApplication().getViewHandler()).getWrapped().getClass(),
         "createView", new Class<?>[] { FacesContext.class, String.class },
         new Object[] { null, "/viewId" }, out);
   }
@@ -282,7 +283,7 @@ public final class TestServlet extends HttpTCKServlet {
       HttpServletResponse response) throws ServletException, IOException {
     PrintWriter out = response.getWriter();
 
-    JSFTestUtil.checkForNPE(getApplication().getViewHandler().getClass(),
+    JSFTestUtil.checkForNPE(((ViewHandlerWrapper)getApplication().getViewHandler()).getWrapped().getClass(),
         "calculateRenderKitId", new Class<?>[] { FacesContext.class },
         new Object[] { null }, out);
   }
@@ -293,11 +294,11 @@ public final class TestServlet extends HttpTCKServlet {
       HttpServletResponse response) throws ServletException, IOException {
     PrintWriter out = response.getWriter();
 
-    JSFTestUtil.checkForNPE(getApplication().getViewHandler().getClass(),
+    JSFTestUtil.checkForNPE(((ViewHandlerWrapper)getApplication().getViewHandler()).getWrapped().getClass(),
         "getResourceURL", new Class<?>[] { FacesContext.class, String.class },
         new Object[] { null, "testString" }, out);
 
-    JSFTestUtil.checkForNPE(getApplication().getViewHandler().getClass(),
+    JSFTestUtil.checkForNPE(((ViewHandlerWrapper)getApplication().getViewHandler()).getWrapped().getClass(),
         "getResourceURL", new Class<?>[] { FacesContext.class, String.class },
         new Object[] { getFacesContext(), null }, out);
   }
@@ -308,11 +309,11 @@ public final class TestServlet extends HttpTCKServlet {
       HttpServletResponse response) throws ServletException, IOException {
     PrintWriter out = response.getWriter();
 
-    JSFTestUtil.checkForNPE(getApplication().getViewHandler().getClass(),
+    JSFTestUtil.checkForNPE(((ViewHandlerWrapper)getApplication().getViewHandler()).getWrapped().getClass(),
         "getActionURL", new Class<?>[] { FacesContext.class, String.class },
         new Object[] { null, "testString" }, out);
 
-    JSFTestUtil.checkForNPE(getApplication().getViewHandler().getClass(),
+    JSFTestUtil.checkForNPE(((ViewHandlerWrapper)getApplication().getViewHandler()).getWrapped().getClass(),
         "getActionURL", new Class<?>[] { FacesContext.class, String.class },
         new Object[] { getFacesContext(), null }, out);
   }
@@ -322,7 +323,7 @@ public final class TestServlet extends HttpTCKServlet {
       HttpServletResponse response) throws ServletException, IOException {
     PrintWriter out = response.getWriter();
 
-    JSFTestUtil.checkForNPE(getApplication().getViewHandler().getClass(),
+    JSFTestUtil.checkForNPE(((ViewHandlerWrapper)getApplication().getViewHandler()).getWrapped().getClass(),
         "restoreView", new Class<?>[] { FacesContext.class, String.class },
         new Object[] { null, "testString" }, out);
   }
@@ -332,7 +333,7 @@ public final class TestServlet extends HttpTCKServlet {
       HttpServletResponse response) throws ServletException, IOException {
     PrintWriter out = response.getWriter();
 
-    JSFTestUtil.checkForNPE(getApplication().getViewHandler().getClass(),
+    JSFTestUtil.checkForNPE(((ViewHandlerWrapper)getApplication().getViewHandler()).getWrapped().getClass(),
         "writeState", new Class<?>[] { FacesContext.class },
         new Object[] { null }, out);
   }


### PR DESCRIPTION
Due to JSF-CDI changes, org.jboss.weld.module.jsf.ConversationAwareViewHandler is the default viewhandler. 

https://github.com/weld/core/blob/master/modules/jsf/src/main/java/org/jboss/weld/module/jsf/ConversationAwareViewHandler.java

During the tests, JSFTestUtil tries to instantiate this class, but fails because it needs arguments in constructor. 

Since ConversationAwareViewHandler extends ViewHandlerWrapper, we can cast it as ViewHandlerWrapper and get our JSF ViewHandler instead ([com.sun.faces.application.view.MultiViewHandler](https://github.com/eclipse-ee4j/mojarra/blob/6949ee1764ffcdd10005e6a539b4ce0c3a3dffcd/impl/src/main/java/com/sun/faces/application/view/MultiViewHandler.java)). 

As always, please test and verify :) 

@arjantijms  @alwin-joseph 
________
Stack trace for reference: 
   java.lang.InstantiationException: org.jboss.weld.module.jsf.ConversationAwareViewHandler
     [echo]     at java.base/java.lang.Class.newInstance(Class.java:571)
     [echo]     at com.sun.ts.tests.jsf.common.util.JSFTestUtil.checkForNPE(JSFTestUtil.java:440)
     [echo]     at com.sun.ts.tests.jsf.api.jakarta_faces.application.viewhandler.TestServlet.viewHandlerWriteStateNPETest(TestServlet.java:335)
     [echo]     at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
     [echo]     at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
     [echo]     at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
     [echo]     at java.base/java.lang.reflect.Method.invoke(Method.java:566)
     [echo]     at com.sun.ts.tests.jsf.common.servlets.HttpTCKServlet.invokeTest(HttpTCKServlet.java:163)
     [echo]     at com.sun.ts.tests.jsf.common.servlets.HttpTCKServlet.doGet(HttpTCKServlet.java:104)