### PR TITLE
Hopefully convince failsafe to make an aggregate report

### DIFF
--- a/tck/pom.xml
+++ b/tck/pom.xml
@@ -452,22 +452,38 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-report-plugin</artifactId>
+                <version>3.0.0-M6</version>
+                <executions>
+                    <execution>
+                        <phase>post-integration-test</phase>
+                        <goals>
+                            <goal>failsafe-report-only</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <aggregate>true</aggregate>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 
     <reporting>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-report-plugin</artifactId>
-                <version>2.19.1</version>
-                <configuration>
-                    <aggregate>true</aggregate>
-                    <linkXRef>true</linkXRef>
-                </configuration>
-            </plugin>
-        </plugins>
-    </reporting>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-surefire-report-plugin</artifactId>
+				<version>3.0.0-M6</version>
+				<configuration>
+					<skipSurefireReport>${skipSurefireReport}</skipSurefireReport>
+					<aggregate>true</aggregate>
+				</configuration>
+			</plugin>
+		</plugins>
+	</reporting>
 
 
 


### PR DESCRIPTION
Tried

mvn clean install -pl :ajax -am -DskipOldTCK=true -DskipAssembly=true
-Pstaging,glassfish-ci-managed -Dglassfish.version=7.0.0-M4
-Dmojarra.version=4.0.0-M7 surefire-report:failsafe-report-only
-Daggregate=true

Followed by

mvn org.apache.maven.plugins:maven-site-plugin:3.12.0:site
-DskipOldTCK=true -DskipAssembly=true  -Pstaging
surefire-report:failsafe-report-only -Daggregate=true
-Dglassfish.version=7.0.0-M4 -Dmojarra.version=4.0.0-M7
-Dmaven.test.skip=true -DskipTests=true

But it keeps refusing it.