### PR TITLE
Add WildFly profile to TCK parent pom

### DIFF
--- a/tck/pom.xml
+++ b/tck/pom.xml
@@ -763,5 +763,36 @@
             </build>
         </profile>
 
+        <profile>
+            <id>wildfly-ci-managed</id>
+            <dependencies>
+                <dependency>
+                    <groupId>org.wildfly.arquillian</groupId>
+                    <artifactId>wildfly-arquillian-container-managed</artifactId>
+                    <version>5.0.0.Alpha1</version>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>org.jboss.sasl</groupId>
+                            <artifactId>jboss-sasl</artifactId>
+                        </exclusion>
+                    </exclusions>
+                </dependency>
+            </dependencies>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <configuration>
+                            <systemPropertyVariables>
+                                <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
+                                <jboss.home>${wildfly.dir}</jboss.home>
+                                <jboss.install.dir>${wildfly.dir}</jboss.install.dir>
+                            </systemPropertyVariables>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
     </profiles>
 </project>


### PR DESCRIPTION
Add a new profile to allow for running the TCK against WildFly out of the box.