### PR TITLE
https://github.com/jakartaee/faces/issues/1722: Adding ported Selenium Ajax Tests

### DIFF
--- a/tck/faces22/ajax/src/main/webapp/issue1957.xhtml
+++ b/tck/faces22/ajax/src/main/webapp/issue1957.xhtml
@@ -29,13 +29,14 @@
              <script type="text/javascript">
               var statusUpdate = function statusUpdate(data) {
                  var statusArea = document.getElementById("statusArea");
-                 var text = statusArea.value;
+                 var text = statusArea.innerHTML;
                  text = text + "Name: "+data.source.id;
                  if (data.type === "event") {
                      text = text +" Event: "+data.status+" ";
                  }
-                 statusArea.value = text;
+                 statusArea.innerHTML = text;
               }
+
             </script>
 
             <h:form id="form">
@@ -45,13 +46,13 @@
                    <h:outputText value="I am in a panel group"/>
                 </h:panelGroup>
 
-                <h:messages/>
 
             </h:form>
 
             <p>
               <h3> Status:</h3>
-              <textarea id="statusArea" cols="40" rows="10" readonly="readonly" />
+              <div id="statusArea" />
+
             </p>
 
       </h:body>

--- a/tck/faces22/ajax/src/main/webapp/issue2179-page2.xhtml
+++ b/tck/faces22/ajax/src/main/webapp/issue2179-page2.xhtml
@@ -30,12 +30,12 @@
              <script type="text/javascript">
               var statusUpdate = function statusUpdate(data) {
                  var statusArea = document.getElementById("statusArea");
-                 var text = statusArea.value;
+                 var text = statusArea.innerHTML;
                  text = text + "Name: "+data.source.id;
                  if (data.type === "error") {
                      text = text + " Error: "+data.status+" "+data.errorMessage;
                  }
-                 statusArea.value = text;
+                 statusArea.innerHTML = text;
               }
             </script>
 
@@ -53,7 +53,7 @@
 
             <p>
               <h3> Status:</h3>
-              <textarea id="statusArea" cols="40" rows="10" readonly="readonly" />
+              <div id="statusArea"  />
             </p>
 
       </h:body>

--- a/tck/faces22/ajax/src/main/webapp/issue3020Negative.xhtml
+++ b/tck/faces22/ajax/src/main/webapp/issue3020Negative.xhtml
@@ -42,5 +42,12 @@
         </h:panelGroup>
     </h:form>
 
+    <div id="windowError"></div>
+    <script type="text/javascript">
+        window.addEventListener("error", event => {
+            let el = document.getElementById("windowError");
+            el.innerHTML = el.innerHTML + " Type: " + event.type + "Message" + event.message;
+        });
+    </script>
 </h:body>     
 </html>

--- a/tck/faces22/ajax/src/test/java/ee/jakarta/tck/faces/test/servlet30/ajax_new/Issue1284IT.java
+++ b/tck/faces22/ajax/src/test/java/ee/jakarta/tck/faces/test/servlet30/ajax_new/Issue1284IT.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.faces.test.servlet30.ajax_new;
+
+
+import ee.jakarta.tck.faces.test.util.selenium.BaseITNG;
+import ee.jakarta.tck.faces.test.util.selenium.WebPage;
+import jakarta.faces.component.behavior.AjaxBehavior;
+import jakarta.faces.context.PartialViewContext;
+import org.junit.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+
+import static org.junit.Assert.assertEquals;
+
+public class Issue1284IT extends BaseITNG {
+
+    /**
+     * @see AjaxBehavior
+     * @see PartialViewContext#getEvalScripts()
+     * @see https://github.com/eclipse-ee4j/mojarra/issues/1289
+     */
+    @Test
+    public void testCdataEscape5() throws Exception {
+        WebPage page = getPage("issue1284.xhtml");
+        assertEquals("", page.findElement(By.id("form1:out1")).getText());
+        assertEquals("", page.findElement(By.id("form1:in1")).getAttribute("value"));
+
+        WebElement in1 = page.findElement(By.id("form1:in1"));
+        in1.sendKeys("[");
+
+        // Submit the ajax request
+        WebElement button1 = page.findElement(By.id("form1:button1"));
+        button1.click();
+        Thread.sleep(3000);
+
+        // Check that the ajax request succeeds
+        assertEquals("[", page.findElement(By.id("form1:out1")).getText());
+    }
+
+    /**
+     * @see AjaxBehavior
+     * @see PartialViewContext#getEvalScripts()
+     * @see https://github.com/eclipse-ee4j/mojarra/issues/1289
+     */
+    @Test
+    public void testCdataEscape6() throws Exception {
+        WebPage page = getPage("issue1284.xhtml");
+        assertEquals("", page.findElement(By.id("form1:out1")).getText());
+        assertEquals("", page.findElement(By.id("form1:in1")).getAttribute("value"));
+
+        WebElement in1 = page.findElement(By.id("form1:in1"));
+        in1.sendKeys("var a=[");
+
+        // Submit the ajax request
+        WebElement button1 = page.findElement(By.id("form1:button1"));
+        button1.click();
+        Thread.sleep(3000);
+
+        // Check that the ajax request succeeds
+        assertEquals("var a=[", page.findElement(By.id("form1:out1")).getText());
+    }
+}

--- a/tck/faces22/ajax/src/test/java/ee/jakarta/tck/faces/test/servlet30/ajax_new/Issue1533IT.java
+++ b/tck/faces22/ajax/src/test/java/ee/jakarta/tck/faces/test/servlet30/ajax_new/Issue1533IT.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.faces.test.servlet30.ajax_new;
+
+import ee.jakarta.tck.faces.test.util.selenium.BaseITNG;
+import ee.jakarta.tck.faces.test.util.selenium.WebPage;
+import jakarta.faces.component.behavior.AjaxBehavior;
+import jakarta.faces.component.html.HtmlSelectOneRadio;
+import org.junit.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+
+import static org.junit.Assert.assertTrue;
+
+/**
+ * @author Manfred Riem (manfred.riem@oracle.com)
+ */
+public class Issue1533IT extends BaseITNG {
+
+    /**
+     * @see AjaxBehavior
+     * @see HtmlSelectOneRadio
+     * @see https://github.com/eclipse-ee4j/mojarra/issues/1537
+     */
+    @Test
+    public void testIssue1533() throws Exception {
+        WebPage page = getPage("issue1533.xhtml");
+        WebElement input = page.findElement(By.id("form:vip:0"));
+        input.click();
+        Thread.sleep(3000);
+        assertTrue(page.getPageSource().indexOf("form:vip-true") != -1);
+        input = page.findElement(By.id("form:vip:1"));
+        input.click();
+        Thread.sleep(3000);
+        assertTrue(page.getPageSource().indexOf("form:vip-false") != -1);
+    }
+}

--- a/tck/faces22/ajax/src/test/java/ee/jakarta/tck/faces/test/servlet30/ajax_new/Issue1581IT.java
+++ b/tck/faces22/ajax/src/test/java/ee/jakarta/tck/faces/test/servlet30/ajax_new/Issue1581IT.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.faces.test.servlet30.ajax_new;
+
+import ee.jakarta.tck.faces.test.util.selenium.BaseITNG;
+import ee.jakarta.tck.faces.test.util.selenium.WebPage;
+import org.junit.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+
+public class Issue1581IT extends BaseITNG {
+
+    /**
+     * This test verifies correct function of SelectManyCheckbox in a Composite
+     * Component over Ajax.
+     */
+    @Test
+    public void testSelectManyCheckboxInComposite() throws Exception {
+        WebPage page = getPage("issue1581.xhtml");
+
+        // This will ensure JavaScript finishes before evaluating the page.
+        page.waitReqJs();
+        assertCheckBoxes(getCheckboxes(page), false, false, false, false);
+
+        getCheckboxes(page).get(0).click();
+        page.waitReqJs();
+        assertCheckBoxes(getCheckboxes(page), true, false, false, false);
+
+        getCheckboxes(page).get(1).click();
+        page.waitReqJs();
+        assertCheckBoxes(getCheckboxes(page), true, true, false, false);
+
+        getCheckboxes(page).get(2).click();
+        page.waitReqJs();
+        assertCheckBoxes(getCheckboxes(page), true, true, true, false);
+
+        getCheckboxes(page).get(3).click();
+        page.waitReqJs();
+        assertCheckBoxes(getCheckboxes(page), true, true, true, true);
+    }
+
+
+    private void assertCheckBoxes(List<WebElement> checkboxes, boolean... expectedValues) {
+        for (int cnt = 0; cnt < checkboxes.size(); cnt++) {
+            WebElement checkbox = checkboxes.get(cnt);
+            //label assertion, the gettext of the parent returns the label only
+            assert (checkbox.findElement(By.xpath("..")).getText()).equals("JAVASERVERFACES-" + (cnt + 1));
+            boolean assertionValue = expectedValues[cnt];
+            assertEquals(checkbox.isSelected(), assertionValue);
+        }
+    }
+
+    private List<WebElement> getCheckboxes(WebPage page) {
+
+
+        List<WebElement> checkBoxes = new ArrayList<>();
+
+        List<WebElement> elements = page.findElements(By.tagName("input"));
+        for (Iterator<WebElement> it = elements.iterator(); it.hasNext(); ) {
+            WebElement elem = it.next();
+            if (elem.getAttribute("type").equals("checkbox")) {
+                checkBoxes.add(elem);
+            }
+        }
+
+        return checkBoxes;
+    }
+
+}

--- a/tck/faces22/ajax/src/test/java/ee/jakarta/tck/faces/test/servlet30/ajax_new/Issue1781IT.java
+++ b/tck/faces22/ajax/src/test/java/ee/jakarta/tck/faces/test/servlet30/ajax_new/Issue1781IT.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.faces.test.servlet30.ajax_new;
+
+import ee.jakarta.tck.faces.test.util.selenium.BaseITNG;
+import ee.jakarta.tck.faces.test.util.selenium.WebPage;
+import jakarta.faces.component.behavior.ClientBehaviorHolder;
+import jakarta.faces.component.html.HtmlBody;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class Issue1781IT extends BaseITNG {
+
+    /**
+     * Test attaching a ClientBehaviorHolder to h:body. Note the current 2.1
+     * spec does not allow using f:ajax outside of a form so this will throw
+     * a script error which we are going to ignore.
+     *
+     * @see ClientBehaviorHolder
+     * @see HtmlBody
+     * @see https://github.com/eclipse-ee4j/mojarra/issues/1785
+     */
+    @Test
+    public void testAjaxToOnBody() throws Exception {
+        // we stick with the webclient for simple http checks
+        // the selenium drivers cannot do it, that easily
+        WebPage page = getPage("body.xhtml");
+
+        //waitForCondition((webDriver) -> super.page.getResponseStatus() != -1, Duration.ofMillis(3000));
+        assertEquals(page.getResponseStatus(), 200);
+    }
+}

--- a/tck/faces22/ajax/src/test/java/ee/jakarta/tck/faces/test/servlet30/ajax_new/Issue1817IT.java
+++ b/tck/faces22/ajax/src/test/java/ee/jakarta/tck/faces/test/servlet30/ajax_new/Issue1817IT.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.faces.test.servlet30.ajax_new;
+
+import ee.jakarta.tck.faces.test.util.selenium.BaseITNG;
+import ee.jakarta.tck.faces.test.util.selenium.WebPage;
+import jakarta.faces.component.behavior.AjaxBehavior;
+import org.junit.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.ui.ExpectedConditions;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.junit.Assert.assertTrue;
+
+public class Issue1817IT extends BaseITNG {
+
+    /**
+     * @see AjaxBehavior
+     * @see com.sun.faces.facelets.component.UIRepeat
+     * @see https://github.com/eclipse-ee4j/mojarra/issues/1821
+     */
+    @Test
+    public void testAjaxUIRepeat() throws Exception {
+        WebPage page = getPage("issue1817.xhtml");
+        final List<WebElement> elements = page.findElements(By.tagName("a"));
+        List<String[]> ids = elements.stream().map(element -> new String[]{element.getAttribute("id"), element.getText()})
+                .collect(Collectors.toList());
+        for (String[] id : ids) {
+            WebElement anchor = page.findElement(By.id(id[0]));
+            anchor.click();
+            String expectedText = "Triggered item: " + id[1];
+            WebElement body = page.findElement(By.tagName("body"));
+            page.waitForCondition(ExpectedConditions.textToBePresentInElement(body, expectedText), Duration.ofMillis(3000));
+            assertTrue(page.getPageSource().contains(expectedText));
+        }
+    }
+}

--- a/tck/faces22/ajax/src/test/java/ee/jakarta/tck/faces/test/servlet30/ajax_new/Issue1825IT.java
+++ b/tck/faces22/ajax/src/test/java/ee/jakarta/tck/faces/test/servlet30/ajax_new/Issue1825IT.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.faces.test.servlet30.ajax_new;
+
+import ee.jakarta.tck.faces.test.util.selenium.BaseITNG;
+import ee.jakarta.tck.faces.test.util.selenium.WebPage;
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.component.behavior.AjaxBehavior;
+import org.junit.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @author Manfred Riem (manfred.riem@oracle.com)
+ */
+public class Issue1825IT extends BaseITNG {
+
+    /**
+     * @see AjaxBehavior
+     * @see UIComponent#getCurrentCompositeComponent(jakarta.faces.context.FacesContext)
+     * @see https://github.com/eclipse-ee4j/mojarra/issues/1829
+     */
+    @Test
+    public void testIssue1825() throws Exception {
+        WebPage page = getPage("issue1825.xhtml");
+        WebElement button = page.findElement(By.id("form:button"));
+        button.click();
+        page.waitForCurrentRequestEnd();
+        assertEquals(200, page.getResponseStatus());
+        button = page.findElement(By.id("form:button"));
+        button.click();
+        page.waitForCurrentRequestEnd();
+        assertEquals(200, page.getResponseStatus());
+    }
+}

--- a/tck/faces22/ajax/src/test/java/ee/jakarta/tck/faces/test/servlet30/ajax_new/Issue1957IT.java
+++ b/tck/faces22/ajax/src/test/java/ee/jakarta/tck/faces/test/servlet30/ajax_new/Issue1957IT.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.faces.test.servlet30.ajax_new;
+
+import ee.jakarta.tck.faces.test.util.selenium.BaseITNG;
+import ee.jakarta.tck.faces.test.util.selenium.WebPage;
+import jakarta.faces.component.behavior.ClientBehaviorHolder;
+import jakarta.faces.component.html.HtmlPanelGroup;
+import org.junit.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.ui.ExpectedConditions;
+
+import java.time.Duration;
+
+import static org.junit.Assert.assertTrue;
+
+public class Issue1957IT extends BaseITNG {
+
+    /**
+     * @see ClientBehaviorHolder
+     * @see HtmlPanelGroup
+     * @see https://github.com/eclipse-ee4j/mojarra/issues/1961
+     */
+    @Test
+    public void testPanelGroupAjaxBehavior() throws Exception {
+        WebPage page = getPage("issue1957.xhtml");
+        WebElement span = page.findElement(By.id("form:group"));
+        page.waitForCondition(ExpectedConditions.elementToBeClickable(span), Duration.ofMillis(3000));
+        span.click();
+        page.waitForCurrentRequestEnd();
+        assertTrue(page.getPageSource().contains("form:group Event: begin"));
+        assertTrue(page.getPageSource().contains("form:group Event: complete"));
+        assertTrue(page.getPageSource().contains("form:group Event: success"));
+    }
+}

--- a/tck/faces22/ajax/src/test/java/ee/jakarta/tck/faces/test/servlet30/ajax_new/Issue2041IT.java
+++ b/tck/faces22/ajax/src/test/java/ee/jakarta/tck/faces/test/servlet30/ajax_new/Issue2041IT.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.faces.test.servlet30.ajax_new;
+
+import ee.jakarta.tck.faces.test.util.selenium.BaseITNG;
+import ee.jakarta.tck.faces.test.util.selenium.WebPage;
+import jakarta.faces.component.behavior.AjaxBehavior;
+import org.junit.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+
+import static org.junit.Assert.assertTrue;
+
+/**
+ * @author Manfred Riem (manfred.riem@oracle.com)
+ */
+public class Issue2041IT extends BaseITNG {
+
+    /**
+     * @see AjaxBehavior
+     * @see https://github.com/eclipse-ee4j/mojarra/issues/2045
+     */
+    @Test
+    public void testIssue2041() throws Exception {
+        WebPage page = getPage("issue2041.xhtml");
+
+        assertTrue(page.getPageSource().indexOf("PAGE 1 BEGIN") != -1);
+        assertTrue(page.getPageSource().indexOf("PAGE 1 END") != -1);
+
+        WebElement anchor = page.findElement(By.id("commandLink"));
+        anchor.click();
+        page.waitForCurrentRequestEnd();
+
+        assertTrue(page.getPageSource().indexOf("PAGE 2 BEGIN") != -1);
+        assertTrue(page.getPageSource().indexOf("PAGE 2 END") != -1);
+
+        anchor = page.findElement(By.id("commandLink"));
+        anchor.click();
+        page.waitForCurrentRequestEnd();
+
+        assertTrue(page.getPageSource().indexOf("PAGE 1 BEGIN") != -1);
+        assertTrue(page.getPageSource().indexOf("PAGE 1 END") != -1);
+    }
+}

--- a/tck/faces22/ajax/src/test/java/ee/jakarta/tck/faces/test/servlet30/ajax_new/Issue2162IT.java
+++ b/tck/faces22/ajax/src/test/java/ee/jakarta/tck/faces/test/servlet30/ajax_new/Issue2162IT.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.faces.test.servlet30.ajax_new;
+
+import ee.jakarta.tck.faces.test.util.selenium.BaseITNG;
+import ee.jakarta.tck.faces.test.util.selenium.WebPage;
+import jakarta.faces.component.behavior.AjaxBehavior;
+import jakarta.faces.event.PreRenderViewEvent;
+import org.junit.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * @author Manfred Riem (manfred.riem@oracle.com)
+ * <no>Not working</no>
+ */
+public class Issue2162IT extends BaseITNG {
+
+    /**
+     * @see PreRenderViewEvent
+     * @see AjaxBehavior
+     * @see https://github.com/eclipse-ee4j/mojarra/issues/2166
+     */
+    @Test
+    public void testIssue2162() throws Exception {
+        WebPage page = getPage("issue2162.xhtml");
+        assertTrue(page.isInPage("Init called\n"));
+
+        WebElement button = page.findElement(By.id("form:submit"));
+        button.click();
+
+
+        page.waitReqJs();
+        //  this test is failing on Chrome, probably a Mojarra bug
+        //  problem is the ajax update passes, but the init called is not rendered anymore
+        //  the rest is, this is very likely a mojarra bug triggered by the chrome engine
+        // The page source reveals following, so the viewstate update probably has overwritten the
+        // init called text in Chrome:
+        /*
+        <html xmlns="http://www.w3.org/1999/xhtml"><head id="j_idt3">
+            <title>Issue 2162</title><script src="/test-faces22-ajax/jakarta.faces.resource/faces.js.xhtml;jsessionid=987f999fce875c6ec95f00467ca0?ln=jakarta.faces"></script><script type="text/javascript" src="/test-faces22-ajax/jakarta.faces.resource/faces.js.xhtml?ln=jakarta.faces"></script></head>
+            <body>
+                <form id="form" name="form" method="post" action="/test-faces22-ajax/issue2162.xhtml" enctype="application/x-www-form-urlencoded">
+                    <input type="hidden" name="form" value="form">
+                    <input id="form:submit" type="submit" name="form:submit" value="Submit" onclick="mojarra.ab(this,event,'click','@form','@all');return false">
+                    <input type="hidden" name="jakarta.faces.ViewState" value="-502622467461252732:-9011607885137894041">
+                </form>
+            </body></html>
+         */
+        assertTrue(page.isInPage("Init called\nInit called\n"));
+        assertFalse(page.isInPage("Init called\nInit called\nInit called"));
+    }
+}

