### PR TITLE
Fix more ViewHandlingStrategyNotFoundExceptions 

### DIFF
--- a/tck/faces-tck/src/com/sun/ts/tests/jsf/api/jakarta_faces/application/viewhandlerwrapper/TestServlet.java
+++ b/tck/faces-tck/src/com/sun/ts/tests/jsf/api/jakarta_faces/application/viewhandlerwrapper/TestServlet.java
@@ -100,7 +100,7 @@ public final class TestServlet extends HttpTCKServlet {
   public void viewHandlerCreateViewTest(HttpServletRequest request,
       HttpServletResponse response) throws ServletException, IOException {
     PrintWriter out = response.getWriter();
-    String viewId = "/viewId";
+    String viewId = "/viewId.xhtml";
     UIViewRoot root = new SimpleViewHandlerWrapper(
         getApplication().getViewHandler()).createView(getFacesContext(),
             viewId);
@@ -124,7 +124,7 @@ public final class TestServlet extends HttpTCKServlet {
 
     getFacesContext().setViewRoot(root);
 
-    String newViewId = "/newViewId";
+    String newViewId = "/newViewId.xhtml";
 
     UIViewRoot root2 = new SimpleViewHandlerWrapper(
         getApplication().getViewHandler()).createView(getFacesContext(),

--- a/tck/faces-tck/src/com/sun/ts/tests/jsf/api/jakarta_faces/component/common/BaseUIComponentTestServlet.java
+++ b/tck/faces-tck/src/com/sun/ts/tests/jsf/api/jakarta_faces/component/common/BaseUIComponentTestServlet.java
@@ -1287,7 +1287,7 @@ public abstract class BaseUIComponentTestServlet
       HttpServletResponse response) throws ServletException, IOException {
     PrintWriter out = response.getWriter();
     UIViewRoot root = getFacesContext().getViewRoot();
-    root.setViewId("/test");
+    root.setViewId("/test.xhtml");
     root.setId("root");
     UIComponent comp = createComponent();
     root.getChildren().add(comp);
@@ -1308,7 +1308,7 @@ public abstract class BaseUIComponentTestServlet
       HttpServletResponse response) throws ServletException, IOException {
     PrintWriter out = response.getWriter();
     UIViewRoot root = getFacesContext().getViewRoot();
-    root.setViewId("/test");
+    root.setViewId("/test.xhtml");
     root.setId("root");
     UIComponent comp = createComponent();
     root.getChildren().add(comp);
@@ -1331,7 +1331,7 @@ public abstract class BaseUIComponentTestServlet
     String expectedId = "myComp";
     FacesContext context = getFacesContext();
     UIViewRoot root = context.getViewRoot();
-    root.setViewId("/test");
+    root.setViewId("/test.xhtml");
 
     ResponseWriter rw = new TCKResponseWriter();
     context.setResponseWriter(rw);
@@ -1364,7 +1364,7 @@ public abstract class BaseUIComponentTestServlet
 
     FacesContext context = getFacesContext();
     UIViewRoot root = context.getViewRoot();
-    root.setViewId("/test");
+    root.setViewId("/test.xhtml");
 
     ResponseWriter rw = new TCKResponseWriter();
     context.setResponseWriter(rw);
@@ -1400,7 +1400,7 @@ public abstract class BaseUIComponentTestServlet
 
     FacesContext context = getFacesContext();
     UIViewRoot root = context.getViewRoot();
-    root.setViewId("/test");
+    root.setViewId("/test.xhtml");
 
     ResponseWriter rw = new TCKResponseWriter();
     context.setResponseWriter(rw);
@@ -1434,7 +1434,7 @@ public abstract class BaseUIComponentTestServlet
 
     FacesContext context = getFacesContext();
     UIViewRoot root = context.getViewRoot();
-    root.setViewId("/test");
+    root.setViewId("/test.xhtml");
 
     ResponseWriter rw = new TCKResponseWriter();
     context.setResponseWriter(rw);
@@ -1472,7 +1472,7 @@ public abstract class BaseUIComponentTestServlet
 
     FacesContext context = getFacesContext();
     UIViewRoot root = context.getViewRoot();
-    root.setViewId("/test");
+    root.setViewId("/test.xhtml");
 
     ResponseWriter rw = new TCKResponseWriter();
     context.setResponseWriter(rw);
@@ -1506,7 +1506,7 @@ public abstract class BaseUIComponentTestServlet
 
     FacesContext context = getFacesContext();
     UIViewRoot root = context.getViewRoot();
-    root.setViewId("/test");
+    root.setViewId("/test.xhtml");
 
     ResponseWriter rw = new TCKResponseWriter();
     context.setResponseWriter(rw);
@@ -1534,7 +1534,7 @@ public abstract class BaseUIComponentTestServlet
 
     FacesContext context = getFacesContext();
     UIViewRoot root = context.getViewRoot();
-    root.setViewId("/test");
+    root.setViewId("/test.xhtml");
 
     ResponseWriter rw = new TCKResponseWriter();
     context.setResponseWriter(rw);
@@ -3430,7 +3430,7 @@ public abstract class BaseUIComponentTestServlet
 
     FacesContext context = getFacesContext();
     UIViewRoot root = context.getViewRoot();
-    root.setViewId("/test");
+    root.setViewId("/test.xhtml");
 
     ResponseWriter rw = new TCKResponseWriter();
     context.setResponseWriter(rw);
@@ -3489,7 +3489,7 @@ public abstract class BaseUIComponentTestServlet
 
     FacesContext context = getFacesContext();
     UIViewRoot root = context.getViewRoot();
-    root.setViewId("/test");
+    root.setViewId("/test.xhtml");
 
     ResponseWriter rw = new TCKResponseWriter();
     context.setResponseWriter(rw);
@@ -3544,7 +3544,7 @@ public abstract class BaseUIComponentTestServlet
 
     FacesContext context = getFacesContext();
     UIViewRoot root = context.getViewRoot();
-    root.setViewId("/test");
+    root.setViewId("/test.xhtml");
 
     ResponseWriter rw = new TCKResponseWriter();
     context.setResponseWriter(rw);
@@ -3662,7 +3662,7 @@ public abstract class BaseUIComponentTestServlet
     PrintWriter out = response.getWriter();
     FacesContext context = getFacesContext();
     UIViewRoot root = context.getViewRoot();
-    root.setViewId("/test");
+    root.setViewId("/test.xhtml");
 
     ResponseWriter rw = new TCKResponseWriter();
     context.setResponseWriter(rw);
@@ -3808,7 +3808,7 @@ public abstract class BaseUIComponentTestServlet
     String testId = "comp";
     FacesContext context = getFacesContext();
     UIViewRoot root = context.getViewRoot();
-    root.setViewId("/test");
+    root.setViewId("/test.xhtml");
 
     ResponseWriter rw = new TCKResponseWriter();
     context.setResponseWriter(rw);
@@ -3852,7 +3852,7 @@ public abstract class BaseUIComponentTestServlet
     String testId = "comp";
     FacesContext context = getFacesContext();
     UIViewRoot root = context.getViewRoot();
-    root.setViewId("/test");
+    root.setViewId("/test.xhtml");
 
     ResponseWriter rw = new TCKResponseWriter();
     context.setResponseWriter(rw);
@@ -4533,7 +4533,7 @@ public abstract class BaseUIComponentTestServlet
     PrintWriter out = response.getWriter();
     FacesContext context = getFacesContext();
     UIViewRoot root = context.getViewRoot();
-    root.setViewId("/test");
+    root.setViewId("/test.xhtml");
     root.setId("root");
     UIComponent comp = createComponent();
     root.getChildren().add(comp);

--- a/tck/faces-tck/src/com/sun/ts/tests/jsf/api/jakarta_faces/component/common/BaseUIComponentTestServlet.java
+++ b/tck/faces-tck/src/com/sun/ts/tests/jsf/api/jakarta_faces/component/common/BaseUIComponentTestServlet.java
@@ -1371,6 +1371,9 @@ public abstract class BaseUIComponentTestServlet
 
     UIComponent component = createComponent();
     component.setId("test_ID");
+    if(component instanceof UIViewRoot){
+      ((UIViewRoot)component).setViewId("/test.xhtml");
+    }
     String uicType = component.getClass().getSimpleName();
 
     /*
@@ -1441,6 +1444,10 @@ public abstract class BaseUIComponentTestServlet
 
     UIComponent component = createComponent();
     component.setId("test_ID");
+    if(component instanceof UIViewRoot){
+      ((UIViewRoot)component).setViewId("/test.xhtml");
+    }
+
     String uicType = component.getClass().getSimpleName();
 
     /*
@@ -3500,6 +3507,10 @@ public abstract class BaseUIComponentTestServlet
     UIComponent compTwo = createComponent();
     compOne.setId("compOne");
     compTwo.setId("compTwo");
+    if(compOne instanceof UIViewRoot && compTwo instanceof UIViewRoot ){
+      ((UIViewRoot)compOne).setViewId("/test.xhtml");
+      ((UIViewRoot)compTwo).setViewId("/test2.xhtml");
+    }
     String oneType = compOne.getClass().getSimpleName();
     String twoType = compTwo.getClass().getSimpleName();
 
@@ -3881,6 +3892,10 @@ public abstract class BaseUIComponentTestServlet
 
     UIComponent comp = createComponent();
     comp.setRendered(true);
+    if(comp instanceof UIViewRoot){
+      ((UIViewRoot)comp).setViewId("/test.xhtml");
+    }
+
     String sRendererType = comp.getRendererType();
     String sRendererFamily = comp.getFamily();
 
@@ -3938,6 +3953,9 @@ public abstract class BaseUIComponentTestServlet
 
     UIComponent comp = createComponent();
     comp.setRendered(false);
+    if(comp instanceof UIViewRoot){
+      ((UIViewRoot)comp).setViewId("/test.xhtml");
+    }
     String sRendererType = comp.getRendererType();
     String sRendererFamily = comp.getFamily();
 

--- a/tck/faces-tck/src/com/sun/ts/tests/jsf/api/jakarta_faces/component/uidata/TestServlet.java
+++ b/tck/faces-tck/src/com/sun/ts/tests/jsf/api/jakarta_faces/component/uidata/TestServlet.java
@@ -671,7 +671,7 @@ public class TestServlet extends BaseComponentTestServlet {
     // build component tree
     UIViewRoot viewRoot = new UIViewRoot();
     viewRoot.setRenderKitId(RenderKitFactory.HTML_BASIC_RENDER_KIT);
-    viewRoot.setViewId("/view");
+    viewRoot.setViewId("/view.xhtml");
     getFacesContext().setViewRoot(viewRoot);
 
     UIForm form1 = new UIForm();
@@ -775,7 +775,7 @@ public class TestServlet extends BaseComponentTestServlet {
     // build component tree
     UIViewRoot viewRoot = new UIViewRoot();
     viewRoot.setRenderKitId(RenderKitFactory.HTML_BASIC_RENDER_KIT);
-    viewRoot.setViewId("/view");
+    viewRoot.setViewId("/view.xhtml");
     getFacesContext().setViewRoot(viewRoot);
 
     UIForm form1 = new UIForm();
@@ -874,7 +874,7 @@ public class TestServlet extends BaseComponentTestServlet {
     // build component tree
     UIViewRoot viewRoot = new UIViewRoot();
     viewRoot.setRenderKitId(RenderKitFactory.HTML_BASIC_RENDER_KIT);
-    viewRoot.setViewId("/view");
+    viewRoot.setViewId("/view.xhtml");
     getFacesContext().setViewRoot(viewRoot);
 
     UIForm form1 = new UIForm();

--- a/tck/faces-tck/src/com/sun/ts/tests/jsf/api/jakarta_faces/component/uiviewroot/TestServlet.java
+++ b/tck/faces-tck/src/com/sun/ts/tests/jsf/api/jakarta_faces/component/uiviewroot/TestServlet.java
@@ -294,7 +294,7 @@ public final class TestServlet extends BaseComponentTestServlet {
 
     FacesContext context = getFacesContext();
     UIViewRoot root = context.getViewRoot();
-    String myId = "myId";
+    String myId = "myId.xhtml";
 
     root.setViewId(myId);
     String result = root.getViewId();


### PR DESCRIPTION
1) Fixing ViewHandlingStrategyNotFoundException which I had missed in #1655 (appeneded .xhtml to more viewIds)

2)  Components are missing a viewId, so I cast them as a UIViewRoot and set the viewId then.

`((UIViewRoot)component).setViewId("/test.xhtml");`

```
     [echo] com.sun.faces.application.view.ViewHandlingStrategyNotFoundException
     [echo] 	at java.base/java.util.Optional.orElseThrow(Optional.java:408)
     [echo] 	at com.sun.faces.application.view.ViewHandlingStrategyManager.getStrategy(ViewHandlingStrategyManager.java:57)
     [echo] 	at com.sun.faces.application.view.ViewDeclarationLanguageFactoryImpl.getViewDeclarationLanguage(ViewDeclarationLanguageFactoryImpl.java:45)
     [echo] 	at com.sun.faces.application.view.MultiViewHandler.getViewDeclarationLanguage(MultiViewHandler.java:407)
     [echo] 	at jakarta.faces.application.ViewHandlerWrapper.getViewDeclarationLanguage(ViewHandlerWrapper.java:335)
     [echo] 	at jakarta.faces.component.UIViewRoot.encodeViewParameters(UIViewRoot.java:1697)
     [echo] 	at jakarta.faces.component.UIViewRoot.encodeEnd(UIViewRoot.java:1108)
     [echo] 	at com.sun.ts.tests.jsf.api.jakarta_faces.component.common.BaseUIComponentTestServlet.uiComponentEncodeEndNotRenderedTest(BaseUIComponentTestServlet.java:3967) 
```