### PR TITLE
Don't skip tests when test.selenium=true

### DIFF
--- a/tck/faces22/compositeComponent/src/test/java/ee/jakarta/tck/faces/test/servlet30/compositeComponent/Issue5065IT.java
+++ b/tck/faces22/compositeComponent/src/test/java/ee/jakarta/tck/faces/test/servlet30/compositeComponent/Issue5065IT.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023 Contributors to Eclipse Foundation.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -18,7 +19,9 @@ package ee.jakarta.tck.faces.test.servlet30.compositeComponent;
 
 import static org.junit.Assert.assertEquals;
 
+import org.jboss.arquillian.junit.Arquillian;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 
 import com.gargoylesoftware.htmlunit.html.HtmlPage;
 import com.gargoylesoftware.htmlunit.html.HtmlSubmitInput;
@@ -26,6 +29,7 @@ import com.gargoylesoftware.htmlunit.html.HtmlSubmitInput;
 import ee.jakarta.tck.faces.test.util.arquillian.ITBase;
 import jakarta.faces.component.UIViewRoot;
 
+@RunWith(Arquillian.class)
 public class Issue5065IT extends ITBase {
 
     /**

--- a/tck/faces23/disableFaceletToXhtmlMapping/src/test/java/ee/jakarta/tck/faces/test/javaee8/disablefacelettoxhtmlmapping/DisableFaceletToXhtmlIT.java
+++ b/tck/faces23/disableFaceletToXhtmlMapping/src/test/java/ee/jakarta/tck/faces/test/javaee8/disablefacelettoxhtmlmapping/DisableFaceletToXhtmlIT.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023 Contributors to Eclipse Foundation.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -18,12 +19,15 @@ package ee.jakarta.tck.faces.test.javaee8.disablefacelettoxhtmlmapping;
 
 import static org.junit.Assert.assertTrue;
 
+import org.jboss.arquillian.junit.Arquillian;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 
 import com.gargoylesoftware.htmlunit.html.HtmlPage;
 
 import ee.jakarta.tck.faces.test.util.arquillian.ITBase;
 
+@RunWith(Arquillian.class)
 public class DisableFaceletToXhtmlIT extends ITBase {
     
     @Test

--- a/tck/faces23/facelets/src/test/java/ee/jakarta/tck/faces/test/servlet40/facelets/Spec1102IT.java
+++ b/tck/faces23/facelets/src/test/java/ee/jakarta/tck/faces/test/servlet40/facelets/Spec1102IT.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023 Contributors to Eclipse Foundation.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -18,12 +19,15 @@ package ee.jakarta.tck.faces.test.servlet40.facelets;
 
 import static org.junit.Assert.assertTrue;
 
+import org.jboss.arquillian.junit.Arquillian;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 
 import com.gargoylesoftware.htmlunit.html.HtmlPage;
 
 import ee.jakarta.tck.faces.test.util.arquillian.ITBase;
 
+@RunWith(Arquillian.class)
 public class Spec1102IT extends ITBase {
 
     /**

--- a/tck/faces23/facesDataModel/src/test/java/ee/jakarta/tck/faces/test/javaee8/facelets/DataTableCustomDataModelIT.java
+++ b/tck/faces23/facesDataModel/src/test/java/ee/jakarta/tck/faces/test/javaee8/facelets/DataTableCustomDataModelIT.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023 Contributors to Eclipse Foundation.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -19,7 +20,9 @@ package ee.jakarta.tck.faces.test.javaee8.facelets;
 import static java.util.regex.Pattern.matches;
 import static org.junit.Assert.assertTrue;
 
+import org.jboss.arquillian.junit.Arquillian;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 
 import com.gargoylesoftware.htmlunit.html.HtmlPage;
 
@@ -27,6 +30,7 @@ import ee.jakarta.tck.faces.test.util.arquillian.ITBase;
 import jakarta.faces.component.html.HtmlDataTable;
 import jakarta.faces.model.FacesDataModel;
 
+@RunWith(Arquillian.class)
 public class DataTableCustomDataModelIT extends ITBase {
 
     /**

--- a/tck/faces23/facesDataModel/src/test/java/ee/jakarta/tck/faces/test/javaee8/facelets/UIRepeatCustomDataModelIT.java
+++ b/tck/faces23/facesDataModel/src/test/java/ee/jakarta/tck/faces/test/javaee8/facelets/UIRepeatCustomDataModelIT.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023 Contributors to Eclipse Foundation.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -19,13 +20,16 @@ package ee.jakarta.tck.faces.test.javaee8.facelets;
 import static java.util.regex.Pattern.matches;
 import static org.junit.Assert.assertTrue;
 
+import org.jboss.arquillian.junit.Arquillian;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 
 import com.gargoylesoftware.htmlunit.html.HtmlPage;
 
 import ee.jakarta.tck.faces.test.util.arquillian.ITBase;
 import jakarta.faces.model.FacesDataModel;
 
+@RunWith(Arquillian.class)
 public class UIRepeatCustomDataModelIT extends ITBase {
 
     /**

--- a/tck/faces23/flash/src/test/java/ee/jakarta/tck/faces/test/javaee8/flash/Issue4167IT.java
+++ b/tck/faces23/flash/src/test/java/ee/jakarta/tck/faces/test/javaee8/flash/Issue4167IT.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023 Contributors to Eclipse Foundation.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -18,7 +19,9 @@ package ee.jakarta.tck.faces.test.javaee8.flash;
 
 import static org.junit.Assert.assertTrue;
 
+import org.jboss.arquillian.junit.Arquillian;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 
 import com.gargoylesoftware.htmlunit.html.HtmlPage;
 import com.gargoylesoftware.htmlunit.html.HtmlSubmitInput;
@@ -26,6 +29,7 @@ import com.gargoylesoftware.htmlunit.html.HtmlSubmitInput;
 import ee.jakarta.tck.faces.test.util.arquillian.ITBase;
 import jakarta.faces.context.Flash;
 
+@RunWith(Arquillian.class)
 public class Issue4167IT extends ITBase {
 
     /**

--- a/tck/faces23/importConstants/src/test/java/ee/jakarta/tck/faces/test/javaee8/importConstants/Spec1424IT.java
+++ b/tck/faces23/importConstants/src/test/java/ee/jakarta/tck/faces/test/javaee8/importConstants/Spec1424IT.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023 Contributors to Eclipse Foundation.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -18,13 +19,16 @@ package ee.jakarta.tck.faces.test.javaee8.importConstants;
 
 import static org.junit.Assert.assertTrue;
 
+import org.jboss.arquillian.junit.Arquillian;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 
 import com.gargoylesoftware.htmlunit.html.HtmlPage;
 
 import ee.jakarta.tck.faces.test.util.arquillian.ITBase;
 import jakarta.faces.component.UIImportConstants;
 
+@RunWith(Arquillian.class)
 public class Spec1424IT extends ITBase {
 
     /**

--- a/tck/faces23/refreshPeriodExplicit/src/test/java/ee/jakarta/tck/faces/test/servlet40/refreshperiodexplicit/Issue3787IT.java
+++ b/tck/faces23/refreshPeriodExplicit/src/test/java/ee/jakarta/tck/faces/test/servlet40/refreshperiodexplicit/Issue3787IT.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023 Contributors to Eclipse Foundation.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -18,7 +19,9 @@ package ee.jakarta.tck.faces.test.servlet40.refreshperiodexplicit;
 
 import static org.junit.Assert.assertTrue;
 
+import org.jboss.arquillian.junit.Arquillian;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 
 import com.gargoylesoftware.htmlunit.html.HtmlPage;
 
@@ -26,7 +29,8 @@ import ee.jakarta.tck.faces.test.util.arquillian.ITBase;
 import jakarta.faces.application.ProjectStage;
 import jakarta.faces.application.ViewHandler;
 
-public class Isuse3787IT extends ITBase {
+@RunWith(Arquillian.class)
+public class Issue3787IT extends ITBase {
 
     /**
      * @see ViewHandler#FACELETS_REFRESH_PERIOD_PARAM_NAME

--- a/tck/faces23/refreshPeriodProduction/src/test/java/ee/jakarta/tck/faces/test/servlet40/refreshperiodproduction/Issue3787IT.java
+++ b/tck/faces23/refreshPeriodProduction/src/test/java/ee/jakarta/tck/faces/test/servlet40/refreshperiodproduction/Issue3787IT.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023 Contributors to Eclipse Foundation.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -18,7 +19,9 @@ package ee.jakarta.tck.faces.test.servlet40.refreshperiodproduction;
 
 import static org.junit.Assert.assertTrue;
 
+import org.jboss.arquillian.junit.Arquillian;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 
 import com.gargoylesoftware.htmlunit.html.HtmlPage;
 
@@ -26,7 +29,8 @@ import ee.jakarta.tck.faces.test.util.arquillian.ITBase;
 import jakarta.faces.application.ProjectStage;
 import jakarta.faces.application.ViewHandler;
 
-public class Isuse3787IT extends ITBase  {
+@RunWith(Arquillian.class)
+public class Issue3787IT extends ITBase  {
 
     /**
      * @see ViewHandler#FACELETS_REFRESH_PERIOD_PARAM_NAME

--- a/tck/faces23/uiinput-required-true/src/test/java/ee/jakarta/tck/faces/test/javaee8/uiinput/Spec1433IT.java
+++ b/tck/faces23/uiinput-required-true/src/test/java/ee/jakarta/tck/faces/test/javaee8/uiinput/Spec1433IT.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023 Contributors to Eclipse Foundation.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -18,7 +19,9 @@ package ee.jakarta.tck.faces.test.javaee8.uiinput;
 
 import static org.junit.Assert.assertTrue;
 
+import org.jboss.arquillian.junit.Arquillian;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 
 import com.gargoylesoftware.htmlunit.html.HtmlPage;
 import com.gargoylesoftware.htmlunit.html.HtmlSubmitInput;
@@ -27,6 +30,7 @@ import com.gargoylesoftware.htmlunit.html.HtmlTextInput;
 import ee.jakarta.tck.faces.test.util.arquillian.ITBase;
 import jakarta.faces.component.UIInput;
 
+@RunWith(Arquillian.class)
 public class Spec1433IT extends ITBase {
 
     /**

--- a/tck/faces23/uiinput/src/test/java/ee/jakarta/tck/faces/test/javaee8/uiinput/Issue4330IT.java
+++ b/tck/faces23/uiinput/src/test/java/ee/jakarta/tck/faces/test/javaee8/uiinput/Issue4330IT.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023 Contributors to Eclipse Foundation.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -19,7 +20,9 @@ package ee.jakarta.tck.faces.test.javaee8.uiinput;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+import org.jboss.arquillian.junit.Arquillian;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 
 import com.gargoylesoftware.htmlunit.html.HtmlButtonInput;
 import com.gargoylesoftware.htmlunit.html.HtmlCheckBoxInput;
@@ -31,6 +34,7 @@ import ee.jakarta.tck.faces.test.util.arquillian.ITBase;
 import jakarta.faces.component.UISelectItem;
 import jakarta.faces.component.html.HtmlSelectManyCheckbox;
 
+@RunWith(Arquillian.class)
 public class Issue4330IT extends ITBase {
 
     /**

--- a/tck/faces23/uiinput/src/test/java/ee/jakarta/tck/faces/test/javaee8/uiinput/Issue4734IT.java
+++ b/tck/faces23/uiinput/src/test/java/ee/jakarta/tck/faces/test/javaee8/uiinput/Issue4734IT.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 1997, 2019 Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2020 Contributors to the Eclipse Foundation.
+ * Copyright (c) 2020, 2023 Contributors to the Eclipse Foundation.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -16,7 +16,9 @@
  */
 package ee.jakarta.tck.faces.test.javaee8.uiinput;
 
+import org.jboss.arquillian.junit.Arquillian;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 
 import com.gargoylesoftware.htmlunit.html.HtmlPage;
 import com.gargoylesoftware.htmlunit.html.HtmlSubmitInput;
@@ -25,6 +27,7 @@ import ee.jakarta.tck.faces.test.util.arquillian.ITBase;
 import jakarta.faces.component.UIViewParameter;
 import jakarta.faces.component.behavior.AjaxBehavior;
 
+@RunWith(Arquillian.class)
 public class Issue4734IT extends ITBase {
 
     /**

--- a/tck/faces23/uiinput/src/test/java/ee/jakarta/tck/faces/test/javaee8/uiinput/Issue5081IT.java
+++ b/tck/faces23/uiinput/src/test/java/ee/jakarta/tck/faces/test/javaee8/uiinput/Issue5081IT.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 1997, 2019 Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2022 Contributors to the Eclipse Foundation.
+ * Copyright (c) 2022, 2023 Contributors to the Eclipse Foundation.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -19,7 +19,9 @@ package ee.jakarta.tck.faces.test.javaee8.uiinput;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+import org.jboss.arquillian.junit.Arquillian;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 
 import com.gargoylesoftware.htmlunit.html.HtmlElement;
 import com.gargoylesoftware.htmlunit.html.HtmlPage;
@@ -31,6 +33,7 @@ import jakarta.faces.component.UIInput;
 import jakarta.faces.component.UISelectMany;
 import jakarta.faces.component.behavior.AjaxBehavior;
 
+@RunWith(Arquillian.class)
 public class Issue5081IT extends ITBase {
 
     /**

--- a/tck/faces23/uiinput/src/test/java/ee/jakarta/tck/faces/test/javaee8/uiinput/Spec1422IT.java
+++ b/tck/faces23/uiinput/src/test/java/ee/jakarta/tck/faces/test/javaee8/uiinput/Spec1422IT.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023 Contributors to Eclipse Foundation.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -20,7 +21,9 @@ import static org.junit.Assert.assertTrue;
 
 import java.util.Collection;
 
+import org.jboss.arquillian.junit.Arquillian;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 
 import com.gargoylesoftware.htmlunit.html.HtmlCheckBoxInput;
 import com.gargoylesoftware.htmlunit.html.HtmlPage;
@@ -31,6 +34,7 @@ import jakarta.faces.application.Application;
 import jakarta.faces.component.UISelectItems;
 import jakarta.faces.component.UISelectMany;
 
+@RunWith(Arquillian.class)
 public class Spec1422IT extends ITBase {
 
     /**

--- a/tck/faces23/uiinput/src/test/java/ee/jakarta/tck/faces/test/javaee8/uiinput/Spec329IT.java
+++ b/tck/faces23/uiinput/src/test/java/ee/jakarta/tck/faces/test/javaee8/uiinput/Spec329IT.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023 Contributors to Eclipse Foundation.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -19,7 +20,9 @@ package ee.jakarta.tck.faces.test.javaee8.uiinput;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+import org.jboss.arquillian.junit.Arquillian;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 
 import com.gargoylesoftware.htmlunit.html.HtmlPage;
 import com.gargoylesoftware.htmlunit.html.HtmlRadioButtonInput;
@@ -28,6 +31,7 @@ import com.gargoylesoftware.htmlunit.html.HtmlSubmitInput;
 import ee.jakarta.tck.faces.test.util.arquillian.ITBase;
 import jakarta.faces.component.html.HtmlSelectOneRadio;
 
+@RunWith(Arquillian.class)
 public class Spec329IT extends ITBase {
 
     /**

--- a/tck/faces23/uiinput/src/test/java/ee/jakarta/tck/faces/test/javaee8/uiinput/Spec671IT.java
+++ b/tck/faces23/uiinput/src/test/java/ee/jakarta/tck/faces/test/javaee8/uiinput/Spec671IT.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023 Contributors to Eclipse Foundation.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -18,7 +19,9 @@ package ee.jakarta.tck.faces.test.javaee8.uiinput;
 
 import static org.junit.Assert.assertTrue;
 
+import org.jboss.arquillian.junit.Arquillian;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 
 import com.gargoylesoftware.htmlunit.html.HtmlPage;
 import com.gargoylesoftware.htmlunit.html.HtmlSubmitInput;
@@ -27,6 +30,7 @@ import com.gargoylesoftware.htmlunit.html.HtmlTextInput;
 import ee.jakarta.tck.faces.test.util.arquillian.ITBase;
 import jakarta.faces.component.UIInput;
 
+@RunWith(Arquillian.class)
 public class Spec671IT extends ITBase {
 
     /**


### PR DESCRIPTION
Because of the changes to ITBase for Selenium support, a dozen or so tests were inadvertently being skipped when the `test.selenium` flag is set to true. This updates the affected test classes to override the inherited RunWith setting.