--- a/tck/faces22/ajax/src/test/java/ee/jakarta/tck/faces/test/servlet30/ajax_new/Issue2179IT.java
+++ b/tck/faces22/ajax/src/test/java/ee/jakarta/tck/faces/test/servlet30/ajax_new/Issue2179IT.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.faces.test.servlet30.ajax_new;
+
+import ee.jakarta.tck.faces.test.util.selenium.BaseITNG;
+import ee.jakarta.tck.faces.test.util.selenium.WebPage;
+import jakarta.faces.context.ExceptionHandler;
+import jakarta.faces.context.PartialViewContext;
+import org.junit.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+
+import static org.junit.Assert.assertTrue;
+
+public class Issue2179IT extends BaseITNG {
+
+    /**
+     * @see PartialViewContext
+     * @see ExceptionHandler
+     * @see https://github.com/eclipse-ee4j/mojarra/issues/2183
+     */
+    @Test
+    public void testEncodeException() throws Exception {
+        WebPage page = getPage("issue2179-page1.xhtml");
+        int responseStatus = page.getResponseStatus();
+        assertTrue(responseStatus == 500);
+    }
+
+    /**
+     * @see PartialViewContext
+     * @see ExceptionHandler
+     * @see https://github.com/eclipse-ee4j/mojarra/issues/2183
+     */
+    @Test
+    public void testDecodeException() {
+        // the major change is to shift the textarea over
+        // apparently they used the text attribute which does not work
+        // on new browsers, innerText must be used
+        // or a div with innerHTML which always will work
+        WebPage page = getPage("issue2179-page2.xhtml");
+        WebElement button = page.findElement(By.id("form:submit"));
+        button.click();
+        assertTrue(page.isInPage("Name: form:submit Error: serverError"));
+    }
+}

--- a/tck/faces22/ajax/src/test/java/ee/jakarta/tck/faces/test/servlet30/ajax_new/Issue2255IT.java
+++ b/tck/faces22/ajax/src/test/java/ee/jakarta/tck/faces/test/servlet30/ajax_new/Issue2255IT.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.faces.test.servlet30.ajax_new;
+
+import ee.jakarta.tck.faces.test.util.selenium.BaseITNG;
+import ee.jakarta.tck.faces.test.util.selenium.WebPage;
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.component.behavior.AjaxBehavior;
+import org.junit.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+
+import static org.junit.Assert.assertTrue;
+
+public class Issue2255IT extends BaseITNG {
+
+    /**
+     * @see AjaxBehavior
+     * @see UIComponent#getCurrentCompositeComponent(jakarta.faces.context.FacesContext)
+     * @see https://github.com/eclipse-ee4j/mojarra/issues/2259
+     */
+    @Test
+    public void testBehaviorState() throws Exception {
+        WebPage page = getPage("divInComposite.xhtml");
+
+        assertTrue(page.getPageSource().contains("false"));
+        WebElement cbox = page.findElement(By.id("cc:form:test"));
+        cbox.click();
+        assertTrue(page.isInPage("true"));
+        cbox.click();
+        assertTrue(page.isInPage("false"));
+        cbox.click();
+        assertTrue(page.isInPage("true"));
+        cbox.click();
+        assertTrue(page.isInPage("false"));
+    }
+}

--- a/tck/faces22/ajax/src/test/java/ee/jakarta/tck/faces/test/servlet30/ajax_new/Issue2340IT.java
+++ b/tck/faces22/ajax/src/test/java/ee/jakarta/tck/faces/test/servlet30/ajax_new/Issue2340IT.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.faces.test.servlet30.ajax_new;
+
+import ee.jakarta.tck.faces.test.util.selenium.BaseITNG;
+import ee.jakarta.tck.faces.test.util.selenium.WebPage;
+import jakarta.faces.component.behavior.AjaxBehavior;
+import jakarta.faces.component.html.HtmlCommandLink;
+import jakarta.faces.component.html.HtmlSelectOneRadio;
+import org.junit.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+
+import static org.junit.Assert.assertTrue;
+
+public class Issue2340IT extends BaseITNG {
+
+    /**
+     * @see AjaxBehavior
+     * @see HtmlCommandLink
+     * @see HtmlSelectOneRadio
+     * @see https://github.com/eclipse-ee4j/mojarra/issues/2344
+     */
+    @Test
+    public void testCommandLinkRadio() throws Exception {
+        WebPage page = getPage("commandLinkRadio.xhtml");
+        WebElement anchor = page.findElement(By.id("testLink"));
+        // This will ensure JavaScript finishes before evaluating the page.
+        anchor.click();
+
+        assertTrue(page.isInPage("LINK ACTION"));
+
+        WebElement radio1 = page.findElement(By.id("testRadio:0"));
+        WebElement radio2 = page.findElement(By.id("testRadio:1"));
+        WebElement radio3 = page.findElement(By.id("testRadio:2"));
+
+        radio1.click();
+        page.waitForCurrentRequestEnd();
+        assertTrue(page.isInPage("RADIO:red"));
+
+        radio2.click();
+        assertTrue(page.isInPage("RADIO:blue"));
+
+        radio3.click();
+        assertTrue(page.isInPage("RADIO:white"));
+    }
+}

--- a/tck/faces22/ajax/src/test/java/ee/jakarta/tck/faces/test/servlet30/ajax_new/Issue2381IT.java
+++ b/tck/faces22/ajax/src/test/java/ee/jakarta/tck/faces/test/servlet30/ajax_new/Issue2381IT.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.faces.test.servlet30.ajax_new;
+
+import ee.jakarta.tck.faces.test.util.selenium.BaseITNG;
+import ee.jakarta.tck.faces.test.util.selenium.WebPage;
+import jakarta.faces.component.behavior.AjaxBehavior;
+import jakarta.faces.component.html.HtmlBody;
+import org.junit.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+
+import static org.junit.Assert.assertTrue;
+
+public class Issue2381IT extends BaseITNG {
+
+    /**
+     * This test verifies that the page contains updated information from an
+     * Ajax response.  The response is updated in <code>UpdateBean</code>.
+     *
+     * @see AjaxBehavior
+     * @see HtmlBody
+     * @see https://github.com/eclipse-ee4j/mojarra/issues/2385
+     */
+    @Test
+    public void testBodyAttributesAfterUpdate() throws Exception {
+        WebPage page = getPage("updateBody.xhtml");
+        WebElement button = page.findElement(By.id("form1:bodytag"));
+        button.click();
+        // This will ensure JavaScript finishes before evaluating the page.
+        assertTrue(page.isInPage("BODY CLASS:foo"));
+    }
+
+}

--- a/tck/faces22/ajax/src/test/java/ee/jakarta/tck/faces/test/servlet30/ajax_new/Issue2407IT.java
+++ b/tck/faces22/ajax/src/test/java/ee/jakarta/tck/faces/test/servlet30/ajax_new/Issue2407IT.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.faces.test.servlet30.ajax_new;
+
+import ee.jakarta.tck.faces.test.util.selenium.BaseITNG;
+import ee.jakarta.tck.faces.test.util.selenium.WebPage;
+import jakarta.faces.component.behavior.AjaxBehavior;
+import jakarta.faces.component.html.HtmlCommandButton;
+import org.junit.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+
+import static org.junit.Assert.assertTrue;
+
+public class Issue2407IT extends BaseITNG {
+
+    /**
+     * This test verifies that an attribute named 'value' can be successfully updated
+     * from a partial response (over Ajax).
+     *
+     * @see AjaxBehavior
+     * @see HtmlCommandButton#getValue()
+     * @see https://github.com/eclipse-ee4j/mojarra/issues/2411
+     */
+    @Test
+    public void testUpdateAttributeNamedValue() throws Exception {
+        WebPage page = getPage("attributeNameIsValue.xhtml");
+        assertTrue(page.isCondition(webDriver1 -> page.findElement(By.id("form1:foo")).getAttribute("value").equals("foo")));
+        WebElement button = page.findElement(By.id("form1:button"));
+        button.click();
+        assertTrue(page.isCondition(webDriver1 -> page.findElement(By.id("form1:foo")).getAttribute("value").equals("bar")));
+    }
+}

--- a/tck/faces22/ajax/src/test/java/ee/jakarta/tck/faces/test/servlet30/ajax_new/Issue2408IT.java
+++ b/tck/faces22/ajax/src/test/java/ee/jakarta/tck/faces/test/servlet30/ajax_new/Issue2408IT.java
@@ -1,0 +1,177 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.faces.test.servlet30.ajax_new;
+
+import ee.jakarta.tck.faces.test.util.selenium.BaseITNG;
+import ee.jakarta.tck.faces.test.util.selenium.WebPage;
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.component.behavior.AjaxBehavior;
+import jakarta.faces.component.html.HtmlSelectManyCheckbox;
+import org.junit.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+
+import java.util.List;
+
+import static org.junit.Assert.assertTrue;
+
+public class Issue2408IT extends BaseITNG {
+
+    /**
+     * This test verifies correct function of SelectManyCheckbox in a Composite
+     * Component over Ajax.
+     *
+     * @see AjaxBehavior
+     * @see HtmlSelectManyCheckbox
+     * @see UIComponent#getCurrentCompositeComponent(jakarta.faces.context.FacesContext)
+     * @see https://github.com/eclipse-ee4j/mojarra/issues/2412
+     */
+    @Test
+    public void testSelectManyCheckboxInComposite() throws Exception {
+        WebPage page = getPage("selectManyCheckboxInComposite.xhtml");
+
+        // This will ensure JavaScript finishes before evaluating the page.
+        assertTrue(page.getPageSource().contains("Status: Pending"));
+
+        getCheckBoxes(page).get(0).click();
+        assertTrue(page.isInPage("Status: mcheck-1"));
+
+        getCheckBoxes(page).get(1).click();
+        assertTrue(page.isInPage("Status: mcheck-1 mcheck-2"));
+
+        getCheckBoxes(page).get(2).click();
+        assertTrue(page.isInPage("Status: mcheck-1 mcheck-2 mcheck-3"));
+    }
+
+    /**
+     * This test verifies correct function of SelectManyCheckbox in a Composite
+     * Component over Ajax. The components in the page have ids.
+     */
+    @Test
+    public void testSelectManyCheckboxIdsInComposite() throws Exception {
+        WebPage page = getPage("selectManyCheckboxIdsInComposite.xhtml");
+
+        // This will ensure JavaScript finishes before evaluating the page.
+        assertTrue(page.getPageSource().contains("Status: Pending"));
+
+        WebElement cbox1 = page.findElement(By.id("form:compId:cbox:0"));
+        cbox1.click();
+        assertTrue(page.isInPage("Status: mcheck-1"));
+
+        WebElement cbox2 = page.findElement(By.id("form:compId:cbox:1"));
+        cbox2.click();
+        assertTrue(page.isInPage("Status: mcheck-1 mcheck-2"));
+
+        WebElement cbox3 = page.findElement(By.id("form:compId:cbox:2"));
+        cbox3.click();
+        assertTrue(page.isInPage("Status: mcheck-1 mcheck-2 mcheck-3"));
+    }
+
+    /**
+     * This test verifies correct function of SelectManyCheckbox Component over Ajax.
+     */
+    @Test
+    public void testSelectManyCheckboxNoComposite() throws Exception {
+        WebPage page = getPage("selectManyCheckboxNoComposite.xhtml");
+
+        // This will ensure JavaScript finishes before evaluating the page.
+        assertTrue(page.getPageSource().contains("Status: Pending"));
+
+        getCheckBoxes(page).get(0).click();
+        assertTrue(page.isInPage("Status: mcheck-1"));
+
+        getCheckBoxes(page).get(1).click();
+        assertTrue(page.isInPage("Status: mcheck-1 mcheck-2"));
+
+        getCheckBoxes(page).get(2).click();
+        assertTrue(page.isInPage("Status: mcheck-1 mcheck-2 mcheck-3"));
+    }
+
+    /**
+     * This test verifies correct function of SelectOneRadio in a Composite
+     * Component over Ajax.
+     */
+    @Test
+    public void testSelectOneRadioInComposite() throws Exception {
+        WebPage page = getPage("selectOneRadioInComposite.xhtml");
+
+        // This will ensure JavaScript finishes before evaluating the page.
+        assertTrue(page.isInPage("Status: Pending"));
+
+        getRadios(page).get(0).click();
+        assertTrue(page.isInPage("Status: radio-1"));
+
+        getRadios(page).get(1).click();
+        assertTrue(page.isInPage("Status: radio-2"));
+
+        getRadios(page).get(2).click();
+        assertTrue(page.isInPage("Status: radio-3"));
+    }
+
+    /**
+     * This test verifies correct function of SelectOneRadio in a Composite
+     * Component over Ajax. The components in the page have ids.
+     */
+    @Test
+    public void testSelectOneRadioIdsInComposite() throws Exception {
+        WebPage page = getPage("selectOneRadioIdsInComposite.xhtml");
+
+        // This will ensure JavaScript finishes before evaluating the page.
+        assertTrue(page.isInPage("Status: Pending"));
+
+        WebElement radio1 = page.findElement(By.id("form:compId:radio:0"));
+        radio1.click();
+        assertTrue(page.isInPage("Status: radio-1"));
+
+        WebElement radio2 = page.findElement(By.id("form:compId:radio:1"));
+        radio2.click();
+        assertTrue(page.isInPage("Status: radio-2"));
+
+        WebElement radio3 = page.findElement(By.id("form:compId:radio:2"));
+        radio3.click();
+        assertTrue(page.isInPage("Status: radio-3"));
+    }
+
+    /**
+     * This test verifies correct function of SelectOneRadio Component over Ajax.
+     */
+    @Test
+    public void testSelectOneRadioNoComposite() throws Exception {
+        WebPage page = getPage("selectOneRadioNoComposite.xhtml");
+
+        // This will ensure JavaScript finishes before evaluating the page.
+        assertTrue(page.isInPage("Status: Pending"));
+
+        getRadios(page).get(0).click();
+        assertTrue(page.isInPage("Status: radio-1"));
+
+        getRadios(page).get(1).click();
+        assertTrue(page.isInPage("Status: radio-2"));
+
+        getRadios(page).get(2).click();
+        assertTrue(page.isInPage("Status: radio-3"));
+    }
+
+    private List<WebElement> getCheckBoxes(WebPage page) {
+        return page.findElements(By.cssSelector("input[type='checkbox']"));
+    }
+
+    private List<WebElement> getRadios(WebPage page) {
+        return page.findElements(By.cssSelector("input[type='radio']"));
+    }
+
+}

--- a/tck/faces22/ajax/src/test/java/ee/jakarta/tck/faces/test/servlet30/ajax_new/Issue2421IT.java
+++ b/tck/faces22/ajax/src/test/java/ee/jakarta/tck/faces/test/servlet30/ajax_new/Issue2421IT.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.faces.test.servlet30.ajax_new;
+
+import ee.jakarta.tck.faces.test.util.selenium.BaseITNG;
+import ee.jakarta.tck.faces.test.util.selenium.WebPage;
+import jakarta.faces.component.behavior.AjaxBehavior;
+import jakarta.faces.component.html.HtmlCommandButton;
+import org.junit.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+
+import static org.junit.Assert.assertTrue;
+
+public class Issue2421IT extends BaseITNG {
+
+    /**
+     * This test verifies that an attribute named 'disabled' can be successfully updated
+     * from a partial response (over Ajax).
+     *
+     * @see AjaxBehavior
+     * @see HtmlCommandButton#isDisabled()
+     * @see https://github.com/eclipse-ee4j/mojarra/issues/2425
+     */
+    @Test
+    public void testUpdateAttributeNamedDisabled() throws Exception {
+        WebPage page = getPage("attributeNameIsDisabled.xhtml");
+        WebElement input = page.findElement(By.id("form1:foo"));
+        assertTrue(input.isEnabled());
+        assertTrue(page.getPageSource().contains("foo"));
+        WebElement button = page.findElement(By.id("form1:button"));
+        button.click();
+        page.waitForCurrentRequestEnd();
+        Thread.sleep(3000);
+        input = page.findElement(By.id("form1:foo"));
+        assertTrue(input.isEnabled());
+    }
+}

--- a/tck/faces22/ajax/src/test/java/ee/jakarta/tck/faces/test/servlet30/ajax_new/Issue2422IT.java
+++ b/tck/faces22/ajax/src/test/java/ee/jakarta/tck/faces/test/servlet30/ajax_new/Issue2422IT.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.faces.test.servlet30.ajax_new;
+
+import ee.jakarta.tck.faces.test.util.selenium.BaseITNG;
+import ee.jakarta.tck.faces.test.util.selenium.WebPage;
+import jakarta.faces.component.behavior.AjaxBehavior;
+import jakarta.faces.component.html.HtmlSelectManyCheckbox;
+import org.junit.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+
+import static org.junit.Assert.assertTrue;
+
+public class Issue2422IT extends BaseITNG {
+
+    /**
+     * This test verifies correct function of SelectManyCheckbox in a Composite
+     * Component over Ajax.
+     *
+     * @see AjaxBehavior
+     * @see HtmlSelectManyCheckbox
+     * @see https://github.com/eclipse-ee4j/mojarra/issues/2425
+     */
+    @Test
+    public void testSelectBooleanCheckbox() throws Exception {
+        WebPage page = getPage("selectBooleanCheckbox.xhtml");
+        WebElement cbox = page.findElement(By.id("checkbox"));
+        // This will ensure JavaScript finishes before evaluating the page.
+        assertTrue(page.isCondition(webDriver1 -> !cbox.isSelected()));
+
+        cbox.click();
+        assertTrue(page.isCondition(webDriver1 -> cbox.isSelected()));
+    }
+}

--- a/tck/faces22/ajax/src/test/java/ee/jakarta/tck/faces/test/servlet30/ajax_new/Issue2439IT.java
+++ b/tck/faces22/ajax/src/test/java/ee/jakarta/tck/faces/test/servlet30/ajax_new/Issue2439IT.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.faces.test.servlet30.ajax_new;
+
+import ee.jakarta.tck.faces.test.util.selenium.BaseITNG;
+import ee.jakarta.tck.faces.test.util.selenium.WebPage;
+import jakarta.faces.component.behavior.AjaxBehavior;
+import org.junit.Test;
+
+import static org.junit.Assert.assertTrue;
+
+public class Issue2439IT extends BaseITNG {
+
+    /**
+     * @see AjaxBehavior#isDisabled()
+     * @see https://github.com/eclipse-ee4j/mojarra/issues/2443
+     */
+    @Test
+    public void testUpdateAttributeNamedValue() {
+        // change in the rendering due to a different engine, we probably would be
+        // better off checking the dom elements directly
+        String expectedString1 = "<input id=\"form1:input1\" type=\"text\" name=\"form1:input1\">";
+        String expectedString2 = "<input id=\"form1:input2\" type=\"text\" name=\"form1:input2\" onchange=\"faces.util.chain(this,event,'mojarra.ab(this,event,\\'valueChange\\',\\'@this\\',\\'@all\\')')\">";
+        String expectedString3 = "<input id=\"form1:input3\" type=\"text\" name=\"form1:input3\" onchange=\"faces.util.chain(this,event,'alert(\\'Hello, World!\\');')\">";
+
+        WebPage page = getPage("disabledBehaviors.xhtml");
+        assertTrue(page.isInPage(expectedString1));
+        assertTrue(page.isInPage(expectedString2));
+        assertTrue(page.isInPage(expectedString3));
+    }
+}
+

