### PR TITLE
Create a session to avoid NPE reported in PR 1738

### DIFF
--- a/tck/old-tck/source/src/com/sun/ts/tests/jsf/spec/el/elresolvers/TestServlet.java
+++ b/tck/old-tck/source/src/com/sun/ts/tests/jsf/spec/el/elresolvers/TestServlet.java
@@ -598,6 +598,9 @@ public final class TestServlet extends HttpTCKServlet {
     ELResolver[] resolvers = getELResolvers(elContexts);
     boolean passed = true;
 
+    // Force session creation for 'session' implict object
+    request.getSession(true);
+
     for (int i = 0; i < resolvers.length; i++) {
 
       out.println("Testing phase: " + getTestPhase(i));


### PR DESCRIPTION
NPE introduced in 1738. See discussion here: https://github.com/jakartaee/faces/pull/1738#issuecomment-1334688764 

Open Liberty encounters an NPE as no session exists in this test yet. The session implicit object therefore returns null. 

```
Caused by: java.lang.NullPointerException: 
at com.sun.ts.tests.jsf.spec.el.elresolvers.TestServlet.validateImplicitObjectValue(TestServlet.java:1566)
at com.sun.ts.tests.jsf.spec.el.elresolvers.TestServlet.facesImplicitObjectResolverGetValueTest(TestServlet.java:615)
at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
```

Or should the session only be created for the session implicit part of test, and then deleted afterwards?  Previously, the session was created within the `getELContexts` method ( by the JspFactory.getDefaultFactory().getPageContext() call) 