### PR TITLE
Process additional feedback for challenge 1718

### DIFF
--- a/tck/old-tck/source/src/com/sun/ts/tests/jsf/api/jakarta_faces/application/application/TestServlet.java
+++ b/tck/old-tck/source/src/com/sun/ts/tests/jsf/api/jakarta_faces/application/application/TestServlet.java
@@ -1471,6 +1471,9 @@ public class TestServlet extends HttpTCKServlet {
       return;
     }
 
+    while (application instanceof jakarta.faces.application.ApplicationWrapper) {
+        application = ((jakarta.faces.application.ApplicationWrapper)application).getWrapped();
+    }
     ExpressionFactory exprFactory = application.getExpressionFactory();
 
     if (exprFactory == null) {
@@ -1498,10 +1501,10 @@ public class TestServlet extends HttpTCKServlet {
     // "getExpressionFactory() Returns ***: " +
     // controlFactoryTwo.toString());
 
-    if (!exprFactory.toString().equals(controlFactory.toString())) {
+    if (!controlFactory.equals(exprFactory)) {
       out.println(JSFTestUtil.FAIL + JSFTestUtil.NL
           + "Expected Application.getExpressionFactory to return "
-          + "the same type as that returned by "
+          + "the same instance as that returned by "
           + "ELManager.getExpressionFactory()!" + JSFTestUtil.NL
           + "ELManager.getExpressionFactory: " + controlFactory.toString() + JSFTestUtil.NL
           + "application.getExpressionFactory: " + exprFactory.toString());

--- a/tck/old-tck/source/src/com/sun/ts/tests/jsf/api/jakarta_faces/application/applicationwrapper/TestServlet.java
+++ b/tck/old-tck/source/src/com/sun/ts/tests/jsf/api/jakarta_faces/application/applicationwrapper/TestServlet.java
@@ -856,7 +856,7 @@ public class TestServlet extends HttpTCKServlet {
     // "getExpressionFactory() Returns ***: " +
     // controlFactoryTwo.toString());
 
-    if (!exprFactory.toString().equals(controlFactory.toString())) {
+    if (!controlFactory.equals(exprFactory)) {
       out.println(JSFTestUtil.FAIL + JSFTestUtil.NL
           + "Expected Application.getExpressionFactory to return "
           + "the same instance as that returned by"
@@ -1769,7 +1769,11 @@ public class TestServlet extends HttpTCKServlet {
     @Override
     public Application getWrapped() {
       context = FacesContext.getCurrentInstance();
-      return context.getApplication();
+      Application application = context.getApplication();
+      while (application instanceof jakarta.faces.application.ApplicationWrapper) {
+          application = ((jakarta.faces.application.ApplicationWrapper)application).getWrapped();
+      }
+      return application;
     }
 
   }

--- a/tck/old-tck/source/src/com/sun/ts/tests/jsf/spec/el/elresolvers/TestServlet.java
+++ b/tck/old-tck/source/src/com/sun/ts/tests/jsf/spec/el/elresolvers/TestServlet.java
@@ -49,7 +49,6 @@ import jakarta.servlet.ServletConfig;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import jakarta.servlet.jsp.PageContext;
 
 public final class TestServlet extends HttpTCKServlet {
 

--- a/tck/old-tck/source/src/com/sun/ts/tests/jsf/spec/el/managedbean/common/TestServlet.java
+++ b/tck/old-tck/source/src/com/sun/ts/tests/jsf/spec/el/managedbean/common/TestServlet.java
@@ -34,14 +34,11 @@ import com.sun.ts.tests.jsf.common.util.JSFTestUtil;
 import jakarta.faces.application.Application;
 import jakarta.faces.context.ExternalContext;
 import jakarta.faces.context.FacesContext;
-import jakarta.el.ELManager;
 import jakarta.el.ValueExpression;
 import jakarta.servlet.ServletConfig;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import jakarta.servlet.jsp.JspWriter;
-import jakarta.servlet.jsp.PageContext;
 
 public final class TestServlet extends HttpTCKServlet {
 


### PR DESCRIPTION
Remove unneeded imports, and unwrap application as implementations may provide wrapped applications to support things like CDI.

Signed-off-by: Arjan Tijms <arjan.tijms@gmail.com>