--- a/tck/faces22/ajax/src/test/java/ee/jakarta/tck/faces/test/servlet30/ajax_new/Issue2443IT.java
+++ b/tck/faces22/ajax/src/test/java/ee/jakarta/tck/faces/test/servlet30/ajax_new/Issue2443IT.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.faces.test.servlet30.ajax_new;
+
+import ee.jakarta.tck.faces.test.util.selenium.BaseITNG;
+import ee.jakarta.tck.faces.test.util.selenium.WebPage;
+import jakarta.faces.component.behavior.AjaxBehavior;
+import org.junit.Test;
+
+import static org.junit.Assert.assertTrue;
+
+public class Issue2443IT extends BaseITNG {
+
+    /**
+     * @see AjaxBehavior
+     * @see https://github.com/eclipse-ee4j/mojarra/issues/2447
+     */
+    @Test
+    public void testQuotesInScript() throws Exception {
+        String expectedText = '"' + "<div></div>" + '"' + ";";
+        WebPage page = getPage("scriptQuote.xhtml");
+        assertTrue(page.isInPage(expectedText));
+    }
+}
+

--- a/tck/faces22/ajax/src/test/java/ee/jakarta/tck/faces/test/servlet30/ajax_new/Issue2456IT.java
+++ b/tck/faces22/ajax/src/test/java/ee/jakarta/tck/faces/test/servlet30/ajax_new/Issue2456IT.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.faces.test.servlet30.ajax_new;
+
+import ee.jakarta.tck.faces.test.util.selenium.BaseITNG;
+import ee.jakarta.tck.faces.test.util.selenium.WebPage;
+import jakarta.faces.component.behavior.AjaxBehavior;
+import org.junit.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+
+import static org.junit.Assert.assertTrue;
+
+public class Issue2456IT extends BaseITNG {
+
+    /**
+     * @see AjaxBehavior
+     * @see https://github.com/eclipse-ee4j/mojarra/issues/2460
+     */
+    @Test
+    public void testScript() throws Exception {
+        WebPage page = getPage("script.xhtml");
+        assertTrue(page.isInPage("SCRIPT EXECUTED!"));
+        WebElement button = page.findElement(By.id("form1:button1"));
+        button.click();
+        page.waitForCurrentRequestEnd();
+        assertTrue(page.isInPage("SCRIPT EXECUTED!"));
+    }
+}
+

--- a/tck/faces22/ajax/src/test/java/ee/jakarta/tck/faces/test/servlet30/ajax_new/Issue2479IT.java
+++ b/tck/faces22/ajax/src/test/java/ee/jakarta/tck/faces/test/servlet30/ajax_new/Issue2479IT.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.faces.test.servlet30.ajax_new;
+
+import ee.jakarta.tck.faces.test.util.selenium.BaseITNG;
+import ee.jakarta.tck.faces.test.util.selenium.WebPage;
+import jakarta.faces.component.behavior.AjaxBehavior;
+import org.junit.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.ui.Select;
+
+import java.time.Duration;
+
+import static org.junit.Assert.assertTrue;
+
+public class Issue2479IT extends BaseITNG {
+
+    /**
+     * @see AjaxBehavior
+     * @see https://github.com/eclipse-ee4j/mojarra/issues/2483
+     */
+    @Test
+    public void testSelectDataTable() throws Exception {
+        WebPage page = getPage("selectOneMenuDataTable.xhtml");
+        WebElement span1 = page.findElement(By.id("table:0:inCity"));
+        assertTrue((span1.getText()).equals("alpha"));
+        WebElement span2 = page.findElement(By.id("table:1:inCity"));
+        assertTrue((span2.getText()).equals("alpha"));
+        WebElement span3 = page.findElement(By.id("table:2:inCity"));
+        assertTrue((span3.getText()).equals("alpha"));
+        Select select = new Select(page.findElement(By.id("selectMenu")));
+        select.selectByValue("beta");
+        page.waitForCurrentRequestEnd();
+        //failing
+        page.waitForBackgroundJavascript(Duration.ofMillis(3000));
+        span1 = page.findElement(By.id("table:0:inCity"));
+        assertTrue((span1.getText()).equals("beta"));
+        span2 = page.findElement(By.id("table:1:inCity"));
+        assertTrue((span2.getText()).equals("beta"));
+        span3 = page.findElement(By.id("table:2:inCity"));
+        assertTrue((span3.getText()).equals("beta"));
+    }
+}
+

--- a/tck/faces22/ajax/src/test/java/ee/jakarta/tck/faces/test/servlet30/ajax_new/Issue2500IT.java
+++ b/tck/faces22/ajax/src/test/java/ee/jakarta/tck/faces/test/servlet30/ajax_new/Issue2500IT.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.faces.test.servlet30.ajax_new;
+
+import ee.jakarta.tck.faces.test.util.selenium.BaseITNG;
+import ee.jakarta.tck.faces.test.util.selenium.WebPage;
+import jakarta.faces.component.behavior.AjaxBehavior;
+import org.junit.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+
+import static org.junit.Assert.assertTrue;
+
+public class Issue2500IT extends BaseITNG {
+
+    /**
+     * @see AjaxBehavior
+     * @see https://github.com/eclipse-ee4j/mojarra/issues/2504
+     */
+    @Test
+    public void testNoDuplicateViewState() throws Exception {
+        WebPage page = getPage("dupViewState.xhtml");
+        WebElement button1 = page.findElement(By.id("btn5"));
+        button1.click();
+        page.waitReqJs();
+        WebElement button2 = page.findElement(By.id("button1"));
+        button2.click();
+        page.waitReqJs();
+        button2.click();
+        page.waitReqJs();
+        assertTrue(page.isInPage("jakarta.faces.ViewState Has One Value"));
+    }
+
+
+}

--- a/tck/faces22/ajax/src/test/java/ee/jakarta/tck/faces/test/servlet30/ajax_new/Issue2574IT.java
+++ b/tck/faces22/ajax/src/test/java/ee/jakarta/tck/faces/test/servlet30/ajax_new/Issue2574IT.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.faces.test.servlet30.ajax_new;
+
+import ee.jakarta.tck.faces.test.util.selenium.BaseITNG;
+import ee.jakarta.tck.faces.test.util.selenium.WebPage;
+import jakarta.faces.component.behavior.AjaxBehavior;
+import org.junit.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+
+import static org.junit.Assert.assertTrue;
+
+public class Issue2574IT extends BaseITNG {
+
+    /**
+     * @see AjaxBehavior
+     * @see https://github.com/eclipse-ee4j/mojarra/issues/2578
+     */
+    @Test
+    public void testOtherScriptType() throws Exception {
+        WebPage page = getPage("issue2574.xhtml");
+        WebElement button1 = page.findElement(By.id("form:refresh"));
+        button1.click();
+        page.waitReqJs();
+        assertTrue(page.isInPage("This script must not be eval'ed on ajax response."));
+    }
+}

--- a/tck/faces22/ajax/src/test/java/ee/jakarta/tck/faces/test/servlet30/ajax_new/Issue2578IT.java
+++ b/tck/faces22/ajax/src/test/java/ee/jakarta/tck/faces/test/servlet30/ajax_new/Issue2578IT.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.faces.test.servlet30.ajax_new;
+
+import ee.jakarta.tck.faces.test.util.selenium.BaseITNG;
+import ee.jakarta.tck.faces.test.util.selenium.WebPage;
+import jakarta.faces.component.behavior.AjaxBehavior;
+import org.junit.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+
+import static org.junit.Assert.assertTrue;
+
+public class Issue2578IT extends BaseITNG {
+
+    /**
+     * @see AjaxBehavior
+     * @see https://github.com/eclipse-ee4j/mojarra/issues/2582
+     */
+    @Test
+    public void testAjaxClear() throws Exception {
+        WebPage page = getPage("issue2578.xhtml");
+
+        assertTrue(page.findElement(By.id("form:input")).getAttribute("value").indexOf("hello") == -1);
+
+        WebElement input = page.findElement(By.id("form:input"));
+        input.sendKeys("hello");
+        page.waitReqJs();
+
+        assertTrue(page.findElement(By.id("form:input")).getAttribute("value").indexOf("hello") != -1);
+
+        WebElement button = page.findElement(By.id("form:clear"));
+        button.click();
+        page.waitReqJs();
+
+        assertTrue(page.findElement(By.id("form:input")).getAttribute("value").indexOf("hello") == -1);
+    }
+}

--- a/tck/faces22/ajax/src/test/java/ee/jakarta/tck/faces/test/servlet30/ajax_new/Issue2636IT.java
+++ b/tck/faces22/ajax/src/test/java/ee/jakarta/tck/faces/test/servlet30/ajax_new/Issue2636IT.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.faces.test.servlet30.ajax_new;
+
+import ee.jakarta.tck.faces.test.util.selenium.BaseITNG;
+import ee.jakarta.tck.faces.test.util.selenium.WebPage;
+import jakarta.faces.component.behavior.AjaxBehavior;
+import org.junit.Test;
+
+import static org.junit.Assert.assertTrue;
+
+public class Issue2636IT extends BaseITNG {
+
+    /**
+     * @see AjaxBehavior
+     * @see https://github.com/eclipse-ee4j/mojarra/issues/2640
+     */
+    @Test
+    public void testCommandLinksInRepeat() throws Exception {
+        WebPage page = getPage("issue2636.xhtml");
+
+
+        page.getAnchors().get(0).click();
+        assertTrue(page.isInPage("linkAction1"));
+
+        page.getAnchors().get(1).click();
+        assertTrue(page.isInPage("linkAction2"));
+
+        page.getAnchors().get(0).click();
+        assertTrue(page.isInPage("linkAction1"));
+    }
+
+}

--- a/tck/faces22/ajax/src/test/java/ee/jakarta/tck/faces/test/servlet30/ajax_new/Issue2648IT.java
+++ b/tck/faces22/ajax/src/test/java/ee/jakarta/tck/faces/test/servlet30/ajax_new/Issue2648IT.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.faces.test.servlet30.ajax_new;
+
+import ee.jakarta.tck.faces.test.util.selenium.BaseITNG;
+import ee.jakarta.tck.faces.test.util.selenium.WebPage;
+import jakarta.faces.component.behavior.AjaxBehavior;
+import org.junit.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+
+import static org.junit.Assert.assertTrue;
+
+public class Issue2648IT extends BaseITNG {
+
+    /**
+     * @see AjaxBehavior
+     * @see https://github.com/eclipse-ee4j/mojarra/issues/2652
+     */
+    //failing, time elapse
+    @Test
+    public void testIssue2648() {
+        WebPage page = getPage("issue2648.xhtml");
+
+        WebElement input = page.findElement(By.id("form:button"));
+        input.click();
+        page.waitReqJs();
+        page = getPage("issue2648-1.xhtml");
+
+        assertTrue(page.isInPage("IllegalStateException: true"));
+    }
+}

--- a/tck/faces22/ajax/src/test/java/ee/jakarta/tck/faces/test/servlet30/ajax_new/Issue2666IT.java
+++ b/tck/faces22/ajax/src/test/java/ee/jakarta/tck/faces/test/servlet30/ajax_new/Issue2666IT.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.faces.test.servlet30.ajax_new;
+
+import ee.jakarta.tck.faces.test.util.selenium.BaseITNG;
+import ee.jakarta.tck.faces.test.util.selenium.WebPage;
+import jakarta.faces.component.behavior.AjaxBehavior;
+import org.junit.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+
+import static org.junit.Assert.assertTrue;
+
+public class Issue2666IT extends BaseITNG {
+
+    /**
+     * @see AjaxBehavior
+     * @see https://github.com/eclipse-ee4j/mojarra/issues/2670
+     */
+    @Test
+    public void testRequestParamWithNoNameDoesNotExist() throws Exception {
+        WebPage page = getPage("issue2666.xhtml");
+        WebElement button = page.findElement(By.id("form:submit"));
+        button.click();
+        page.waitReqJs();
+
+        // Assert the page does not display the request parameter name 'button' that 
+        // is in the page without a 'name' attribute.
+        assertTrue(page.isInPage("Request parameter name 'button' does not exist"));
+    }
+}

--- a/tck/faces22/ajax/src/test/java/ee/jakarta/tck/faces/test/servlet30/ajax_new/Issue2674IT.java
+++ b/tck/faces22/ajax/src/test/java/ee/jakarta/tck/faces/test/servlet30/ajax_new/Issue2674IT.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.faces.test.servlet30.ajax_new;
+
+import ee.jakarta.tck.faces.test.util.selenium.BaseITNG;
+import ee.jakarta.tck.faces.test.util.selenium.WebPage;
+import jakarta.faces.component.behavior.AjaxBehavior;
+import org.junit.Test;
+
+import static org.junit.Assert.assertTrue;
+
+public class Issue2674IT extends BaseITNG {
+
+    /**
+     * @see AjaxBehavior
+     * @see https://github.com/eclipse-ee4j/mojarra/issues/2678
+     */
+    @Test
+    public void testProgrammaticAjaxBehavior() throws Exception {
+        String expectedString = "<input id=" + '"' + "form:input1" + '"' + " type=" + '"' + "text" + '"' + " name=" + '"' + "form:input1" + '"' + " value=" + '"' + "hi" + '"' + " onfocus=" + '"' + "mojarra.ab(this,event,'focus',0,0)" + '"';
+        WebPage page = getPage("issue2674.xhtml");
+        assertTrue(page.isInPage(expectedString));
+    }
+}
+

--- a/tck/faces22/ajax/src/test/java/ee/jakarta/tck/faces/test/servlet30/ajax_new/Issue2697IT.java
+++ b/tck/faces22/ajax/src/test/java/ee/jakarta/tck/faces/test/servlet30/ajax_new/Issue2697IT.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.faces.test.servlet30.ajax_new;
+
+import ee.jakarta.tck.faces.test.util.selenium.BaseITNG;
+import ee.jakarta.tck.faces.test.util.selenium.WebPage;
+import jakarta.faces.component.behavior.AjaxBehavior;
+import org.junit.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+
+import static org.junit.Assert.assertTrue;
+
+
+public class Issue2697IT extends BaseITNG {
+
+    /**
+     * @see AjaxBehavior
+     * @see https://github.com/eclipse-ee4j/mojarra/issues/2701
+     */
+    @Test
+    public void testAjaxViewScope() throws Exception {
+        WebPage page = getPage("viewScope.xhtml");
+
+        WebElement button = page.findElement(By.id("form:reset"));
+        button.click();
+        page.waitReqJs();
+
+        button = page.findElement(By.id("form:ajax"));
+        button.click();
+        assertTrue(page.isInPage("VIEWSCOPEBEAN() CALLED"));
+
+        // Assert that second Ajax request does not execute the bean constructor again.
+        button = page.findElement(By.id("form:ajax")); //we need to reload the button due to detachement
+        button.click();
+        page.waitReqJs();
+
+        // this looks like a RI bug exposed by chrome, not following this any further because the test is so basic
+        // this text is exactly like it should not be in the page, very likely similar to Issue2162IT
+        assertTrue(page.isNotInPageText("VIEWSCOPEBEAN() CALLED VIEWSCOPEBEAN() CALLED"));
+    }
+}

--- a/tck/faces22/ajax/src/test/java/ee/jakarta/tck/faces/test/servlet30/ajax_new/Issue2749IT.java
+++ b/tck/faces22/ajax/src/test/java/ee/jakarta/tck/faces/test/servlet30/ajax_new/Issue2749IT.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.faces.test.servlet30.ajax_new;
+
+import ee.jakarta.tck.faces.test.util.selenium.BaseITNG;
+import ee.jakarta.tck.faces.test.util.selenium.WebPage;
+import jakarta.faces.component.behavior.AjaxBehavior;
+import org.junit.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+
+import static org.junit.Assert.assertTrue;
+
+public class Issue2749IT extends BaseITNG {
+
+    /**
+     * @see AjaxBehavior
+     * @see https://github.com/eclipse-ee4j/mojarra/issues/2753
+     */
+    @Test
+    public void testUpdateAttributeNamedOn() throws Exception {
+        WebPage page = getPage("attributeNameIsOn.xhtml");
+
+        WebElement button = page.findElement(By.id("form1:button"));
+        button.click();
+        assertTrue(page.isInPage("ONCLICK CALLED"));
+    }
+
+}

--- a/tck/faces22/ajax/src/test/java/ee/jakarta/tck/faces/test/servlet30/ajax_new/Issue2750IT.java
+++ b/tck/faces22/ajax/src/test/java/ee/jakarta/tck/faces/test/servlet30/ajax_new/Issue2750IT.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.faces.test.servlet30.ajax_new;
+
+import ee.jakarta.tck.faces.test.util.selenium.BaseITNG;
+import ee.jakarta.tck.faces.test.util.selenium.WebPage;
+import jakarta.faces.component.behavior.AjaxBehavior;
+import org.junit.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+
+import static org.junit.Assert.assertTrue;
+
+public class Issue2750IT extends BaseITNG {
+
+    /**
+     * @see AjaxBehavior
+     * @see https://github.com/eclipse-ee4j/mojarra/issues/2754
+     */
+    @Test
+    public void testUpdateAttributeNamedChecked() throws Exception {
+        WebPage page = getPage("attributeNameIsChecked.xhtml");
+        WebElement cbox = page.findElement(By.id("form1:foo"));
+        assertTrue(cbox.isSelected() == false);
+        assertTrue(page.isInPage("foo"));
+        WebElement button = page.findElement(By.id("form1:button"));
+        button.click();
+        page.waitForCurrentRequestEnd();
+        Thread.sleep(3000);
+        cbox = page.findElement(By.id("form1:foo"));
+        assertTrue(cbox.isSelected() == true);
+    }
+
+    /**
+     * This test verifies that an attribute named 'readonly' can be successfully updated
+     * from a partial response (over Ajax).
+     */
+    @Test
+    public void testUpdateAttributeNamedReadonly() throws Exception {
+        WebPage page = getPage("attributeNameIsReadonly.xhtml");
+        WebElement input = page.findElement(By.id("form1:foo"));
+        assertTrue(input.getAttribute("readOnly") == null || !input.getAttribute("readOnly").equals("true"));
+        WebElement button = page.findElement(By.id("form1:button"));
+        button.click();
+        page.waitReqJs();
+        input = page.findElement(By.id("form1:foo"));
+        assertTrue(input.getAttribute("readOnly").equals("true"));
+    }
+
+}

