### PR TITLE
RenderKit Followup 

### DIFF
--- a/tck/faces-tck/src/com/sun/ts/tests/jsf/common/servlets/HttpTCKServlet.java
+++ b/tck/faces-tck/src/com/sun/ts/tests/jsf/common/servlets/HttpTCKServlet.java
@@ -192,7 +192,12 @@ public abstract class HttpTCKServlet extends HttpServlet {
 
   protected UIViewRoot createViewRoot() {
 
-    return new UIViewRoot();
+    UIViewRoot root = new UIViewRoot();
+    // Set up RenderKit
+    String renderKitId = facesContext.getApplication().getViewHandler().calculateRenderKitId(facesContext);
+    root.setRenderKitId(renderKitId);
+
+    return root;
 
   }
 
@@ -219,10 +224,6 @@ public abstract class HttpTCKServlet extends HttpServlet {
       // Set up references to the application and facesContext objects
       application = facesContext.getApplication();
       facesContext.setViewRoot(createViewRoot());
-
-      // Set up RenderKit
-      String renderKitId = facesContext.getApplication().getViewHandler().calculateRenderKitId(facesContext);
-      facesContext.getViewRoot().setRenderKitId(renderKitId);
 
     } else {
       throw new IllegalStateException(


### PR DESCRIPTION
Follow up to  #1653.

Some methods call createViewRoot() with the test itself, and, therefore, the test fails because the renderkit is not set.

I moved the setRenderKitId code into createViewRoot. 

