### PR TITLE
Remove JSP Tests from the Old TCK

### DIFF
--- a/tck/faces-tck/src/com/sun/ts/tests/jsf/api/jakarta_faces/view/statemanagementstrategy/URLClient.java
+++ b/tck/faces-tck/src/com/sun/ts/tests/jsf/api/jakarta_faces/view/statemanagementstrategy/URLClient.java
@@ -57,20 +57,7 @@ public class URLClient extends AbstractUrlClient {
    * @since 2.2
    */
   public void stateMgmtStrategyNonNullTest() throws Fault {
-    TEST_PROPS.setProperty(APITEST, "stateMgmtStratNullForJSPTest");
-    invoke();
-  }
-
-  /**
-   * @testName: stateMgmtStratNullForJSPTest
-   * @assertion_ids: JSF:JAVADOC:2243
-   * @test_Strategy: Validate that StateManagementStrategy is null for JSP
-   *                 views.
-   * 
-   * @since 2.2
-   */
-  public void stateMgmtStratNullForJSPTest() throws Fault {
-    TEST_PROPS.setProperty(APITEST, "stateMgmtStratNullForJSPTest");
+    TEST_PROPS.setProperty(APITEST, "stateMgmtStrategyNonNullTest");
     invoke();
   }
 

--- a/tck/faces-tck/src/com/sun/ts/tests/jsf/api/jakarta_faces/view/viewdeclarationlang/URLClient.java
+++ b/tck/faces-tck/src/com/sun/ts/tests/jsf/api/jakarta_faces/view/viewdeclarationlang/URLClient.java
@@ -51,32 +51,6 @@ public class URLClient extends AbstractUrlClient {
   // methods
 
   /**
-   * @testName: vdlGetComponentMetadataUSOETest
-   * @assertion_ids: JSF:JAVADOC:2251
-   * @test_Strategy: Validate that getComponentMetadata throws an
-   *                 UnsupportedOperationException if in the JSP VDL.
-   * 
-   * @since 2.1
-   */
-  public void vdlGetComponentMetadataUSOETest() throws Fault {
-    TEST_PROPS.setProperty(APITEST, "vdlGetComponentMetadataUSOETest");
-    invoke();
-  }
-
-  /**
-   * @testName: vdlGetScriptComponentResourceUSOETest
-   * @assertion_ids: JSF:JAVADOC:2255
-   * @test_Strategy: Validate that getScriptComponentResource throws an
-   *                 UnsupportedOperationException if in the JSP VDL.
-   * 
-   * @since 2.1
-   */
-  public void vdlGetScriptComponentResourceUSOETest() throws Fault {
-    TEST_PROPS.setProperty(APITEST, "vdlGetScriptComponentResourceUSOETest");
-    invoke();
-  }
-
-  /**
    * @testName: vdlGetComponentMetadataNPETest
    * @assertion_ids: JSF:JAVADOC:2249
    * @test_Strategy: Validate that getComponentMetadata throws a

--- a/tck/faces-tck/src/com/sun/ts/tests/jsf/api/jakarta_faces/view/viewdeclarationlangwrapper/URLClient.java
+++ b/tck/faces-tck/src/com/sun/ts/tests/jsf/api/jakarta_faces/view/viewdeclarationlangwrapper/URLClient.java
@@ -51,37 +51,6 @@ public class URLClient extends AbstractUrlClient {
   // methods
 
   /**
-   * @testName: vdlWrapperGetComponentMetadataUSOETest
-   * 
-   * @assertion_ids: JSF:JAVADOC:2610
-   * 
-   * @test_Strategy: Validate that getComponentMetadata throws an
-   *                 UnsupportedOperationException if in the JSP VDL.
-   * 
-   * @since 2.1
-   */
-  public void vdlWrapperGetComponentMetadataUSOETest() throws Fault {
-    TEST_PROPS.setProperty(APITEST, "vdlWrapperGetComponentMetadataUSOETest");
-    invoke();
-  }
-
-  /**
-   * @testName: vdlWrapperGetScriptComponentResourceUSOETest
-   * 
-   * @assertion_ids: JSF:JAVADOC:2615
-   * 
-   * @test_Strategy: Validate that getScriptComponentResource throws an
-   *                 UnsupportedOperationException if in the JSP VDL.
-   * 
-   * @since 2.1
-   */
-  public void vdlWrapperGetScriptComponentResourceUSOETest() throws Fault {
-    TEST_PROPS.setProperty(APITEST,
-        "vdlWrapperGetScriptComponentResourceUSOETest");
-    invoke();
-  }
-
-  /**
    * @testName: vdlWrapperGetComponentMetadataNPETest
    * 
    * @assertion_ids: JSF:JAVADOC:2608


### PR DESCRIPTION
These tests fail due to

     [echo] java.lang.IllegalArgumentException: wrong number of arguments
     [echo] 	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
     [echo] 	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
     [echo] 	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
     [echo] 	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
     [echo] 	at com.sun.ts.tests.jsf.common.servlets.HttpTCKServlet.invokeTest(HttpTCKServlet.java:163)
     [echo] 	at com.sun.ts.tests.jsf.common.servlets.HttpTCKServlet.doGet(HttpTCKServlet.java:104
     
 
 
As these are JSP tests, I'm just removing them. Should I comment them out instead...? 