--- a/tck/faces22/ajax/src/test/java/ee/jakarta/tck/faces/test/servlet30/ajax_new/Issue2751IT.java
+++ b/tck/faces22/ajax/src/test/java/ee/jakarta/tck/faces/test/servlet30/ajax_new/Issue2751IT.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.faces.test.servlet30.ajax_new;
+
+import ee.jakarta.tck.faces.test.util.selenium.BaseITNG;
+import ee.jakarta.tck.faces.test.util.selenium.WebPage;
+import jakarta.faces.component.behavior.AjaxBehavior;
+import org.junit.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+
+import static org.junit.Assert.assertTrue;
+
+public class Issue2751IT extends BaseITNG {
+
+    /**
+     * @see AjaxBehavior
+     * @see https://github.com/eclipse-ee4j/mojarra/issues/2755
+     */
+    @Test
+    public void testUpdateAttributeNamedClass() throws Exception {
+        WebPage page = getPage("attributeNameIsClass.xhtml");
+
+        WebElement input = page.findElement(By.id("form1:foo"));
+
+        assertTrue(input.getAttribute("value").equals("foo"));
+        WebElement button = page.findElement(By.id("form1:button"));
+        button.click();
+        page.waitReqJs();
+        input = page.findElement(By.id("form1:foo"));
+        assertTrue(page.isInPage("myclass"));
+    }
+}

--- a/tck/faces22/ajax/src/test/java/ee/jakarta/tck/faces/test/servlet30/ajax_new/Issue2752IT.java
+++ b/tck/faces22/ajax/src/test/java/ee/jakarta/tck/faces/test/servlet30/ajax_new/Issue2752IT.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.faces.test.servlet30.ajax_new;
+
+import ee.jakarta.tck.faces.test.util.selenium.BaseITNG;
+import ee.jakarta.tck.faces.test.util.selenium.WebPage;
+import jakarta.faces.component.behavior.AjaxBehavior;
+import org.junit.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+
+import static org.junit.Assert.assertTrue;
+
+public class Issue2752IT extends BaseITNG {
+
+    /**
+     * @see AjaxBehavior
+     * @see https://github.com/eclipse-ee4j/mojarra/issues/2756
+     */
+    @Test
+    public void testInsertFromResponse() throws Exception {
+        WebPage page = getPage("insertElement.xhtml");
+
+        WebElement beforeButton = page.findElement(By.id("beforeButton"));
+        beforeButton.click();
+        // This will ensure JavaScript finishes before evaluating the page.
+        page.waitReqJs();
+        assertTrue(page.isInPageText("This is before textalpha"));
+        WebElement afterButton = page.findElement(By.id("afterButton"));
+        afterButton.click();
+        // This will ensure JavaScript finishes before evaluating the page.
+        page.waitReqJs();
+        assertTrue(page.isInPageText("This is before textalphaThis is after text"));
+    }
+
+}

--- a/tck/faces22/ajax/src/test/java/ee/jakarta/tck/faces/test/servlet30/ajax_new/Issue2754IT.java
+++ b/tck/faces22/ajax/src/test/java/ee/jakarta/tck/faces/test/servlet30/ajax_new/Issue2754IT.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.faces.test.servlet30.ajax_new;
+
+import ee.jakarta.tck.faces.test.util.selenium.BaseITNG;
+import ee.jakarta.tck.faces.test.util.selenium.WebPage;
+import jakarta.faces.component.behavior.AjaxBehavior;
+import org.junit.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+
+import static org.junit.Assert.assertTrue;
+
+public class Issue2754IT extends BaseITNG {
+
+    /**
+     * @see AjaxBehavior
+     * @see https://github.com/eclipse-ee4j/mojarra/issues/2758
+     */
+    @Test
+    public void testAjaxViewScope() throws Exception {
+        WebPage page = getPage("issue2754.xhtml");
+
+        WebElement input;
+        WebElement button = page.findElement(By.id("button"));
+        button.click();
+        page.waitReqJs();
+        assertTrue(page.isInPage("<ul id=\"messages\"><li>"));
+        input = page.findElement(By.id("input"));
+        input.sendKeys("hello");
+        button = page.findElement(By.id("button"));
+        button.click();
+        page.waitReqJs();
+        assertTrue(page.isNotInPage("<ul id=\"messages\"><li>"));
+    }
+}

--- a/tck/faces22/ajax/src/test/java/ee/jakarta/tck/faces/test/servlet30/ajax_new/Issue2767IT.java
+++ b/tck/faces22/ajax/src/test/java/ee/jakarta/tck/faces/test/servlet30/ajax_new/Issue2767IT.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.faces.test.servlet30.ajax_new;
+
+import ee.jakarta.tck.faces.test.util.selenium.BaseITNG;
+import ee.jakarta.tck.faces.test.util.selenium.WebPage;
+import jakarta.faces.component.behavior.AjaxBehavior;
+import org.junit.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+
+import static org.junit.Assert.assertTrue;
+
+public class Issue2767IT extends BaseITNG {
+
+    /**
+     * @see AjaxBehavior
+     * @see https://github.com/eclipse-ee4j/mojarra/issues/2771
+     */
+    @Test
+    public void testCommandLinkRadio() throws Exception {
+        WebPage page = getPage("issue2767.xhtml");
+        // This will ensure JavaScript finishes before evaluating the page.
+
+        WebElement anchor = page.findElement(By.id("testLink"));
+        anchor.click();
+        page.waitReqJs();
+        assertTrue(page.isInPage("LINK ACTION"));
+        WebElement radio1 = page.findElement(By.id("testRadio:0"));
+        WebElement radio2 = page.findElement(By.id("testRadio:1"));
+        WebElement radio3 = page.findElement(By.id("testRadio:2"));
+
+        radio1.click();
+        page.waitReqJs();
+        assertTrue(page.isInPage("RADIO:red"));
+
+        radio2.click();
+        page.waitReqJs();
+        assertTrue(page.isInPage("RADIO:blue"));
+
+        radio3.click();
+        page.waitReqJs();
+        assertTrue(page.isInPage("RADIO:white"));
+    }
+}

--- a/tck/faces22/ajax/src/test/java/ee/jakarta/tck/faces/test/servlet30/ajax_new/Issue2906IT.java
+++ b/tck/faces22/ajax/src/test/java/ee/jakarta/tck/faces/test/servlet30/ajax_new/Issue2906IT.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.faces.test.servlet30.ajax_new;
+
+import ee.jakarta.tck.faces.test.util.selenium.BaseITNG;
+import ee.jakarta.tck.faces.test.util.selenium.WebPage;
+import jakarta.faces.component.behavior.AjaxBehavior;
+import org.junit.Test;
+import org.openqa.selenium.WebElement;
+
+import java.util.List;
+
+import static org.junit.Assert.assertTrue;
+
+public class Issue2906IT extends BaseITNG {
+
+    /**
+     * @see AjaxBehavior
+     * @see https://github.com/eclipse-ee4j/mojarra/issues/2910
+     */
+    @Test
+    public void testCommandLinksInRepeat() throws Exception {
+        WebPage page = getPage("issue2906.xhtml");
+
+
+        assertTrue(page.matchesPageText(".*(2\\s+){9}2.*"));
+
+        List<WebElement> anchors = page.getAnchors();
+        WebElement anchor = anchors.get(9);
+        anchor.click();
+        page.waitReqJs();
+        anchors = page.getAnchors();
+        assertTrue(page.matchesPageText(".*(3\\s+){8}3.*"));
+        assertTrue(anchors.size() == 9);
+
+        anchor = anchors.get(8);
+        anchor.click();
+        page.waitReqJs(); 
+
+        anchors = page.getAnchors();
+        assertTrue(page.matchesPageText(".*(4\\s+){7}4.*"));
+        assertTrue(anchors.size() == 8);
+
+        anchor = anchors.get(7);
+        anchor.click();
+        page.waitReqJs(); 
+
+        anchors = page.getAnchors();
+        assertTrue(page.matchesPageText(".*(5\\s+){6}5.*"));
+        assertTrue(anchors.size() == 7);
+
+        anchor = anchors.get(0);
+        anchor.click();
+        page.waitReqJs(); 
+
+        anchors = page.getAnchors();
+        assertTrue(page.matchesPageText(".*(6\\s+){5}6.*"));
+        assertTrue(anchors.size() == 6);
+
+        anchor = anchors.get(2);
+        anchor.click();
+        page.waitReqJs(); 
+
+        anchors = page.getAnchors();
+        assertTrue(page.matchesPageText(".*(7\\s+){4}7.*"));
+        assertTrue(anchors.size() == 5);
+    }
+
+
+}

--- a/tck/faces22/ajax/src/test/java/ee/jakarta/tck/faces/test/servlet30/ajax_new/Issue2969IT.java
+++ b/tck/faces22/ajax/src/test/java/ee/jakarta/tck/faces/test/servlet30/ajax_new/Issue2969IT.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.faces.test.servlet30.ajax_new;
+
+import ee.jakarta.tck.faces.test.util.selenium.BaseITNG;
+import ee.jakarta.tck.faces.test.util.selenium.WebPage;
+import jakarta.faces.component.behavior.AjaxBehavior;
+import org.junit.Test;
+import org.openqa.selenium.By;
+
+import static org.junit.Assert.assertTrue;
+
+public class Issue2969IT extends BaseITNG {
+
+    /**
+     * @see AjaxBehavior
+     * @see https://github.com/eclipse-ee4j/mojarra/issues/2973
+     */
+    @Test
+    public void testAjaxProjectStage() throws Exception {
+        WebPage page = getPage("ajaxProjectStage.xhtml");
+
+        String stage = page.findElement(By.id("stage")).getText();
+        assertTrue(stage.equals("Production") || stage.equals("Development"));
+    }
+}

--- a/tck/faces22/ajax/src/test/java/ee/jakarta/tck/faces/test/servlet30/ajax_new/Issue3020IT.java
+++ b/tck/faces22/ajax/src/test/java/ee/jakarta/tck/faces/test/servlet30/ajax_new/Issue3020IT.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.faces.test.servlet30.ajax_new;
+
+import ee.jakarta.tck.faces.test.util.selenium.BaseITNG;
+import ee.jakarta.tck.faces.test.util.selenium.WebPage;
+import jakarta.faces.component.behavior.AjaxBehavior;
+import org.junit.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+
+import static org.junit.Assert.assertTrue;
+
+public class Issue3020IT extends BaseITNG {
+
+    /**
+     * @see AjaxBehavior
+     * @see https://github.com/eclipse-ee4j/mojarra/issues/3024
+     */
+    @Test
+    public void testDelayPositive() throws Exception {
+        WebPage page = getPage("issue3020Positive.xhtml");
+
+        WebElement in1 = page.findElement(By.id("input"));
+        in1.sendKeys("a");
+
+        Thread.sleep(3000);
+
+        // Check that the ajax request succeeds
+        assertTrue(page.findElement(By.id("result")).getText().contains("aaaaaaaaaa"));
+    }
+
+    /**
+     * @see AjaxBehavior
+     * @see https://github.com/eclipse-ee4j/mojarra/issues/3024
+     */
+    @Test
+    public void testDelayNegative() throws Exception {
+        WebPage page = getPage("issue3020Negative.xhtml");
+
+        WebElement in1 = page.findElement(By.id("input"));
+        in1.sendKeys("a");
+
+        page.waitReqJs();
+
+        // Check that the ajax request does not succeed, change from the original which had direct access to the js exceptions
+        WebElement errorHolder = page.findElement(By.id("windowError"));
+        assertTrue(errorHolder.getText().contains("NaN"));
+    }
+
+
+}

--- a/tck/faces22/ajax/src/test/java/ee/jakarta/tck/faces/test/servlet30/ajax_new/Issue3097IT.java
+++ b/tck/faces22/ajax/src/test/java/ee/jakarta/tck/faces/test/servlet30/ajax_new/Issue3097IT.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.faces.test.servlet30.ajax_new;
+
+import ee.jakarta.tck.faces.test.util.selenium.BaseITNG;
+import ee.jakarta.tck.faces.test.util.selenium.WebPage;
+import jakarta.faces.component.behavior.AjaxBehavior;
+import org.junit.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+
+import static org.junit.Assert.assertTrue;
+
+public class Issue3097IT extends BaseITNG {
+
+    /**
+     * @see AjaxBehavior
+     * @see https://github.com/eclipse-ee4j/mojarra/issues/3101
+     */
+    @Test
+    public void testViewExpired1() throws Exception {
+        WebPage page = getPage("viewExpired1.xhtml");
+
+        if (page.getPageSource().indexOf("State Saving Method: server") != -1) {
+            WebElement expireButton = page.findElement(By.id("form:expireSessionSoon"));
+            expireButton.click();
+            Thread.sleep(25000);
+            WebElement submitButton = page.findElement(By.id("form:submit"));
+            submitButton.click();
+            page.waitReqJs();
+            assertTrue(page.isInPageText("class jakarta.faces.application.ViewExpiredException"));
+        }
+    }
+}

--- a/tck/faces22/ajax/src/test/java/ee/jakarta/tck/faces/test/servlet30/ajax_new/Issue3106IT.java
+++ b/tck/faces22/ajax/src/test/java/ee/jakarta/tck/faces/test/servlet30/ajax_new/Issue3106IT.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.faces.test.servlet30.ajax_new;
+
+import ee.jakarta.tck.faces.test.util.selenium.BaseITNG;
+import ee.jakarta.tck.faces.test.util.selenium.WebPage;
+import jakarta.faces.component.behavior.AjaxBehavior;
+import org.junit.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+
+import static org.junit.Assert.assertTrue;
+
+public class Issue3106IT extends BaseITNG {
+
+    /**
+     * @see AjaxBehavior
+     * @see https://github.com/eclipse-ee4j/mojarra/issues/3110
+     */
+    @Test
+    public void testMultiPart1() throws Exception {
+        WebPage page = getPage("multiPart1.xhtml");
+
+        WebElement element = page.findElement(By.id("form:submit"));
+
+        element.click();
+        Thread.sleep(500);
+
+        page.findElement(By.id("form:submit")).click();
+
+        //2 requests after that we have to move forward
+        Thread.sleep(3000);
+
+        page = getPage("multiPart1b.xhtml");
+
+        assertTrue(page.isInPageText("Count is 2"));
+    }
+}

