### PR TITLE
Update faces22/multiFieldValidation's FACELETS_BUFFER_SIZE to 4096

### DIFF
--- a/tck/faces22/multiFieldValidation/src/main/webapp/WEB-INF/web.xml
+++ b/tck/faces22/multiFieldValidation/src/main/webapp/WEB-INF/web.xml
@@ -50,4 +50,8 @@
     <welcome-file-list>
         <welcome-file>faces/index.xhtml</welcome-file>
     </welcome-file-list>
+    <context-param>
+        <param-name>jakarta.faces.FACELETS_BUFFER_SIZE</param-name>
+        <param-value>4096</param-value>
+    </context-param>
 </web-app>


### PR DESCRIPTION
Same issue as reported in challenge #1716, but for `faces22/multiFieldValidation`. The response is committed before the exception and we fail to send a 500 response. 

See my follow comment here: https://github.com/jakartaee/faces/issues/1716#issuecomment-1386411059