--- a/tck/faces22/ajax/src/test/java/ee/jakarta/tck/faces/test/servlet30/ajax_new/Issue3171IT.java
+++ b/tck/faces22/ajax/src/test/java/ee/jakarta/tck/faces/test/servlet30/ajax_new/Issue3171IT.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.faces.test.servlet30.ajax_new;
+
+import ee.jakarta.tck.faces.test.util.selenium.BaseITNG;
+import ee.jakarta.tck.faces.test.util.selenium.WebPage;
+import jakarta.faces.component.behavior.AjaxBehavior;
+import org.junit.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+
+import static org.junit.Assert.assertTrue;
+
+public class Issue3171IT extends BaseITNG {
+
+    /**
+     * @see AjaxBehavior
+     * @see https://github.com/eclipse-ee4j/mojarra/issues/3175
+     */
+    @Test
+    public void testExceptionDuringRenderOk() {
+        WebPage page = getPage("exceptionDuringRender.xhtml");
+
+        String pageText = page.getPageSource();
+
+        assertTrue(pageText.contains("not an ajax request"));
+
+        WebElement button = page.findElement(By.id("submit"));
+
+        button.click();
+        try {
+            Thread.sleep(3000);
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+
+        assertTrue(page.isInPageText("not an ajax request"));
+        assertTrue(page.isInPageText("Error from submit"));
+
+    }
+}

--- a/tck/faces22/ajax/src/test/java/ee/jakarta/tck/faces/test/servlet30/ajax_new/Issue3261IT.java
+++ b/tck/faces22/ajax/src/test/java/ee/jakarta/tck/faces/test/servlet30/ajax_new/Issue3261IT.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.faces.test.servlet30.ajax_new;
+
+import ee.jakarta.tck.faces.test.util.selenium.BaseITNG;
+import ee.jakarta.tck.faces.test.util.selenium.WebPage;
+import jakarta.faces.component.behavior.AjaxBehavior;
+import org.junit.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+
+import static org.junit.Assert.assertEquals;
+
+public class Issue3261IT extends BaseITNG {
+
+    /**
+     * @see AjaxBehavior
+     * @see https://github.com/eclipse-ee4j/mojarra/issues/3265
+     */
+    @Test
+    public void testLegendWithoutIdOK() throws Exception {
+
+        WebPage page = getPage("legendWithoutId.xhtml");
+        WebElement button = page.findElement(By.id("form:submit"));
+
+        button.click();
+        page.waitReqJs();
+
+        assertEquals(200, page.getResponseStatus());
+    }
+}

--- a/tck/faces22/ajax/src/test/java/ee/jakarta/tck/faces/test/servlet30/ajax_new/Issue3344IT.java
+++ b/tck/faces22/ajax/src/test/java/ee/jakarta/tck/faces/test/servlet30/ajax_new/Issue3344IT.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.faces.test.servlet30.ajax_new;
+
+import ee.jakarta.tck.faces.test.util.selenium.BaseITNG;
+import ee.jakarta.tck.faces.test.util.selenium.WebPage;
+import jakarta.faces.component.behavior.AjaxBehavior;
+import org.junit.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+
+import static org.junit.Assert.assertTrue;
+
+public class Issue3344IT extends BaseITNG {
+
+    /**
+     * @see AjaxBehavior
+     * @see https://github.com/eclipse-ee4j/mojarra/issues/3348
+     */
+    @Test
+    public void testXmlPreambleOnRedirect() throws Exception {
+        WebPage page = getPage("ajaxRedirect01.xhtml");
+
+        WebElement button = page.findElement(By.id("button"));
+        button.click();
+        page.waitForCurrentRequestEnd();
+
+        Thread.sleep(3000);
+        assertTrue(page.isInPage("&lt;?xml version=\"1.0\" encoding=\"UTF-8\"?&gt;"));
+    }
+}

--- a/tck/faces22/ajax/src/test/java/ee/jakarta/tck/faces/test/servlet30/ajax_new/Issue3351IT.java
+++ b/tck/faces22/ajax/src/test/java/ee/jakarta/tck/faces/test/servlet30/ajax_new/Issue3351IT.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.faces.test.servlet30.ajax_new;
+
+import ee.jakarta.tck.faces.test.util.selenium.BaseITNG;
+import ee.jakarta.tck.faces.test.util.selenium.WebPage;
+import jakarta.faces.component.behavior.AjaxBehavior;
+import org.junit.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+
+import static org.junit.Assert.assertTrue;
+
+public class Issue3351IT extends BaseITNG {
+
+    /**
+     * @see AjaxBehavior
+     * @see https://github.com/eclipse-ee4j/mojarra/issues/3355
+     */
+    @Test
+    public void testButtonOnlySubmitsOne() throws Exception {
+        WebPage page = getPage("buttonOnlySubmitsOne.xhtml");
+        assertTrue(page.isInPage("value1,value2,"));
+
+        WebElement button = page.findElement(By.id("form:button1"));
+        button.click();
+        page.waitReqJs();
+        assertTrue(page.isInPageText("value2,"));
+        assertTrue(page.isNotInPageText("value1,value2,"));
+    }
+}

--- a/tck/faces22/ajax/src/test/java/ee/jakarta/tck/faces/test/servlet30/ajax_new/Issue3473IT.java
+++ b/tck/faces22/ajax/src/test/java/ee/jakarta/tck/faces/test/servlet30/ajax_new/Issue3473IT.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.faces.test.servlet30.ajax_new;
+
+import ee.jakarta.tck.faces.test.util.selenium.BaseITNG;
+import ee.jakarta.tck.faces.test.util.selenium.WebPage;
+import jakarta.faces.component.behavior.AjaxBehavior;
+import org.junit.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+
+import static org.junit.Assert.assertTrue;
+
+public class Issue3473IT extends BaseITNG {
+
+    /**
+     * @see AjaxBehavior
+     * @see https://github.com/eclipse-ee4j/mojarra/issues/3477
+     */
+    @Test
+    public void testButtonOnlySubmitsOne() throws Exception {
+        WebPage page = getPage("ajaxScriptError.xhtml");
+        WebElement button = page.findElement(By.id("form:commandButton"));
+        page.waitReqJs();
+        button.click();
+        page.waitReqJs();
+        assertTrue(page.isInPage("Error from form:commandButton"));
+    }
+}

--- a/tck/faces22/ajax/src/test/java/ee/jakarta/tck/faces/test/servlet30/ajax_new/Issue3833IT.java
+++ b/tck/faces22/ajax/src/test/java/ee/jakarta/tck/faces/test/servlet30/ajax_new/Issue3833IT.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.faces.test.servlet30.ajax_new;
+
+import ee.jakarta.tck.faces.test.util.selenium.BaseITNG;
+import ee.jakarta.tck.faces.test.util.selenium.WebPage;
+import jakarta.faces.component.behavior.AjaxBehavior;
+import org.junit.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.support.ui.Select;
+
+import static org.junit.Assert.assertTrue;
+
+public class Issue3833IT extends BaseITNG {
+
+    /**
+     * @see AjaxBehavior
+     * @see com.sun.faces.facelets.component.UIRepeat
+     * @see https://github.com/eclipse-ee4j/mojarra/issues/3837
+     */
+    @Test
+    public void testUIRepeatStateSaving() throws Exception {
+        WebPage page = getPage("issue3833.xhtml");
+
+        Select select1 = new Select(page.findElement(By.id("form:repeat:0:list")));
+        Select select2 = new Select(page.findElement(By.id("form:repeat:1:list")));
+
+
+        select1.selectByIndex(0);
+        page.waitForCurrentRequestEnd();
+        Thread.sleep(3000);
+        assertTrue(page.findElement(By.id("form:message")).getText().equals("null -> 1"));
+
+        select2.selectByIndex(0);
+        page.waitForCurrentRequestEnd();
+        Thread.sleep(3000);
+        assertTrue(page.findElement(By.id("form:message")).getText().equals("null -> 3"));
+
+        select1.selectByIndex(1);
+        page.waitForCurrentRequestEnd();
+        Thread.sleep(3000);
+        assertTrue(page.findElement(By.id("form:message")).getText().equals("1 -> 2"));
+
+        select2.selectByIndex(1);
+        page.waitForCurrentRequestEnd();
+        Thread.sleep(3000);
+        assertTrue(page.findElement(By.id("form:message")).getText().equals("3 -> 4"));
+    }
+}

--- a/tck/faces22/ajax/src/test/java/ee/jakarta/tck/faces/test/servlet30/ajax_new/Issue4345IT.java
+++ b/tck/faces22/ajax/src/test/java/ee/jakarta/tck/faces/test/servlet30/ajax_new/Issue4345IT.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.faces.test.servlet30.ajax_new;
+
+import ee.jakarta.tck.faces.test.util.selenium.BaseITNG;
+import ee.jakarta.tck.faces.test.util.selenium.WebPage;
+import jakarta.faces.component.behavior.AjaxBehavior;
+import org.junit.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+public class Issue4345IT extends BaseITNG {
+
+    /**
+     * @see AjaxBehavior
+     * @see https://github.com/eclipse-ee4j/mojarra/issues/4345
+     */
+    @Test
+    public void testAjaxResourceNotDoubleHTMLEscaped() throws Exception {
+        WebPage page = getPage("issue4345start.xhtml");
+
+        WebElement issue4340Button = page.findElement(By.id("form:issue4345Button"));
+        issue4340Button.click();
+        page.waitForCurrentRequestEnd();
+
+        page.waitReqJs();
+
+        WebElement result = page.findElement(By.id("issue4345Result"));
+        assertNotNull(result);
+        assertEquals("SUCCESS", result.getText());
+    }
+}

--- a/tck/faces22/ajax/src/test/java/ee/jakarta/tck/faces/test/servlet30/ajax_new/Issue939IT.java
+++ b/tck/faces22/ajax/src/test/java/ee/jakarta/tck/faces/test/servlet30/ajax_new/Issue939IT.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package ee.jakarta.tck.faces.test.servlet30.ajax_new;
+
+
+import ee.jakarta.tck.faces.test.util.selenium.BaseITNG;
+import ee.jakarta.tck.faces.test.util.selenium.WebPage;
+import org.junit.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Demo port to showcase how to implement
+ * an ajax test with Selenium web drivers
+ */
+public class Issue939IT extends BaseITNG {
+
+    @Test
+    public void testCdataEscape1() throws Exception {
+        WebPage page = getPage("issue939.xhtml");
+        WebElement out1 = page.findElement(By.id("form1:out1"));
+        WebElement in1 = page.findElement(By.id("form1:in1"));
+        assertEquals("", out1.getText().trim());
+        assertEquals("", in1.getAttribute("value").trim());
+        in1.sendKeys("]]>");
+        WebElement button1 = page.findElement(By.id("form1:button1"));
+        button1.click();
+        Thread.sleep(1000);
+        // Check that the ajax request succeeds
+        assertEquals("]]>", page.findElement(By.id("form1:out1")).getText().trim());
+    }
+
+    @Test
+    public void testCdataEscape2() throws Exception {
+        WebPage page = getPage("issue939.xhtml");
+        assertEquals("", page.findElement(By.id("form1:out1")).getText());
+        assertEquals("", page.findElement(By.id("form1:in1")).getAttribute("value"));
+
+        WebElement in1 = page.findElement(By.id("form1:in1"));
+        in1.sendKeys("<!");
+
+        // Submit the ajax request
+        WebElement button1 = page.findElement(By.id("form1:button1"));
+        button1.click();
+        Thread.sleep(3000);
+
+        // Check that the ajax request succeeds
+        assertEquals("<!", page.findElement(By.id("form1:out1")).getText());
+    }
+
+    @Test
+    public void testCdataEscape3() throws Exception {
+        Thread.sleep(3000);
+        WebPage page = getPage("issue939.xhtml");
+        assertEquals("", page.findElement(By.id("form1:out1")).getText());
+        assertEquals("", page.findElement(By.id("form1:in1")).getAttribute("value"));
+
+        WebElement in1 = page.findElement(By.id("form1:in1"));
+        in1.sendKeys("]");
+
+        // Submit the ajax request
+        WebElement button1 = page.findElement(By.id("form1:button1"));
+        button1.click();
+        Thread.sleep(3000);
+
+        // Check that the ajax request succeeds
+        assertEquals("]", page.findElement(By.id("form1:out1")).getText());
+    }
+
+    @Test
+    public void testCdataEscape4() throws Exception {
+        Thread.sleep(3000);
+        WebPage page = getPage("issue939.xhtml");
+        assertEquals("", page.findElement(By.id("form1:out1")).getText());
+        assertEquals("", page.findElement(By.id("form1:in1")).getAttribute("value"));
+
+        WebElement in1 = page.findElement(By.id("form1:in1"));
+        in1.sendKeys("<![CDATA[ ]]>");
+
+        // Submit the ajax request
+        WebElement button1 = page.findElement(By.id("form1:button1"));
+        button1.click();
+        Thread.sleep(3000);
+
+        // Check that the ajax request succeeds
+        assertEquals("<![CDATA[ ]]>", page.findElement(By.id("form1:out1")).getText());
+    }
+}

--- a/tck/faces22/ajax/src/test/java/ee/jakarta/tck/faces/test/servlet30/ajax_new/Spec1296IT.java
+++ b/tck/faces22/ajax/src/test/java/ee/jakarta/tck/faces/test/servlet30/ajax_new/Spec1296IT.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.faces.test.servlet30.ajax_new;
+
+import ee.jakarta.tck.faces.test.util.selenium.BaseITNG;
+import ee.jakarta.tck.faces.test.util.selenium.WebPage;
+import jakarta.faces.context.PartialResponseWriter;
+import org.junit.Test;
+
+import static org.junit.Assert.assertTrue;
+
+public class Spec1296IT extends BaseITNG {
+
+    /**
+     * @see PartialResponseWriter
+     * @see https://github.com/jakartaee/faces/issues/1296
+     */
+    @Test
+    public void testPartialResponseWriterOutsideFacesServlet() throws Exception {
+        WebPage page = getPage("BeforeFilter");
+        String pageXml = page.getResponseBody();
+        assertTrue(pageXml.matches("(?s).*<\\?xml\\s+version=\\'1\\.0\\'\\s+encoding=\\'UTF-8\\'\\?>\\s*<partial-response>\\s*<changes>\\s*<update\\s+id=\\\"foo\\\">\\s*<\\!\\[CDATA\\[\\s*\\]]>\\s*</update>\\s*</changes>\\s*</partial-response>.*"));
+    }
+}

--- a/tck/faces22/ajax/src/test/java/ee/jakarta/tck/faces/test/servlet30/ajax_new/Spec220IT.java
+++ b/tck/faces22/ajax/src/test/java/ee/jakarta/tck/faces/test/servlet30/ajax_new/Spec220IT.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.faces.test.servlet30.ajax_new;
+
+import ee.jakarta.tck.faces.test.util.selenium.BaseITNG;
+import ee.jakarta.tck.faces.test.util.selenium.ExtendedTextInput;
+import ee.jakarta.tck.faces.test.util.selenium.WebPage;
+import jakarta.faces.component.behavior.AjaxBehavior;
+import jakarta.faces.render.ResponseStateManager;
+import org.junit.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+
+import static junit.framework.Assert.assertTrue;
+
+public class Spec220IT extends BaseITNG {
+
+    /**
+     * @see AjaxBehavior
+     * @see ResponseStateManager#VIEW_STATE_PARAM
+     * @see https://github.com/jakartaee/faces/issues/220
+     */
+    @Test
+    public void testViewState() throws Exception {
+        WebPage page = getPage("viewState1.xhtml");
+        ExtendedTextInput textField = new ExtendedTextInput(getWebDriver(), page.findElement(By.id("firstName")));
+        //we need to clear out the textfield first, it has a preset value of Duke
+        textField.setValue("ajaxFirstName");
+
+        WebElement button = page.findElement(By.id("submitAjax"));
+        button.click();
+
+        Thread.sleep(2000);
+
+        assertTrue(page.isInPageText("|ajaxFirstName|"));
+
+        textField = new ExtendedTextInput(getWebDriver(), page.findElement(By.id("firstName")));
+        textField.setValue("nonAjaxFirstName");
+
+        button = page.findElement(By.id("submitNonAjax"));
+        button.click();
+
+        Thread.sleep(2000);
+        assertTrue(page.isInPageText("|nonAjaxFirstName|"));
+    }
+
+}

--- a/tck/faces23/ajax/src/test/java/ee/jakarta/tck/faces/test/javaee8/ajax_new/Issue3981IT.java
+++ b/tck/faces23/ajax/src/test/java/ee/jakarta/tck/faces/test/javaee8/ajax_new/Issue3981IT.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation.
+ * Copyright (c) 1997, 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.faces.test.javaee8.ajax_new;
+
+import ee.jakarta.tck.faces.test.util.selenium.BaseITNG;
+import ee.jakarta.tck.faces.test.util.selenium.WebPage;
+import jakarta.faces.component.html.HtmlOutputText;
+import org.jboss.arquillian.junit.Arquillian;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+
+import java.time.Duration;
+
+import static org.junit.Assert.assertTrue;
+
+@RunWith(Arquillian.class)
+public class Issue3981IT extends BaseITNG {
+
+    /**
+     * @see HtmlOutputText#setEscape(boolean)
+     * @see https://github.com/eclipse-ee4j/mojarra/issues/3985
+     */
+    @Test
+    public void testIssue3981() throws Exception {
+        WebPage page = getPage("issue3981.xhtml");
+        assertTrue(page.findElement(By.id("form:result")).getText().trim().isEmpty());
+
+        WebElement button = page.findElement(By.id("form:button"));
+        button.click();
+        page.waitReqJs(Duration.ofMillis(6000));
+
+        assertTrue(page.findElement(By.id("form:result")).getText().trim().equals("Success!"));
+    }
+
+}

--- a/tck/faces23/ajax/src/test/java/ee/jakarta/tck/faces/test/javaee8/ajax_new/Issue4115IT.java
+++ b/tck/faces23/ajax/src/test/java/ee/jakarta/tck/faces/test/javaee8/ajax_new/Issue4115IT.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation.
+ * Copyright (c) 1997, 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.faces.test.javaee8.ajax_new;
+
+import ee.jakarta.tck.faces.test.util.selenium.BaseITNG;
+import ee.jakarta.tck.faces.test.util.selenium.ExtendedTextInput;
+import ee.jakarta.tck.faces.test.util.selenium.WebPage;
+import jakarta.faces.component.behavior.AjaxBehavior;
+import org.junit.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+
+import java.time.Duration;
+
+import static org.junit.Assert.assertTrue;
+
+public class Issue4115IT extends BaseITNG {
+
+    /**
+     * @see AjaxBehavior#getExecute()
+     * @see https://github.com/eclipse-ee4j/mojarra/issues/4119
+     */
+    @Test
+    public void testSpec1412() throws Exception {
+
+        WebPage page = getPage("issue4115.xhtml");
+        page.waitForPageToLoad();
+        assertTrue(page.findElement(By.id("form:output")).getText().isEmpty());
+
+        ExtendedTextInput input = new ExtendedTextInput(getWebDriver(), page.findElement(By.id("form:input")));
+        input.setValue("execute");
+        WebElement link =  page.findElement(By.id("form:link"));
+        link.click();
+        page.waitReqJs(Duration.ofMillis(60000));
+        assertTrue(page.findElement(By.id("form:output")).getText().trim().equals("executeParamValue"));
+    }
+}

--- a/tck/faces23/ajax/src/test/java/ee/jakarta/tck/faces/test/javaee8/ajax_new/Spec1412IT.java
+++ b/tck/faces23/ajax/src/test/java/ee/jakarta/tck/faces/test/javaee8/ajax_new/Spec1412IT.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation.
+ * Copyright (c) 1997, 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.faces.test.javaee8.ajax_new;
+
+import ee.jakarta.tck.faces.test.util.selenium.BaseITNG;
+import ee.jakarta.tck.faces.test.util.selenium.WebPage;
+import jakarta.faces.context.PartialViewContext;
+import org.junit.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+
+import java.time.Duration;
+
+import static org.junit.Assert.assertTrue;
+
+public class Spec1412IT extends BaseITNG {
+
+    /**
+     * @see PartialViewContext#getEvalScripts()
+     * @see https://github.com/jakartaee/faces/issues/1412
+     */
+    @Test
+    public void testSpec1412() throws Exception {
+
+        WebPage page = getPage("spec1412.xhtml");
+        page.waitForPageToLoad();
+        assertTrue(page.isNotInPage("Success!"));
+
+        WebElement button = page.findElement(By.id("form:button"));
+
+        assertTrue(button.getAttribute("value").equals("foo"));
+
+        button.click();
+        page.waitReqJs(Duration.ofMillis(60000));
+        assertTrue(page.isInPage("Success!"));
+
+        button =  page.findElement(By.id("form:button"));
+        assertTrue(button.getAttribute("value").equals("bar"));
+    }
+
+}

--- a/tck/faces23/ajax/src/test/java/ee/jakarta/tck/faces/test/javaee8/ajax_new/Spec1423IT.java
+++ b/tck/faces23/ajax/src/test/java/ee/jakarta/tck/faces/test/javaee8/ajax_new/Spec1423IT.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation.
+ * Copyright (c) 1997, 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.faces.test.javaee8.ajax_new;
+
+import ee.jakarta.tck.faces.test.util.selenium.BaseITNG;
+import ee.jakarta.tck.faces.test.util.selenium.WebPage;
+import jakarta.faces.component.UIViewRoot;
+import org.junit.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+
+import java.time.Duration;
+
+import static org.junit.Assert.assertTrue;
+
+public class Spec1423IT extends BaseITNG {
+
+    /**
+     * @see UIViewRoot#addComponentResource(jakarta.faces.context.FacesContext, jakarta.faces.component.UIComponent, String)
+     * @see https://github.com/jakartaee/faces/issues/1423
+     */
+    @Test
+    public void testSpec1423Basic() throws Exception {
+        WebPage page = getPage("spec1423.xhtml");
+        WebElement button;
+
+        assertTrue(page.findElement(By.id("scriptResult")).getText().isEmpty());
+        assertTrue(page.findElement(By.id("stylesheetResult")).getText().isEmpty());
+
+        button =  page.findElement(By.id("form1:addViaHead"));
+        button.click();
+        page.waitReqJs(Duration.ofMillis(60000));
+        assertTrue(page.findElement(By.id("scriptResult")).getText().trim().equals("addedViaHead"));
+        assertTrue(page.findElement(By.id("stylesheetResult")).getText().isEmpty());
+    }
+
+    @Test
+    public void testSpec1423() throws Exception {
+        WebPage page = getPage("spec1423.xhtml");
+        WebElement button;
+
+        assertTrue(page.findElement(By.id("scriptResult")).getText().isEmpty());
+        assertTrue(page.findElement(By.id("stylesheetResult")).getText().isEmpty());
+
+        button =  page.findElement(By.id("form1:addViaHead"));
+        button.click();
+        page.waitReqJs(Duration.ofMillis(6000));
+        assertTrue(page.findElement(By.id("scriptResult")).getText().trim().equals("addedViaHead"));
+        assertTrue(page.findElement(By.id("stylesheetResult")).getText().isEmpty());
+
+        button =  page.findElement(By.id("form2:addViaInclude"));
+        button.click();
+        page.waitReqJs(Duration.ofMillis(6000));
+
+        assertTrue(page.findElement(By.id("scriptResult")).getText().trim().equals("addedViaInclude"));
+        assertTrue(page.findElement(By.id("stylesheetResult")).getText().trim().equals("rgb(255, 0, 0)"));
+
+        button =  page.findElement(By.id("form1:addViaBody"));
+        button.click();
+        page.waitReqJs(Duration.ofMillis(6000));
+        assertTrue(page.findElement(By.id("scriptResult")).getText().trim().equals("addedViaBody"));
+        assertTrue(page.findElement(By.id("stylesheetResult")).getText().trim().equals("rgb(255, 0, 0)"));
+
+        button =  page.findElement(By.id("form2:addViaInclude"));
+        button.click();
+        page.waitReqJs(Duration.ofMillis(6000));
+        assertTrue(page.findElement(By.id("scriptResult")).getText().trim().equals("addedViaBody"));
+        assertTrue(page.findElement(By.id("stylesheetResult")).getText().trim().equals("rgb(255, 0, 0)"));
+
+        button =  page.findElement(By.id("form1:addProgrammatically"));
+        button.click();
+        page.waitReqJs(Duration.ofMillis(6000));
+        assertTrue(page.findElement(By.id("scriptResult")).getText().trim().equals("addedProgrammatically"));
+        assertTrue(page.findElement(By.id("stylesheetResult")).getText().trim().equals("rgb(0, 255, 0)"));
+
+        button =  page.findElement(By.id("form1:addViaHead"));
+        button.click();
+        page.waitReqJs(Duration.ofMillis(6000));
+        assertTrue(page.findElement(By.id("scriptResult")).getText().trim().equals("addedProgrammatically"));
+        assertTrue(page.findElement(By.id("stylesheetResult")).getText().trim().equals("rgb(0, 255, 0)"));
+
+        button =  page.findElement(By.id("form1:addViaBody"));
+        button.click();
+        page.waitReqJs(Duration.ofMillis(6000));
+        assertTrue(page.findElement(By.id("scriptResult")).getText().trim().equals("addedProgrammatically"));
+        assertTrue(page.findElement(By.id("stylesheetResult")).getText().trim().equals("rgb(0, 255, 0)"));
+
+        button =  page.findElement(By.id("form2:addViaInclude"));
+        button.click();
+        page.waitReqJs(Duration.ofMillis(6000));
+        assertTrue(page.findElement(By.id("scriptResult")).getText().trim().equals("addedProgrammatically"));
+        assertTrue(page.findElement(By.id("stylesheetResult")).getText().trim().equals("rgb(0, 255, 0)"));
+    }
+
+}

--- a/tck/faces23/ajax/src/test/java/ee/jakarta/tck/faces/test/javaee8/ajax_new/Spec790IT.java
+++ b/tck/faces23/ajax/src/test/java/ee/jakarta/tck/faces/test/javaee8/ajax_new/Spec790IT.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) 1997, 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.faces.test.javaee8.ajax_new;
+
+import ee.jakarta.tck.faces.test.util.selenium.BaseITNG;
+import ee.jakarta.tck.faces.test.util.selenium.ExtendedTextInput;
+import ee.jakarta.tck.faces.test.util.selenium.WebPage;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+import static org.junit.Assert.assertTrue;
+
+import java.time.Duration;
+import org.junit.Test;
+import jakarta.faces.application.NavigationHandler;
+import jakarta.faces.application.StateManager;
+
+
+public class Spec790IT extends BaseITNG {
+
+
+
+    /**
+     * @see StateManager#getViewState(jakarta.faces.context.FacesContext)
+     * @see https://github.com/jakartaee/faces/issues/790
+     */
+    @Test
+    public void testSpec790() throws Exception {
+
+        WebPage page = getPage("spec790.xhtml");
+        WebElement form1 = page.findElement(By.id("form1"));
+        ExtendedTextInput form1ViewState = new ExtendedTextInput( getWebDriver(), form1.findElement(By.name("jakarta.faces.ViewState")));
+        WebElement form2 = page.findElement(By.id("form2"));
+        ExtendedTextInput form2ViewState =  new ExtendedTextInput( getWebDriver(), form2.findElement(By.name("jakarta.faces.ViewState")));
+        WebElement form3 =  page.findElement(By.id("form3"));
+        ExtendedTextInput form3ViewState = form2ViewState =  new ExtendedTextInput( getWebDriver(), form3.findElement(By.name("jakarta.faces.ViewState")));
+        assertTrue(!form1ViewState.getValue().isEmpty());
+        assertTrue(!form2ViewState.getValue().isEmpty());
+        assertTrue(!form3ViewState.getValue().isEmpty());
+
+        WebElement form1Button = page.findElement(By.id("form1:button"));
+        form1Button.click();
+        page.waitReqJs(Duration.ofMillis(6000));
+        form1 =  page.findElement(By.id("form1"));
+        form1ViewState = new ExtendedTextInput( getWebDriver(), form1.findElement(By.name("jakarta.faces.ViewState")));
+        form2 =  page.findElement(By.id("form2"));
+        form2ViewState = new ExtendedTextInput( getWebDriver(), form2.findElement(By.name("jakarta.faces.ViewState")));
+        form3 =  page.findElement(By.id("form3"));
+        form3ViewState = new ExtendedTextInput( getWebDriver(), form3.findElement(By.name("jakarta.faces.ViewState")));
+        assertTrue(!form1ViewState.getValue().isEmpty());
+        assertTrue(!form2ViewState.getValue().isEmpty());
+        assertTrue(!form3ViewState.getValue().isEmpty());
+
+        WebElement form2Link =  page.findElement(By.id("form2:link"));
+        form2Link.click();
+        page.waitReqJs(Duration.ofMillis(60000));
+        form1 =  page.findElement(By.id("form1"));
+        form1ViewState = new ExtendedTextInput( getWebDriver(), form1.findElement(By.name("jakarta.faces.ViewState")));
+        form2 =  page.findElement(By.id("form2"));
+        form2ViewState = new ExtendedTextInput( getWebDriver(),form2.findElement(By.name("jakarta.faces.ViewState")));
+        form3 =  page.findElement(By.id("form3"));
+        form3ViewState = new ExtendedTextInput( getWebDriver(),form3.findElement(By.name("jakarta.faces.ViewState")));
+        assertTrue(!form1ViewState.getValue().isEmpty());
+        assertTrue(!form2ViewState.getValue().isEmpty());
+        assertTrue(!form3ViewState.getValue().isEmpty());
+
+        WebElement form3Link =  page.findElement(By.id("form3:link"));
+        form3Link.click();
+        page.waitForCurrentRequestEnd();
+        Thread.sleep(60000);
+        form1 =  page.findElement(By.id("form1"));
+        form1ViewState = new ExtendedTextInput( getWebDriver(), form1.findElement(By.name("jakarta.faces.ViewState")));
+        form2 =  page.findElement(By.id("form2"));
+        form2ViewState = new ExtendedTextInput( getWebDriver(), form2.findElement(By.name("jakarta.faces.ViewState")));
+        form3 =  page.findElement(By.id("form3"));
+        form3ViewState = new ExtendedTextInput( getWebDriver(), form3.findElement(By.name("jakarta.faces.ViewState")));
+        assertTrue(!form1ViewState.getValue().isEmpty());
+        assertTrue(!form2ViewState.getValue().isEmpty());
+        assertTrue(!form3ViewState.getValue().isEmpty());
+    }
+
+    /**
+     * @see NavigationHandler#handleNavigation(jakarta.faces.context.FacesContext, String, String, String)
+     * @see StateManager#getViewState(jakarta.faces.context.FacesContext)
+     * @see https://github.com/jakartaee/faces/issues/790
+     */
+    @Test
+    public void testSpec790AjaxNavigation() throws Exception {
+        
+
+        WebPage page = getPage("spec790AjaxNavigation.xhtml");
+        WebElement form =  page.findElement(By.id("form"));
+        ExtendedTextInput formViewState = new ExtendedTextInput( getWebDriver(), form.findElement(By.name("jakarta.faces.ViewState")));
+        assertTrue(!formViewState.getValue().isEmpty());
+
+        WebElement button = page.findElement(By.id("form:button"));
+        button.click();
+        page.waitReqJs(Duration.ofMillis(60000));
+        WebElement form1 =  page.findElement(By.id("form1"));
+        ExtendedTextInput form1ViewState = new ExtendedTextInput( getWebDriver(), form1.findElement(By.name("jakarta.faces.ViewState")));
+        WebElement form2 =  page.findElement(By.id("form2"));
+        ExtendedTextInput form2ViewState = new ExtendedTextInput( getWebDriver(), form2.findElement(By.name("jakarta.faces.ViewState")));
+        assertTrue(!form1ViewState.getValue().isEmpty());
+        assertTrue(!form2ViewState.getValue().isEmpty());
+    }
+
+
+
+}

--- a/tck/faces40/ajax/src/test/java/ee/jakarta/tck/faces/test/servlet50/ajax_new/Issue5032IT.java
+++ b/tck/faces40/ajax/src/test/java/ee/jakarta/tck/faces/test/servlet50/ajax_new/Issue5032IT.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.faces.test.servlet50.ajax_new;
+
+import ee.jakarta.tck.faces.test.util.selenium.BaseITNG;
+import ee.jakarta.tck.faces.test.util.selenium.ExtendedTextInput;
+import ee.jakarta.tck.faces.test.util.selenium.WebPage;
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.component.behavior.AjaxBehavior;
+import org.junit.Test;
+import org.openqa.selenium.By;
+
+import static org.junit.Assert.assertEquals;
+
+
+public class Issue5032IT extends BaseITNG {
+
+    /**
+     * @see AjaxBehavior#getExecute()
+     * @see UIComponent#getCompositeComponentParent(UIComponent)
+     * @see https://github.com/eclipse-ee4j/mojarra/issues/5032
+     */
+    @Test
+    public void testImplicitThis() throws Exception {
+        WebPage page = getPage("issue5032IT.xhtml");
+
+        ExtendedTextInput form1input2 = new ExtendedTextInput( getWebDriver(), page.findElement(By.id("form1:inputs:input2")));
+        assertEquals("f:ajax execute of form1:input2 is implied as @this", "mojarra.ab(this,event,'valueChange',0,'@form')", form1input2.getAttribute("onchange"));
+
+        form1input2.setValue("1");
+        form1input2.fireEvent("change");
+        page.waitReqJs();
+        String form1messages = page.findElement(By.id("form1:messages")).getText();
+        assertEquals("there are no validation messages coming from required field form1:input1", "", form1messages);
+    }
+
+    /**
+     * @see AjaxBehavior#getExecute()
+     * @see UIComponent#getCompositeComponentParent(UIComponent)
+     * @see https://github.com/eclipse-ee4j/mojarra/issues/5032
+     */
+    @Test
+    public void testExplicitThis() throws Exception {
+        WebPage page = getPage("issue5032IT.xhtml");
+
+        ExtendedTextInput form2input2 = new ExtendedTextInput( getWebDriver(), page.findElement(By.id("form2:inputs:input2")));
+        assertEquals("f:ajax execute of form2:input2 is still @this", "mojarra.ab(this,event,'valueChange','@this','@form')", form2input2.getAttribute("onchange"));
+
+        form2input2.setValue("1");
+        form2input2.fireEvent("change");
+        page.waitReqJs();
+        String form2messages = page.findElement(By.id("form2:messages")).getText();
+        assertEquals("there are no validation messages coming from required field form2:input1", "", form2messages);
+    }
+
+}

--- a/tck/faces40/ajax/src/test/java/ee/jakarta/tck/faces/test/servlet50/ajax_new/Spec1567IT.java
+++ b/tck/faces40/ajax/src/test/java/ee/jakarta/tck/faces/test/servlet50/ajax_new/Spec1567IT.java
@@ -1,0 +1,185 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.faces.test.servlet50.ajax_new;
+
+import ee.jakarta.tck.faces.test.util.selenium.BaseITNG;
+import ee.jakarta.tck.faces.test.util.selenium.ExtendedTextInput;
+import ee.jakarta.tck.faces.test.util.selenium.WebPage;
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.component.behavior.AjaxBehavior;
+import org.junit.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+
+import static org.junit.Assert.assertEquals;
+
+public class Spec1567IT extends BaseITNG {
+
+
+    /**
+     * @see AjaxBehavior#getExecute()
+     * @see UIComponent#getCompositeComponentParent(UIComponent)
+     * @see https://github.com/jakartaee/faces/issues/1567
+     */
+    @Test
+    public void test() throws Exception {
+        WebPage page = getPage("spec1567IT.xhtml");
+
+        validateRenderedMarkup(page, "form1", "form1:messages");
+        validateRenderedMarkup(page, "form2", "form2:messages");
+        validateRenderedMarkup(page,"form3", "form3:inputs form3:messages");
+
+        // fill form1 input1
+        ExtendedTextInput input1 = new ExtendedTextInput(getWebDriver(), page.findElement(By.id("form1:inputs:input1")));
+        input1.setValue("1");
+        input1.fireEvent("change");
+        Thread.sleep(3000);
+        input1 = new ExtendedTextInput(getWebDriver(), page.findElement(By.id("form1:inputs:input1")));
+        ExtendedTextInput input2 = new ExtendedTextInput(getWebDriver(), page.findElement(By.id("form1:inputs:input2")));
+        ExtendedTextInput input3 = new ExtendedTextInput(getWebDriver(), page.findElement(By.id("form1:inputs:input3")));
+        String messages = page.findElement(By.id("form1:messages")).getText();
+        assertEquals("input1 is filled with 1", "1", input1.getValue());
+        assertEquals("input2 is empty", "", input2.getValue());
+        assertEquals("input3 is empty", "", input3.getValue());
+        assertEquals("input1 is filled and input2 is empty", "setForm1input1:1\nsetForm1input2:", messages);
+
+        // fill form1 input2
+        input2 = new ExtendedTextInput(getWebDriver(), page.findElement(By.id("form1:inputs:input2")));
+        input2.setValue("1");
+        input2.fireEvent("change");
+        page.waitReqJs();
+        input1 = new ExtendedTextInput(getWebDriver(), page.findElement(By.id("form1:inputs:input1")));
+        input2 = new ExtendedTextInput(getWebDriver(), page.findElement(By.id("form1:inputs:input2")));
+        input3 = new ExtendedTextInput(getWebDriver(), page.findElement(By.id("form1:inputs:input3")));
+        messages = page.findElement(By.id("form1:messages")).getText();
+        assertEquals("input1 is filled with 1", "1", input1.getValue());
+        assertEquals("input2 is filled with 1", "1", input2.getValue());
+        assertEquals("input3 is empty", "", input3.getValue());
+        assertEquals("input1 is filled and input2 is filled", "setForm1input1:1\nsetForm1input2:1", messages);
+
+        // fill form1 input3
+        input3 = new ExtendedTextInput(getWebDriver(), page.findElement(By.id("form1:inputs:input3")));
+        input3.setValue("1");
+        input3.fireEvent("change");
+        page.waitReqJs();
+        input1 = new ExtendedTextInput(getWebDriver(), page.findElement(By.id("form1:inputs:input1")));
+        input2 = new ExtendedTextInput(getWebDriver(), page.findElement(By.id("form1:inputs:input2")));
+        input3 = new ExtendedTextInput(getWebDriver(), page.findElement(By.id("form1:inputs:input3")));
+        messages = page.findElement(By.id("form1:messages")).getText();
+        assertEquals("input1 is refreshed to empty string", "", input1.getValue());
+        assertEquals("input2 is refreshed to empty string", "", input2.getValue());
+        assertEquals("input3 is filled and refreshed", "1x", input3.getValue());
+        assertEquals("input3 is filled", "setForm1input3:1", messages);
+
+        // fill form2 input1
+        input1 = new ExtendedTextInput(getWebDriver(), page.findElement(By.id("form2:inputs:input1")));
+        input1.setValue("1");
+        input1.fireEvent("change");
+        Thread.sleep(3000);
+        input1 = new ExtendedTextInput(getWebDriver(), page.findElement(By.id("form2:inputs:input1")));
+        input2 = new ExtendedTextInput(getWebDriver(), page.findElement(By.id("form2:inputs:input2")));
+        input3 = new ExtendedTextInput(getWebDriver(), page.findElement(By.id("form2:inputs:input3")));
+        messages = page.findElement(By.id("form2:messages")).getText();
+        assertEquals("input1 is filled with 1", "1", input1.getValue());
+        assertEquals("input2 is empty", "", input2.getValue());
+        assertEquals("input3 is empty", "", input3.getValue());
+        assertEquals("input1 is filled and input2 is empty", "setForm2input1:1\nsetForm2input2:", messages);
+
+        // fill form2 input2
+        input2 = new ExtendedTextInput(getWebDriver(), page.findElement(By.id("form2:inputs:input2")));
+        input2.setValue("1");
+        input2.fireEvent("change");
+        Thread.sleep(3000);
+        input1 = new ExtendedTextInput(getWebDriver(), page.findElement(By.id("form2:inputs:input1")));
+        input2 = new ExtendedTextInput(getWebDriver(), page.findElement(By.id("form2:inputs:input2")));
+        input3 = new ExtendedTextInput(getWebDriver(), page.findElement(By.id("form2:inputs:input3")));
+        messages = page.findElement(By.id("form2:messages")).getText();
+        assertEquals("input1 is filled with 1", "1", input1.getValue());
+        assertEquals("input2 is filled with 1", "1", input2.getValue());
+        assertEquals("input3 is empty", "", input3.getValue());
+        assertEquals("input1 is filled and input2 is filled", "setForm2input1:1\nsetForm2input2:1", messages);
+
+        // fill form2 input3
+        input3 = new ExtendedTextInput(getWebDriver(), page.findElement(By.id("form2:inputs:input3")));
+        input3.setValue("1");
+        input3.fireEvent("change");
+        Thread.sleep(3000);
+        input1 = new ExtendedTextInput(getWebDriver(), page.findElement(By.id("form2:inputs:input1")));
+        input2 = new ExtendedTextInput(getWebDriver(), page.findElement(By.id("form2:inputs:input2")));
+        input3 = new ExtendedTextInput(getWebDriver(), page.findElement(By.id("form2:inputs:input3")));
+        messages = page.findElement(By.id("form2:messages")).getText();
+        assertEquals("input1 is refreshed to empty string", "", input1.getValue());
+        assertEquals("input2 is refreshed to empty string", "", input2.getValue());
+        assertEquals("input3 is filled and refreshed", "1x", input3.getValue());
+        assertEquals("input3 is filled", "setForm2input3:1", messages);
+
+        // fill form3 input1
+        input1 = new ExtendedTextInput(getWebDriver(), page.findElement(By.id("form3:inputs:input1")));
+        input1.setValue("1");
+        input1.fireEvent("change");
+        Thread.sleep(3000);
+        input1 = new ExtendedTextInput(getWebDriver(), page.findElement(By.id("form3:inputs:input1")));
+        input2 = new ExtendedTextInput(getWebDriver(), page.findElement(By.id("form3:inputs:input2")));
+        input3 = new ExtendedTextInput(getWebDriver(), page.findElement(By.id("form3:inputs:input3")));
+        messages = page.findElement(By.id("form3:messages")).getText();
+        assertEquals("input1 is refreshed to 1x", "1x", input1.getValue());
+        assertEquals("input2 is refreshed to x", "x", input2.getValue());
+        assertEquals("input3 is empty", "", input3.getValue());
+        assertEquals("input1 is filled and input2 is empty", "setForm3input1:1\nsetForm3input2:", messages);
+
+        // fill form3 input2
+        input2 = new ExtendedTextInput(getWebDriver(), page.findElement(By.id("form3:inputs:input2")));
+        input2.setValue("1");
+        input2.fireEvent("change");
+        Thread.sleep(3000);
+        input1 = new ExtendedTextInput(getWebDriver(), page.findElement(By.id("form3:inputs:input1")));
+        input2 = new ExtendedTextInput(getWebDriver(), page.findElement(By.id("form3:inputs:input2")));
+        input3 = new ExtendedTextInput(getWebDriver(), page.findElement(By.id("form3:inputs:input3")));
+        messages = page.findElement(By.id("form3:messages")).getText();
+        assertEquals("input1 is refreshed to 1xx", "1xx", input1.getValue());
+        assertEquals("input2 is refreshed to 1x", "1x", input2.getValue());
+        assertEquals("input3 is empty", "", input3.getValue());
+        assertEquals("input1 is filled and input2 is filled", "setForm3input1:1x\nsetForm3input2:1", messages);
+
+        // fill form3 input3
+        input3 = new ExtendedTextInput(getWebDriver(), page.findElement(By.id("form3:inputs:input3")));
+        input3.setValue("1");
+        input3.fireEvent("change");
+        Thread.sleep(3000);
+        input1 = new ExtendedTextInput(getWebDriver(), page.findElement(By.id("form3:inputs:input1")));
+        input2 = new ExtendedTextInput(getWebDriver(), page.findElement(By.id("form3:inputs:input2")));
+        input3 = new ExtendedTextInput(getWebDriver(), page.findElement(By.id("form3:inputs:input3")));
+        messages = page.findElement(By.id("form3:messages")).getText();
+        assertEquals("input1 is refreshed to empty string", "", input1.getValue());
+        assertEquals("input2 is refreshed to empty string", "", input2.getValue());
+        assertEquals("input3 is filled and refreshed", "1x", input3.getValue());
+        assertEquals("input3 is filled", "setForm3input3:1", messages);
+    }
+
+    private void validateRenderedMarkup(WebPage page, String formId, String render) {
+
+        WebElement input1 = page.findElement(By.id(formId + ":inputs:input1"));
+        assertEquals("input1 and input2 are implied as @this", "mojarra.ab(this,event,'change','" + formId + ":inputs:input1 " + formId + ":inputs:input2','" + render + "')", input1.getAttribute("onchange"));
+
+        WebElement input2 = page.findElement(By.id(formId + ":inputs:input2"));
+        assertEquals("input1 and input2 are implied as @this", "mojarra.ab(this,event,'change','" + formId + ":inputs:input1 " + formId + ":inputs:input2','" + render + "')", input2.getAttribute("onchange"));
+
+        WebElement input3 = page.findElement(By.id(formId + ":inputs:input3"));
+        assertEquals("input3 has still its own f:ajax", "mojarra.ab(this,event,'valueChange',0,'@form')", input3.getAttribute("onchange"));
+    }
+
+}

--- a/tck/util/pom.xml
+++ b/tck/util/pom.xml
@@ -42,6 +42,22 @@
             <artifactId>arquillian-junit-container</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.seleniumhq.selenium</groupId>
+            <artifactId>selenium-java</artifactId>
+            <version>4.6.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.seleniumhq.selenium</groupId>
+            <artifactId>selenium-chrome-driver</artifactId>
+            <version>4.6.0</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.github.bonigarcia</groupId>
+            <artifactId>webdrivermanager</artifactId>
+            <version>5.3.1</version>
+        </dependency>
+        <dependency>
             <groupId>org.jboss.shrinkwrap.resolver</groupId>
             <artifactId>shrinkwrap-resolver-impl-maven</artifactId>
         </dependency>

--- a/tck/util/src/main/java/ee/jakarta/tck/faces/test/util/selenium/BaseITNG.java
+++ b/tck/util/src/main/java/ee/jakarta/tck/faces/test/util/selenium/BaseITNG.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package ee.jakarta.tck.faces.test.util.selenium;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.importer.ZipImporter;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.runner.RunWith;
+
+import java.io.File;
+import java.net.URL;
+
+import static java.lang.System.getProperty;
+import static org.jboss.shrinkwrap.api.ShrinkWrap.create;
+
+/**
+ * Base class for tests,
+ * which provides a certain infrastructure
+ * can be used, but does not have to be
+ */
+@RunWith(Arquillian.class)
+public class BaseITNG {
+
+    @ArquillianResource
+    protected URL webUrl;
+
+    private ExtendedWebDriver webDriver;
+
+    static DriverPool driverPool = new DriverPool();
+
+    @Deployment(testable = false)
+    public static WebArchive createDeployment() {
+        return create(ZipImporter.class, getProperty("finalName") + ".war")
+                .importFrom(new File("target/" + getProperty("finalName") + ".war"))
+                .as(WebArchive.class);
+    }
+
+
+    @Before
+    public void setUp() {
+        webDriver = driverPool.getOrNewInstance();
+    }
+
+
+    @After
+    public void tearDown() {
+        driverPool.returnInstance(webDriver);
+    }
+
+    @AfterClass
+    public static void afterAll() {
+        driverPool.quitAll();
+    }
+
+
+    protected WebPage getPage(String page) {
+        webDriver.get(webUrl.toString() + page);
+        WebPage webPage = new WebPage(webDriver);
+        webPage.waitForPageToLoad();
+        return webPage;
+    }
+
+    public ExtendedWebDriver getWebDriver() {
+        return webDriver;
+    }
+}

--- a/tck/util/src/main/java/ee/jakarta/tck/faces/test/util/selenium/ChromeDevtoolsDriver.java
+++ b/tck/util/src/main/java/ee/jakarta/tck/faces/test/util/selenium/ChromeDevtoolsDriver.java
@@ -1,0 +1,487 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package ee.jakarta.tck.faces.test.util.selenium;
+
+import io.github.bonigarcia.wdm.WebDriverManager;
+import org.apache.commons.io.output.NullOutputStream;
+import org.openqa.selenium.*;
+import org.openqa.selenium.chrome.ChromeDriver;
+import org.openqa.selenium.chrome.ChromeDriverLogLevel;
+import org.openqa.selenium.chrome.ChromeDriverService;
+import org.openqa.selenium.chrome.ChromeOptions;
+import org.openqa.selenium.chromium.ChromiumNetworkConditions;
+import org.openqa.selenium.devtools.DevTools;
+import org.openqa.selenium.devtools.v105.network.Network;
+import org.openqa.selenium.devtools.v105.network.model.Request;
+import org.openqa.selenium.devtools.v105.network.model.RequestId;
+import org.openqa.selenium.devtools.v105.network.model.ResponseReceived;
+import org.openqa.selenium.devtools.v105.network.model.TimeSinceEpoch;
+import org.openqa.selenium.html5.LocalStorage;
+import org.openqa.selenium.html5.Location;
+import org.openqa.selenium.html5.SessionStorage;
+import org.openqa.selenium.interactions.Sequence;
+import org.openqa.selenium.logging.EventType;
+import org.openqa.selenium.mobile.NetworkConnection;
+import org.openqa.selenium.print.PrintOptions;
+import org.openqa.selenium.remote.*;
+import org.openqa.selenium.virtualauthenticator.VirtualAuthenticator;
+import org.openqa.selenium.virtualauthenticator.VirtualAuthenticatorOptions;
+
+import java.net.URI;
+import java.util.NoSuchElementException;
+import java.util.*;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.function.BiFunction;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
+import java.util.logging.Level;
+
+/**
+ * Extended driver which we need for getting
+ * the http response code
+ * and the http response
+ * without having to revert to proxy solutions
+ * <p>
+ * We need access top the response body and response
+ * code from always the last access
+ * <p>
+ * We use the chrome dev tools to access the data but we isolate
+ * the new functionality in an interface, so other drivers must apply something different
+ * to get the results
+ *
+ * @see also https://medium.com/codex/selenium4-a-peek-into-chrome-devtools-92bca6de55e0
+ */
+
+class HttpCycleData {
+    public RequestId requestId;
+    public Request request;
+    public ResponseReceived responseReceived;
+}
+
+@SuppressWarnings("unused")
+public class ChromeDevtoolsDriver implements ExtendedWebDriver {
+
+    ChromeDriver delegate;
+
+    List<HttpCycleData> cycleData = new CopyOnWriteArrayList<>();
+
+    String lastGet;
+
+    public ChromeDevtoolsDriver(ChromeOptions options) {
+        ChromeDriverService chromeDriverService = new ChromeDriverService.Builder().build();
+        chromeDriverService.sendOutputTo(NullOutputStream.NULL_OUTPUT_STREAM);
+        delegate = new ChromeDriver(chromeDriverService, options);
+    }
+
+    /**
+     * initializes the extended functionality
+     */
+    public void postInit() {
+        DevTools devTools = getDevTools();
+        //we store always the last request for further reference
+        initNetworkListeners(devTools);
+        initDevTools(devTools);
+    }
+
+    private static void initDevTools(DevTools devTools) {
+        devTools.createSession();
+        devTools.send(Network.clearBrowserCache());
+        devTools.send(Network.enable(Optional.empty(), Optional.empty(), Optional.empty()));
+    }
+
+    private void initNetworkListeners(DevTools devTools) {
+        devTools.addListener(Network.requestWillBeSent(),
+                entry -> {
+                    // the jsf ajax only targets itself
+                    // that way we can filter out resource requests early
+                    if (!entry.getRequest().getUrl().contains(lastGet)) {
+                        return;
+                    }
+                    HttpCycleData data = new HttpCycleData();
+                    data.requestId = entry.getRequestId();
+                    data.request = entry.getRequest();
+                    cycleData.add(data);
+                });
+        devTools.addListener(Network.responseReceived(), entry -> {
+            RequestId requestId = entry.getRequestId();
+            //only in case of a match we add response to request
+            //so we only cover our ajax cycle and the original get
+            Optional<HttpCycleData> found = cycleData.stream().filter(item -> item.requestId.toJson().equals(requestId.toJson())).findFirst();
+            found.ifPresent(httpCycleData -> httpCycleData.responseReceived = entry);
+        });
+    }
+
+    public Capabilities getCapabilities() {
+        return delegate.getCapabilities();
+    }
+
+    public void setFileDetector(FileDetector detector) {
+        delegate.setFileDetector(detector);
+    }
+
+    public <X> void onLogEvent(EventType<X> kind) {
+        delegate.onLogEvent(kind);
+    }
+
+    public void register(Predicate<URI> whenThisMatches, Supplier<Credentials> useTheseCredentials) {
+        delegate.register(whenThisMatches, useTheseCredentials);
+    }
+
+    public LocalStorage getLocalStorage() {
+        return delegate.getLocalStorage();
+    }
+
+    public SessionStorage getSessionStorage() {
+        return delegate.getSessionStorage();
+    }
+
+    public Location location() {
+        return delegate.location();
+    }
+
+    public void setLocation(Location location) {
+        delegate.setLocation(location);
+    }
+
+    public NetworkConnection.ConnectionType getNetworkConnection() {
+        return delegate.getNetworkConnection();
+    }
+
+    public NetworkConnection.ConnectionType setNetworkConnection(NetworkConnection.ConnectionType type) {
+        return delegate.setNetworkConnection(type);
+    }
+
+    public void launchApp(String id) {
+        delegate.launchApp(id);
+    }
+
+    public Map<String, Object> executeCdpCommand(String commandName, Map<String, Object> parameters) {
+        return delegate.executeCdpCommand(commandName, parameters);
+    }
+
+    public Optional<DevTools> maybeGetDevTools() {
+        return delegate.maybeGetDevTools();
+    }
+
+    public List<Map<String, String>> getCastSinks() {
+        return delegate.getCastSinks();
+    }
+
+    public String getCastIssueMessage() {
+        return delegate.getCastIssueMessage();
+    }
+
+    public void selectCastSink(String deviceName) {
+        delegate.selectCastSink(deviceName);
+    }
+
+    public void startDesktopMirroring(String deviceName) {
+        delegate.startDesktopMirroring(deviceName);
+    }
+
+    public void startTabMirroring(String deviceName) {
+        delegate.startTabMirroring(deviceName);
+    }
+
+    public void stopCasting(String deviceName) {
+        delegate.stopCasting(deviceName);
+    }
+
+    public void setPermission(String name, String value) {
+        delegate.setPermission(name, value);
+    }
+
+    public ChromiumNetworkConditions getNetworkConditions() {
+        return delegate.getNetworkConditions();
+    }
+
+    public void setNetworkConditions(ChromiumNetworkConditions networkConditions) {
+        delegate.setNetworkConditions(networkConditions);
+    }
+
+    public void deleteNetworkConditions() {
+        delegate.deleteNetworkConditions();
+    }
+
+
+    public SessionId getSessionId() {
+        return delegate.getSessionId();
+    }
+
+    public ErrorHandler getErrorHandler() {
+        return delegate.getErrorHandler();
+    }
+
+    public void setErrorHandler(ErrorHandler handler) {
+        delegate.setErrorHandler(handler);
+    }
+
+    public CommandExecutor getCommandExecutor() {
+        return delegate.getCommandExecutor();
+    }
+
+    public void get(String url) {
+        lastGet = url;
+        delegate.get(url);
+    }
+
+    public String getTitle() {
+        return delegate.getTitle();
+    }
+
+    public String getCurrentUrl() {
+        return delegate.getCurrentUrl();
+    }
+
+    public <X> X getScreenshotAs(OutputType<X> outputType) throws WebDriverException {
+        return delegate.getScreenshotAs(outputType);
+    }
+
+    public Pdf print(PrintOptions printOptions) throws WebDriverException {
+        return delegate.print(printOptions);
+    }
+
+    public WebElement findElement(By locator) {
+        return delegate.findElement(locator);
+    }
+
+    public List<WebElement> findElements(By locator) {
+        return delegate.findElements(locator);
+    }
+
+    public List<WebElement> findElements(SearchContext context, BiFunction<String, Object, CommandPayload> findCommand, By locator) {
+        return delegate.findElements(context, findCommand, locator);
+    }
+
+    public String getPageSource() {
+        return delegate.getPageSource();
+    }
+
+    public String getPageText() {
+        String head = delegate.findElement(By.tagName("head")).getAttribute("innerText").replaceAll("[\\s\\n ]", " ");
+        String body = delegate.findElement(By.tagName("body")).getAttribute("innerText").replaceAll("[\\s\\n ]", " ");
+        return head + " " + body;
+    }
+
+    public String getPageTextReduced() {
+        String head = delegate.findElement(By.tagName("head")).getAttribute("innerText");
+        String body = delegate.findElement(By.tagName("body")).getAttribute("innerText");
+        return (head + " " + body).replaceAll("[\\s\\n ]+", " ");
+    }
+
+    /**
+     * resets the current tab and gives it a clean slate
+     * that way we do not have to build up the entire tab again
+     */
+    public void reset() {
+        DevTools devTools = delegate.getDevTools();
+        devTools.clearListeners();
+        devTools.send(Network.clearBrowserCookies()); // just to be sure w clear out all cookies
+        devTools.disconnectSession(); //This kills off the existing session
+
+        cycleData.clear();
+        lastGet = null;
+    }
+
+    /**
+     * closes the current tab for good, this has been problematic
+     * when the last or only tab was closes for recycling
+     * apparently we run into dev tools timeouts then
+     * hence reset now is the preferred way to recycle tabs instead
+     * of using close
+     */
+    public void close() {
+        reset();
+        delegate.close();
+    }
+
+    /**
+     * quits the driver entirely
+     */
+    public void quit() {
+        delegate.quit();
+    }
+
+    public Set<String> getWindowHandles() {
+        return delegate.getWindowHandles();
+    }
+
+    public String getWindowHandle() {
+        return delegate.getWindowHandle();
+    }
+
+    public Object executeScript(String script, Object... args) {
+        return delegate.executeScript(script, args);
+    }
+
+    public Object executeAsyncScript(String script, Object... args) {
+        return delegate.executeAsyncScript(script, args);
+    }
+
+    public WebDriver.TargetLocator switchTo() {
+        return delegate.switchTo();
+    }
+
+    public WebDriver.Navigation navigate() {
+        return delegate.navigate();
+    }
+
+    public WebDriver.Options manage() {
+        return delegate.manage();
+    }
+
+    public void setLogLevel(Level level) {
+        delegate.setLogLevel(level);
+    }
+
+    public void perform(Collection<Sequence> actions) {
+        delegate.perform(actions);
+    }
+
+    public void resetInputState() {
+        delegate.resetInputState();
+    }
+
+    public VirtualAuthenticator addVirtualAuthenticator(VirtualAuthenticatorOptions options) {
+        return delegate.addVirtualAuthenticator(options);
+    }
+
+    public void removeVirtualAuthenticator(VirtualAuthenticator authenticator) {
+        delegate.removeVirtualAuthenticator(authenticator);
+    }
+
+    public FileDetector getFileDetector() {
+        return delegate.getFileDetector();
+    }
+
+    public ScriptKey pin(String script) {
+        return delegate.pin(script);
+    }
+
+    public void unpin(ScriptKey key) {
+        delegate.unpin(key);
+    }
+
+    public Set<ScriptKey> getPinnedScripts() {
+        return delegate.getPinnedScripts();
+    }
+
+    public Object executeScript(ScriptKey key, Object... args) {
+        return delegate.executeScript(key, args);
+    }
+
+    public void register(Supplier<Credentials> alwaysUseTheseCredentials) {
+        delegate.register(alwaysUseTheseCredentials);
+    }
+
+    public DevTools getDevTools() {
+        return delegate.getDevTools();
+    }
+
+
+    @Override
+    public int getResponseStatus() {
+        try {
+            HttpCycleData data = getLastGetData();
+            if (data == null) {
+                return -1;
+            }
+            if (data.responseReceived == null) {
+                return -1;
+            }
+            return data.responseReceived.getResponse().getStatus();
+        } catch (NoSuchElementException ex) {
+            return -1;
+        }
+    }
+
+    @Override
+    public String getResponseBody() {
+        HttpCycleData data = getLastGetData();
+        return delegate.getDevTools().send(Network.getResponseBody(data.requestId)).getBody();
+    }
+
+    private HttpCycleData getLastGetData() {
+        sortResponses();
+
+        return cycleData.stream().filter(item -> item.request.getUrl().contains(lastGet))
+                // missing last api
+                .reduce((item1, item2) -> item2).orElse(null);
+    }
+
+    private void sortResponses() {
+        //we sort by response timestamps, with items with no response being first
+        //last response always being the one at the bottom
+        cycleData.sort((o1, o2) -> {
+            if (o1.responseReceived == null) {
+                return -1;
+            }
+            if (o2.responseReceived == null) {
+                return 1;
+            }
+            return Long.compare(o1.responseReceived.getTimestamp().toJson().longValue(), o2.responseReceived.getTimestamp().toJson().longValue());
+        });
+    }
+
+    public void printProcessedResponses() {
+        sortResponses();
+
+        cycleData.stream().filter(item -> item.responseReceived != null)
+                // missing last api
+                .forEach(item -> {
+                    System.out.println("Url: " + item.request.getUrl());
+                    System.out.println("RequestId: " + item.requestId.toJson());
+                    Optional<TimeSinceEpoch> responseTime = item.responseReceived.getResponse().getResponseTime();
+                    System.out.println("ResponseTime: " + responseTime.orElse(new TimeSinceEpoch(-1)));
+                    System.out.println("ResponseStatus: " + item.responseReceived.getResponse().getStatus());
+                });
+    }
+
+    public ChromeDriver getDelegate() {
+        return delegate;
+    }
+
+    @Override
+    public JavascriptExecutor getJSExecutor() {
+        return delegate;
+    }
+
+
+    public static ExtendedWebDriver stdInit() {
+        Locale.setDefault(new Locale("en", "US"));
+        WebDriverManager.chromedriver().setup();
+
+        ChromeOptions options = new ChromeOptions();
+        options.addArguments("--headless");
+        options.addArguments("--disable-web-security");
+        options.addArguments("--allow-insecure-localhost");
+        options.addArguments("--ignore-urlfetcher-cert-requests");
+        options.addArguments("--disable-gpu");
+        Map<String, Object> prefs = new HashMap<>();
+        prefs.put("intl.accept_languages", "en");
+        options.setExperimentalOption("prefs", prefs);
+        options.addArguments("--lang=en");
+
+        options.setLogLevel(ChromeDriverLogLevel.OFF);
+
+        ExtendedWebDriver driver = new ChromeDevtoolsDriver(options);
+        driver.manage().timeouts().implicitlyWait(WebPage.STD_TIMEOUT);
+        driver.manage().timeouts().pageLoadTimeout(WebPage.STD_TIMEOUT);
+        driver.manage().timeouts().scriptTimeout(WebPage.STD_TIMEOUT);
+        return driver;
+    }
+
+}

--- a/tck/util/src/main/java/ee/jakarta/tck/faces/test/util/selenium/DriverPool.java
+++ b/tck/util/src/main/java/ee/jakarta/tck/faces/test/util/selenium/DriverPool.java
@@ -1,0 +1,70 @@
+package ee.jakarta.tck.faces.test.util.selenium;
+
+import java.util.concurrent.ConcurrentLinkedQueue;
+
+/**
+ * a helper class providing pool management for our drivers
+ * Note, the pool itself is thread safe (and must be), the drivers are not!
+ */
+@SuppressWarnings("unused")
+public class DriverPool {
+
+    ConcurrentLinkedQueue<ExtendedWebDriver> allDrivers = new ConcurrentLinkedQueue<>();
+    ConcurrentLinkedQueue<ExtendedWebDriver> availableDrivers = new ConcurrentLinkedQueue<>();
+
+
+    /**
+     * creates or activates a new driver instance
+     * @return a new or recycled driver instance
+     */
+    public ExtendedWebDriver getOrNewInstance() {
+        ExtendedWebDriver webDriver = (availableDrivers.size() > 0) ? availableDrivers.remove() : null;
+        if(webDriver == null) {
+            webDriver = ChromeDevtoolsDriver.stdInit();
+            allDrivers.add(webDriver);
+        }
+
+        webDriver.postInit();
+        return webDriver;
+    }
+
+    /**
+     * resets a driver and keeps it in the pool for recycling
+     * @param driver
+     */
+    public void returnInstance(ExtendedWebDriver driver) {
+        driver.reset();
+        availableDrivers.add(driver);
+    }
+
+    /**
+     * closes a driver but keeps it in the pool
+     * @param driver
+     */
+    public void returnAndCloseInstance(ExtendedWebDriver driver) {
+        driver.close();
+        availableDrivers.add(driver);
+    }
+
+    /**
+     * quits a driver and removes it from the pool
+     * @param driver
+     */
+    public void quitInstance(ExtendedWebDriver driver) {
+        driver.quit();
+        allDrivers.remove(driver);
+    }
+
+    public void removeInstance(ExtendedWebDriver driver) {
+        allDrivers.remove(driver);
+    }
+
+    /**
+     * cleans up the pool
+     */
+    public void quitAll() {
+        allDrivers.stream().forEach(webDriver -> webDriver.quit());
+        allDrivers.clear();
+        availableDrivers.clear();
+    }
+}

--- a/tck/util/src/main/java/ee/jakarta/tck/faces/test/util/selenium/ExtendedTextInput.java
+++ b/tck/util/src/main/java/ee/jakarta/tck/faces/test/util/selenium/ExtendedTextInput.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package ee.jakarta.tck.faces.test.util.selenium;
+
+import org.openqa.selenium.*;
+
+import java.util.List;
+
+/**
+ * Helper to provide a set value and get value functionality
+ * on top of Selenium functionality. Something Selenium has omitted functionality wise
+ * (similar to what Select as Utils class does)
+ */
+public class ExtendedTextInput implements WebElement {
+    WebElement delegate;
+    ExtendedWebDriver webDriver;
+
+    public ExtendedTextInput(ExtendedWebDriver webDriver, WebElement delegate) {
+        this.delegate = delegate;
+        this.webDriver = webDriver;
+    }
+
+    public void setValue(String value) {
+        webDriver.getJSExecutor().executeScript("arguments[0].value='"+value+"'", delegate);
+    }
+
+    public void fireEvent(String eventName) {
+        webDriver.getJSExecutor().executeScript("var __evt__ =  new Event('"+eventName+"', {bubbles: true});" +
+                "arguments[0].dispatchEvent(__evt__)", delegate);
+    }
+
+    public String getValue() {
+        return delegate.getAttribute("value");
+    }
+
+    public void click() {
+        delegate.click();
+    }
+
+    public void submit() {
+        delegate.submit();
+    }
+
+    public void sendKeys(CharSequence... keysToSend) {
+        delegate.sendKeys(keysToSend);
+    }
+
+    public void clear() {
+        delegate.clear();
+    }
+
+    public String getTagName() {
+        return delegate.getTagName();
+    }
+
+    public String getDomProperty(String name) {
+        return delegate.getDomProperty(name);
+    }
+
+    public String getDomAttribute(String name) {
+        return delegate.getDomAttribute(name);
+    }
+
+    public String getAttribute(String name) {
+        return delegate.getAttribute(name);
+    }
+
+    public String getAriaRole() {
+        return delegate.getAriaRole();
+    }
+
+    public String getAccessibleName() {
+        return delegate.getAccessibleName();
+    }
+
+    public boolean isSelected() {
+        return delegate.isSelected();
+    }
+
+    public boolean isEnabled() {
+        return delegate.isEnabled();
+    }
+
+    public String getText() {
+        return delegate.getText();
+    }
+
+    public List<WebElement> findElements(By by) {
+        return delegate.findElements(by);
+    }
+
+    public WebElement findElement(By by) {
+        return delegate.findElement(by);
+    }
+
+    public SearchContext getShadowRoot() {
+        return delegate.getShadowRoot();
+    }
+
+    public boolean isDisplayed() {
+        return delegate.isDisplayed();
+    }
+
+    public Point getLocation() {
+        return delegate.getLocation();
+    }
+
+    public Dimension getSize() {
+        return delegate.getSize();
+    }
+
+    public Rectangle getRect() {
+        return delegate.getRect();
+    }
+
+    public String getCssValue(String propertyName) {
+        return delegate.getCssValue(propertyName);
+    }
+
+    public <X> X getScreenshotAs(OutputType<X> target) throws WebDriverException {
+        return delegate.getScreenshotAs(target);
+    }
+}

--- a/tck/util/src/main/java/ee/jakarta/tck/faces/test/util/selenium/ExtendedWebDriver.java
+++ b/tck/util/src/main/java/ee/jakarta/tck/faces/test/util/selenium/ExtendedWebDriver.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package ee.jakarta.tck.faces.test.util.selenium;
+
+import org.openqa.selenium.JavascriptExecutor;
+import org.openqa.selenium.WebDriver;
+
+/**
+ * an extended web driver interface which takes the response into consideration
+ * selenium does not have an official api but several webdrivers
+ * allow access to the data via various means
+ *
+ * Another possibility would have been a proxy, but I could not find any properly
+ * working proxy for selenium
+ */
+public interface ExtendedWebDriver extends WebDriver {
+
+    /**
+     * gets the response status of the last response (of the last triggered request against get)
+     * @return
+     */
+    int getResponseStatus();
+
+    /**
+     * gets the last response as body
+     * @return
+     */
+    String getResponseBody();
+
+    /**
+     * postinit call for tests
+     */
+    void postInit();
+
+    /**
+     * gets the internal webdriver delegate
+     * @return
+     */
+    WebDriver getDelegate();
+
+    /**
+     * returns a reference to the Selenium JS Executor of this webdriver
+     * @return
+     */
+    JavascriptExecutor getJSExecutor();
+
+    /**
+     * @return the innerText of the Page
+     */
+    String getPageText();
+
+    /**
+     * returns the innerText of the page in a blank reduced state (more than one blank is reduced to one
+     * invisible blanks like nbsp are replaced by normal blanks)
+     * @return
+     */
+    String getPageTextReduced();
+
+    /**
+     * debugging helper which allows to look into the processed response data
+     */
+    void printProcessedResponses();
+
+    /**
+     * quits the driver engine
+     */
+    void quit();
+
+    /**
+     * closes the current tab
+     */
+    void close();
+
+    /**
+     * resets the current page to its initial stage before the page load
+     * without dropping the engine or closing it
+     */
+    void reset();
+}

--- a/tck/util/src/main/java/ee/jakarta/tck/faces/test/util/selenium/WebPage.java
+++ b/tck/util/src/main/java/ee/jakarta/tck/faces/test/util/selenium/WebPage.java
@@ -1,0 +1,348 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package ee.jakarta.tck.faces.test.util.selenium;
+
+import org.openqa.selenium.*;
+import org.openqa.selenium.support.ui.ExpectedCondition;
+import org.openqa.selenium.support.ui.ExpectedConditions;
+import org.openqa.selenium.support.ui.WebDriverWait;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Function;
+
+/**
+ * Mimics the html unit webpage
+ */
+public class WebPage {
+
+    public static final Duration STD_TIMEOUT = Duration.ofMillis(3000);
+
+    protected ExtendedWebDriver webDriver;
+
+    public WebPage(ExtendedWebDriver webDriver) {
+        this.webDriver = webDriver;
+    }
+
+    public ExtendedWebDriver getWebDriver() {
+        return webDriver;
+    }
+
+    public void setWebDriver(ExtendedWebDriver webDriver) {
+        this.webDriver = webDriver;
+    }
+
+    /**
+     * implemented helper to wait for the background javascript
+     *
+     * @param timeout the standard timeout to wait in case the condition is not executed
+     */
+    public void waitForBackgroundJavascript(Duration timeout) {
+        WebDriverWait wait = new WebDriverWait(webDriver, timeout);
+        double rand = Math.random();
+        @SuppressWarnings("UnnecessaryLabelJS")
+        final String identifier = "__insert__:" + rand;
+        webDriver.manage().timeouts().scriptTimeout(timeout);
+        //We use a trick here, javascript  is cooperative multitasking
+        //so we defer into a time when the script is executed
+        //and then check for the new element
+        webDriver.getJSExecutor().executeAsyncScript("let [resolve] = arguments; setTimeout(function() { var insert__ = document.createElement('div');" +
+                "insert__.id = '" + identifier + "';" +
+                "insert__.innerHTML = 'done';" +
+                "document.body.append(insert__); resolve()}, 0);");
+        wait.until(ExpectedConditions.numberOfElementsToBeMoreThan(By.id(identifier), 0));
+        webDriver.getJSExecutor().executeScript("document.body.removeChild(document.getElementById('" + identifier + "'));");
+    }
+
+    /**
+     * waits for a certain condition is met until a timeout is hit
+     * in case of exceeding the condition a runtime Exception is thrown
+     * @param isTrue the condition lambda to check
+     * @param timeout timeout duration
+     */
+    public <V> void waitForCondition(Function<? super WebDriver, V> isTrue, Duration timeout) {
+        WebDriverWait wait = new WebDriverWait(webDriver, timeout);
+        wait.until(isTrue);
+    }
+
+    /**
+     * waits until no more running requests are present
+     * in case of exceeding our STD_TIMEOUT, a runtime exception is thrown
+     */
+    public void waitForCurrentRequestEnd() {
+        waitForCondition(webDriver1 -> webDriver.getResponseStatus() != -1, STD_TIMEOUT);
+    }
+
+    /**
+     * wait until the current ajax request targeting the same page
+     * has stopped and then tests for blocking running scripts
+     * still running.
+     * A small initial delay cannot hurt either
+     */
+    public void waitReqJs() {
+        this.waitReqJs(STD_TIMEOUT);
+    }
+
+    /**
+     * same as before but with a decdicated timeout
+     * @param timeout the timeout duration after that the wait is cancelled
+     *                and an exceotion is thrown
+     */
+    public void waitReqJs(Duration timeout) {
+        try {
+            Thread.sleep(100);
+            waitForCurrentRequestEnd();
+            waitForBackgroundJavascript(timeout);
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * waits for backgrounds processes on the browser to complete
+     *
+     * @param timeOut the timeout duration until the wait can proceed before being interupopted
+     */
+    public void waitForPageToLoad(Duration timeOut) {
+        ExpectedCondition<Boolean> expectation = new ExpectedCondition<>() {
+            public Boolean apply(WebDriver driver) {
+                return webDriver.getJSExecutor().executeScript("return document.readyState").equals("complete");
+            }
+        };
+        try {
+            WebDriverWait wait = new WebDriverWait(webDriver, timeOut);
+            wait.until(expectation);
+        } catch (Throwable error) {
+            error.printStackTrace();
+            throw new RuntimeException(error);
+        }
+    }
+
+    /**
+     * wait until the page load is finished
+     */
+    public void waitForPageToLoad() {
+        waitForPageToLoad(STD_TIMEOUT);
+    }
+
+    /**
+     * conditional waiter and checker which checks whether the page text is present
+     * we add our own waiter internally, because pageSource always delivers
+     * @param text to check
+     * @return true in case of found false in case of found after our standard timeout is reached
+     */
+    public boolean isInPageText(String text) {
+        try {
+            waitForCondition(webDriver1 -> webDriver.getPageText().contains(text), STD_TIMEOUT);
+            return true;
+        } catch (TimeoutException ex) {
+            //timeout is wanted in this case and should result in a false
+            return false;
+        }
+    }
+
+    public boolean isInPageTextReduced(String text) {
+        try {
+            waitForCondition(webDriver1 -> webDriver.getPageTextReduced().contains(text), STD_TIMEOUT);
+            return true;
+        } catch (TimeoutException ex) {
+            //timeout is wanted in this case and should result in a false
+            return false;
+        }
+    }
+
+    public boolean matchesPageText(String regexp) {
+        try {
+            waitForCondition(webDriver1 -> webDriver.getPageText().matches(regexp), STD_TIMEOUT);
+            return true;
+        } catch (TimeoutException ex) {
+            //timeout is wanted in this case and should result in a false
+            return false;
+        }
+    }
+    /**
+     * conditional waiter and checker which checks whether a text is not in the page
+     * we add our own waiter internally, because pageSource always delivers
+     * @param text to check
+     * @return true in case of found false in case of found after our standard timeout is reached
+     */
+    public boolean isNotInPageText(String text) {
+        try {
+            waitForCondition(webDriver1 -> !webDriver.getPageText().contains(text), STD_TIMEOUT);
+            return true;
+        } catch (TimeoutException ex) {
+            //timeout is wanted in this case and should result in a false
+            return false;
+        }
+    }
+
+    /**
+     * conditional waiter and checker which checks whether a text is  in the page
+     * we add our own waiter internally, because pageSource always delivers
+     * this version of isInPage checks explicitly the full markup not only the text
+     * @param text to check
+     * @return true in case of found false in case of found after our standard timeout is reached
+     */
+    public boolean isInPage(String text) {
+        try {
+            waitForCondition(webDriver1 -> webDriver.getPageSource().contains(text), STD_TIMEOUT);
+            return true;
+        } catch (TimeoutException ex) {
+            //timeout is wanted in this case and should result in a false
+            return false;
+        }
+    }
+    /**
+     * conditional waiter and checker which checks whether a text is not in the page
+     * we add our own waiter internally, because pageSource always delivers
+     * we need to add two different condition checkers herte because
+     * a timeout automatically throws internally an error which is mapped to false
+     * We therefore cannot simply wait for the condition either being met or timeout
+     * with one method
+     * @param text to check
+     * @return true in case of found false in case of found after our standard timeout is reached
+     */
+    public boolean isNotInPage(String text) {
+        try {
+            waitForCondition(webDriver1 -> !webDriver.getPageSource().contains(text), STD_TIMEOUT);
+            return true;
+        } catch (TimeoutException ex) {
+            //timeout is wanted in this case and should result in a false
+            return false;
+        }
+    }
+
+    /**
+     * conditional waiter and checker which checks whether a text is in the page
+     * we add our own waiter internally, because pageSource always delivers
+     * we need to add two different condition checkers herte because
+     * a timeout automatically throws internally an error which is mapped to false
+     * We therefore cannot simply wait for the condition either being met or timeout
+     * with one method
+     * @param text to check
+     * @return true in case of found false in case of found after our standard timeout is reached
+     */
+    public boolean isInPage(String text, boolean allowExceptions) {
+        try {
+            waitForCondition(webDriver1 -> webDriver.getPageSource().contains(text), STD_TIMEOUT);
+            return true;
+        } catch (TimeoutException exception) {
+            if(allowExceptions) {
+                throw exception;
+            }
+            exception.printStackTrace();
+            return false;
+        }
+    }
+
+    /**
+     * is condition reached or not reached after until a STD_TIMEOUT is reached
+     * if the timeout is exceeded the condition is not met
+     * @param isTrue the isTrue condition lambda
+     * @return true if it is met until STD_TIMEOUT, otherwise false
+     */
+    public <V> boolean isCondition(Function<? super WebDriver, V> isTrue) {
+        try {
+            waitForCondition(isTrue, STD_TIMEOUT);
+            return true;
+        } catch (TimeoutException ex) {
+            //timeout is wanted in this case and should result in a false
+            return false;
+        }
+    }
+
+    public WebElement findElement(By by) {
+        return webDriver.findElement(by);
+    }
+    public List<WebElement> findElements(By by) {
+        return webDriver.findElements(by);
+    }
+
+    public int getResponseStatus() {
+        return webDriver.getResponseStatus();
+    }
+
+    public String getResponseBody() {
+        return webDriver.getResponseBody();
+    }
+
+    public void postInit() {
+        webDriver.postInit();
+    }
+
+    public JavascriptExecutor getJSExecutor() {
+        return webDriver.getJSExecutor();
+    }
+
+    public void printProcessedResponses() {
+        webDriver.printProcessedResponses();
+    }
+
+    public void get(String url) {
+        webDriver.get(url);
+    }
+
+    public String getCurrentUrl() {
+        return webDriver.getCurrentUrl();
+    }
+
+    public String getTitle() {
+        return webDriver.getTitle();
+    }
+
+    public String getPageSource() {
+        return webDriver.getPageSource();
+    }
+
+    public void close() {
+        webDriver.close();
+    }
+
+    public void quit() {
+        webDriver.quit();
+    }
+
+    public Set<String> getWindowHandles() {
+        return webDriver.getWindowHandles();
+    }
+
+    public String getWindowHandle() {
+        return webDriver.getWindowHandle();
+    }
+
+    public WebDriver.TargetLocator switchTo() {
+        return webDriver.switchTo();
+    }
+
+    public WebDriver.Navigation navigate() {
+        return webDriver.navigate();
+    }
+
+    public WebDriver.Options manage() {
+        return webDriver.manage();
+    }
+
+    /**
+     * Convenience method to get all anchor elmements
+     * @return a list of a hrefs as WebElements
+     */
+    public List<WebElement> getAnchors() {
+        return webDriver.findElements(By.cssSelector("a[href]"));
+    }
+
+
+}


### PR DESCRIPTION
This pull request adds Selenium ported TCK Ajax tests with an added Chrome selenium web driver.
(Chrome must be installed on the system to run the tests). This configuration allows to test for ES6 and newer dom levels, where HTMLUnit fails due to not supporting newer specs.