### PR TITLE
Port Failing Old TCK Tests to New TCK Framework (HTMLUnit & Selenium)

### DIFF
--- a/tck/faces22/ajax/src/test/java/ee/jakarta/tck/faces/test/servlet30/ajax_selenium/Deployments.java
+++ b/tck/faces22/ajax/src/test/java/ee/jakarta/tck/faces/test/servlet30/ajax_selenium/Deployments.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ * 
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GPL-2.0 with Classpath-exception-2.0 which 
+ * is available at https://openjdk.java.net/legal/gplv2+ce.html.
+ * 
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 or Apache-2.0
+ */
 package ee.jakarta.tck.faces.test.servlet30.ajax_selenium;
 
 import ee.jakarta.tck.faces.test.util.selenium.BaseITNG;

--- a/tck/faces23/ajax/src/test/java/ee/jakarta/tck/faces/test/javaee8/ajax_selenium/Deployments.java
+++ b/tck/faces23/ajax/src/test/java/ee/jakarta/tck/faces/test/javaee8/ajax_selenium/Deployments.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ * 
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GPL-2.0 with Classpath-exception-2.0 which 
+ * is available at https://openjdk.java.net/legal/gplv2+ce.html.
+ * 
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 or Apache-2.0
+ */
 package ee.jakarta.tck.faces.test.javaee8.ajax_selenium;
 
 import ee.jakarta.tck.faces.test.util.selenium.BaseITNG;

--- a/tck/faces23/namespacedView/src/test/java/ee/jakarta/tck/faces/test/javaee8/namespacedView_selenium/Deployments.java
+++ b/tck/faces23/namespacedView/src/test/java/ee/jakarta/tck/faces/test/javaee8/namespacedView_selenium/Deployments.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ * 
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GPL-2.0 with Classpath-exception-2.0 which 
+ * is available at https://openjdk.java.net/legal/gplv2+ce.html.
+ * 
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 or Apache-2.0
+ */
 package ee.jakarta.tck.faces.test.javaee8.namespacedView_selenium;
 
 import ee.jakarta.tck.faces.test.util.selenium.BaseITNG;

--- a/tck/faces40/ajax/src/test/java/ee/jakarta/tck/faces/test/servlet50/ajax_selenium/Deployments.java
+++ b/tck/faces40/ajax/src/test/java/ee/jakarta/tck/faces/test/servlet50/ajax_selenium/Deployments.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ * 
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GPL-2.0 with Classpath-exception-2.0 which 
+ * is available at https://openjdk.java.net/legal/gplv2+ce.html.
+ * 
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 or Apache-2.0
+ */
 package ee.jakarta.tck.faces.test.servlet50.ajax_selenium;
 
 import ee.jakarta.tck.faces.test.util.selenium.BaseITNG;

--- a/tck/old-tck-selenium/ajax/pom.xml
+++ b/tck/old-tck-selenium/ajax/pom.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2021 Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.eclipse.ee4j.tck.faces.old-tck-selenium</groupId>
+        <artifactId>pom</artifactId>
+        <version>4.0.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>ajax</artifactId>
+    <packaging>war</packaging>
+
+    <name>Jakarta Faces TCK ${project.version} - Test - Old TCK Port - Ajax</name>
+
+    <build>
+        <finalName>old-tck-ajax</finalName>
+    </build>
+</project>

--- a/tck/old-tck-selenium/ajax/pom.xml
+++ b/tck/old-tck-selenium/ajax/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2021 Contributors to Eclipse Foundation.
+    Copyright (c) 2023 Contributors to Eclipse Foundation.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/tck/old-tck-selenium/ajax/src/main/java/com/sun/ts/tests/jsf/spec/ajax/common/AjaxTagValuesBean.java
+++ b/tck/old-tck-selenium/ajax/src/main/java/com/sun/ts/tests/jsf/spec/ajax/common/AjaxTagValuesBean.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+/*
+ * $Id$
+ */
+package com.sun.ts.tests.jsf.spec.ajax.common;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.LinkedHashSet;
+
+import jakarta.faces.event.ActionEvent;
+import java.io.Serializable;
+
+
+@jakarta.inject.Named("ajaxtag") @jakarta.enterprise.context.SessionScoped
+public class AjaxTagValuesBean implements Serializable {
+
+  private static final long serialVersionUID = -2564031884433676327L;
+
+  private Integer count = 0;
+
+  private Boolean checked = false;
+
+  private String text = "";
+
+  private String[] outArray = { "out1", ":form2:out2", ":out3" };
+
+  private Collection<String> outSet = new LinkedHashSet<String>(
+      Arrays.asList(outArray));
+
+  private String render = "out1";
+
+  public String getText() {
+    return text;
+  }
+
+  public void setText(String text) {
+    this.text = text;
+  }
+
+  public Boolean getChecked() {
+    return checked;
+  }
+
+  public void setChecked(Boolean checked) {
+    this.checked = checked;
+  }
+
+  public Integer getCount() {
+    return count++;
+  }
+
+  public void reset(ActionEvent ae) {
+    count = 0;
+    checked = false;
+    text = "";
+  }
+
+  public Collection<String> getRenderList() {
+    return outSet;
+  }
+
+  public String getRenderOne() {
+    return render;
+  }
+}

--- a/tck/old-tck-selenium/ajax/src/main/webapp/WEB-INF/beans.xml
+++ b/tck/old-tck-selenium/ajax/src/main/webapp/WEB-INF/beans.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2022 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+
+<beans xmlns="https://jakarta.ee/xml/ns/jakartaee" 
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_4_0.xsd" 
+        bean-discovery-mode="all">
+</beans>

--- a/tck/old-tck-selenium/ajax/src/main/webapp/WEB-INF/beans.xml
+++ b/tck/old-tck-selenium/ajax/src/main/webapp/WEB-INF/beans.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2022 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2023 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/tck/old-tck-selenium/ajax/src/main/webapp/WEB-INF/faces-config.xml
+++ b/tck/old-tck-selenium/ajax/src/main/webapp/WEB-INF/faces-config.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2009, 2018 Oracle and/or its affiliates. All rights reserved.
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+-->
+
+<faces-config xmlns="https://jakarta.ee/xml/ns/jakartaee"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-facesconfig_3_0.xsd"
+    version="3.0">
+</faces-config>

--- a/tck/old-tck-selenium/ajax/src/main/webapp/WEB-INF/faces-config.xml
+++ b/tck/old-tck-selenium/ajax/src/main/webapp/WEB-INF/faces-config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2009, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2023 Oracle and/or its affiliates. All rights reserved.
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
     http://www.eclipse.org/legal/epl-2.0.
@@ -14,6 +14,6 @@
 
 <faces-config xmlns="https://jakarta.ee/xml/ns/jakartaee"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-facesconfig_3_0.xsd"
-    version="3.0">
+    xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-facesconfig_4_0.xsd"
+    version="4.0">
 </faces-config>

--- a/tck/old-tck-selenium/ajax/src/main/webapp/WEB-INF/web.xml
+++ b/tck/old-tck-selenium/ajax/src/main/webapp/WEB-INF/web.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2011, 2020 Oracle and/or its affiliates. All rights reserved.
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+-->
+
+<web-app version="5.0" xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-app_5_0.xsd">
+    <display-name>jsf_ajax_jsresource</display-name>
+
+    <context-param>
+        <param-name>com.sun.faces.validateXml</param-name>
+        <param-value>true</param-value>
+    </context-param>
+
+    <servlet>
+        <servlet-name>Faces Servlet</servlet-name>
+        <servlet-class>jakarta.faces.webapp.FacesServlet</servlet-class>
+    </servlet>
+    <servlet-mapping>
+        <servlet-name>Faces Servlet</servlet-name>
+        <url-pattern>/faces/*</url-pattern>
+    </servlet-mapping>
+
+    <session-config>
+        <session-timeout>54</session-timeout>
+    </session-config>
+</web-app>

--- a/tck/old-tck-selenium/ajax/src/main/webapp/WEB-INF/web.xml
+++ b/tck/old-tck-selenium/ajax/src/main/webapp/WEB-INF/web.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2011, 2020 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2011, 2023 Oracle and/or its affiliates. All rights reserved.
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
     http://www.eclipse.org/legal/epl-2.0.
@@ -11,9 +11,13 @@
     https://www.gnu.org/software/classpath/license.html.
     SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
 -->
+<web-app
+    xmlns="https://jakarta.ee/xml/ns/jakartaee"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-app_6_0.xsd"
+    version="6.0">
 
-<web-app version="5.0" xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-app_5_0.xsd">
-    <display-name>jsf_ajax_jsresource</display-name>
+    <display-name>ajax</display-name>
 
     <context-param>
         <param-name>com.sun.faces.validateXml</param-name>

--- a/tck/old-tck-selenium/ajax/src/main/webapp/jsresource/pdlApproach.xhtml
+++ b/tck/old-tck-selenium/ajax/src/main/webapp/jsresource/pdlApproach.xhtml
@@ -1,0 +1,38 @@
+<!DOCTYPE html
+        PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+        "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+
+<!--
+
+    Copyright (c) 2013, 2022 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<html xmlns="http://www.w3.org/1999/xhtml"
+	xmlns:h="jakarta.faces.html"
+	xmlns:f="jakarta.faces.core"
+	xmlns:ui="jakarta.faces.facelets">
+
+<h:head>
+	<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
+	<title>PDL Approach</title>
+</h:head>
+
+<h:body>
+	<h:outputScript name="faces.js" library="jakarta.faces" target="body"
+		render="true" />
+</h:body>
+
+</html>

--- a/tck/old-tck-selenium/ajax/src/main/webapp/keyword/ajaxAllKeyword1.xhtml
+++ b/tck/old-tck-selenium/ajax/src/main/webapp/keyword/ajaxAllKeyword1.xhtml
@@ -1,0 +1,51 @@
+<!--
+
+    Copyright (c) 2009, 2022 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<!DOCTYPE html
+PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core"
+      xmlns:ui="jakarta.faces.facelets">
+
+    <h:head>
+        <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
+        <title>Ajax Request</title>
+        <script type="text/javascript">
+        </script>
+    </h:head>
+
+    <h:body>
+
+        <!-- Ajaxify Individual Controls -->
+
+        <h:form id="form" >
+            <h:outputText id="out" value="testtext"/>
+
+            <h:commandButton id="allKeyword"
+                             value="@all">
+                <f:ajax execute="@all"
+                        render="@all"/>
+            </h:commandButton>
+
+        </h:form>
+
+    </h:body>
+
+</html>

--- a/tck/old-tck-selenium/ajax/src/main/webapp/keyword/ajaxAllKeyword2.xhtml
+++ b/tck/old-tck-selenium/ajax/src/main/webapp/keyword/ajaxAllKeyword2.xhtml
@@ -1,0 +1,53 @@
+<!--
+
+    Copyright (c) 2009, 2022 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<!DOCTYPE html
+PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core"
+      xmlns:ui="jakarta.faces.facelets">
+
+    <h:head>
+        <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
+        <title>Ajax Request</title>
+        <script type="text/javascript">
+            var a = true;
+            var b = false;
+        </script>
+    </h:head>
+
+    <h:body>
+
+        <!-- Ajaxify Individual Controls -->
+
+        <h:form id="form" >
+            <h:outputText id="out" value="testtext"/>
+
+            <h:commandButton id="allKeyword"
+                             value="@all">
+                <f:ajax execute="@all"
+                        render="@all"/>
+            </h:commandButton>
+
+        </h:form>
+
+    </h:body>
+
+</html>

--- a/tck/old-tck-selenium/ajax/src/main/webapp/keyword/ajaxAllKeyword3.xhtml
+++ b/tck/old-tck-selenium/ajax/src/main/webapp/keyword/ajaxAllKeyword3.xhtml
@@ -1,0 +1,56 @@
+<!--
+
+    Copyright (c) 2009, 2022 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<!DOCTYPE html
+PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core"
+      xmlns:ui="jakarta.faces.facelets">
+
+    <h:head>
+        <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
+        <title>Ajax Request</title>
+        <script type="text/javascript">
+            // <![CDATA[
+            var a = true;
+            var b = false;
+            var c = a && b;
+            // ]]>
+        </script>
+    </h:head>
+
+    <h:body>
+
+        <!-- Ajaxify Individual Controls -->
+
+        <h:form id="form" >
+            <h:outputText id="out" value="testtext"/>
+
+            <h:commandButton id="allKeyword"
+                             value="@all">
+                <f:ajax execute="@all"
+                        render="@all"/>
+            </h:commandButton>
+
+        </h:form>
+
+    </h:body>
+
+</html>

--- a/tck/old-tck-selenium/ajax/src/main/webapp/keyword/ajaxFormKeyword1.xhtml
+++ b/tck/old-tck-selenium/ajax/src/main/webapp/keyword/ajaxFormKeyword1.xhtml
@@ -1,0 +1,51 @@
+<!--
+
+    Copyright (c) 2009, 2022 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<!DOCTYPE html
+        PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+        "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core"
+      xmlns:ui="jakarta.faces.facelets">
+
+<h:head>
+    <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
+    <title>Ajax Request</title>
+    <script type="text/javascript">
+    </script>
+</h:head>
+
+<h:body>
+
+<!-- Ajaxify Individual Controls -->
+
+    <h:form id="form" >
+        <h:outputText id="out" value="testtext"/>
+
+       <h:commandButton id="formKeyword"
+                        value="@form">
+           <f:ajax execute="@form"
+                   render="@form"/>
+       </h:commandButton>
+
+   </h:form>
+
+</h:body>
+
+</html>

--- a/tck/old-tck-selenium/ajax/src/main/webapp/keyword/ajaxFormKeyword2.xhtml
+++ b/tck/old-tck-selenium/ajax/src/main/webapp/keyword/ajaxFormKeyword2.xhtml
@@ -1,0 +1,52 @@
+<!--
+
+    Copyright (c) 2009, 2022 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+<!DOCTYPE html
+        PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+        "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core"
+      xmlns:ui="jakarta.faces.facelets">
+
+<h:head>
+    <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
+    <title>Ajax Request</title>
+    <script type="text/javascript">
+        var a = true;
+        var b = false;
+    </script>
+</h:head>
+
+<h:body>
+
+<!-- Ajaxify Individual Controls -->
+
+    <h:form id="form" >
+        <h:outputText id="out" value="testtext"/>
+
+       <h:commandButton id="formKeyword"
+                        value="@form">
+           <f:ajax execute="@form"
+                   render="@form"/>
+       </h:commandButton>
+
+   </h:form>
+
+</h:body>
+
+</html>

--- a/tck/old-tck-selenium/ajax/src/main/webapp/keyword/ajaxFormKeyword3.xhtml
+++ b/tck/old-tck-selenium/ajax/src/main/webapp/keyword/ajaxFormKeyword3.xhtml
@@ -1,0 +1,56 @@
+<!--
+
+    Copyright (c) 2009, 2022 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+ 
+<!DOCTYPE html
+        PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+        "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core"
+      xmlns:ui="jakarta.faces.facelets">
+
+<h:head>
+    <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
+    <title>Ajax Request</title>
+    <script type="text/javascript">
+        // <![CDATA[
+        var a = true;
+        var b = false;
+        var c = a && b;
+        // ]]>
+    </script>
+</h:head>
+
+<h:body>
+
+<!-- Ajaxify Individual Controls -->
+
+    <h:form id="form" >
+        <h:outputText id="out" value="testtext"/>
+
+       <h:commandButton id="formKeyword"
+                        value="@form">
+           <f:ajax execute="@form"
+                   render="@form"/>
+       </h:commandButton>
+
+   </h:form>
+
+</h:body>
+
+</html>

--- a/tck/old-tck-selenium/ajax/src/main/webapp/keyword/ajaxNoneKeyword1.xhtml
+++ b/tck/old-tck-selenium/ajax/src/main/webapp/keyword/ajaxNoneKeyword1.xhtml
@@ -1,0 +1,51 @@
+<!--
+
+    Copyright (c) 2009, 2022 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<!DOCTYPE html
+        PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+        "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core"
+      xmlns:ui="jakarta.faces.facelets">
+
+<h:head>
+    <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
+    <title>Ajax Request</title>
+    <script type="text/javascript">
+    </script>
+</h:head>
+
+<h:body>
+
+<!-- Ajaxify Individual Controls -->
+
+    <h:form id="form" >
+        <h:outputText id="out" value="testtext"/>
+
+       <h:commandButton id="noneKeyword"
+                        value="@none">
+           <f:ajax execute="@none"
+                   render="@none"/>
+       </h:commandButton>
+
+   </h:form>
+
+</h:body>
+
+</html>

--- a/tck/old-tck-selenium/ajax/src/main/webapp/keyword/ajaxNoneKeyword2.xhtml
+++ b/tck/old-tck-selenium/ajax/src/main/webapp/keyword/ajaxNoneKeyword2.xhtml
@@ -1,0 +1,53 @@
+<!--
+
+    Copyright (c) 2009, 2022 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<!DOCTYPE html
+        PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+        "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core"
+      xmlns:ui="jakarta.faces.facelets">
+
+<h:head>
+    <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
+    <title>Ajax Request</title>
+    <script type="text/javascript">
+        var a = true;
+        var b = false;
+    </script>
+</h:head>
+
+<h:body>
+
+<!-- Ajaxify Individual Controls -->
+
+    <h:form id="form" >
+        <h:outputText id="out" value="testtext"/>
+
+       <h:commandButton id="noneKeyword"
+                        value="@none">
+           <f:ajax execute="@none"
+                   render="@none"/>
+       </h:commandButton>
+
+   </h:form>
+
+</h:body>
+
+</html>

--- a/tck/old-tck-selenium/ajax/src/main/webapp/keyword/ajaxNoneKeyword3.xhtml
+++ b/tck/old-tck-selenium/ajax/src/main/webapp/keyword/ajaxNoneKeyword3.xhtml
@@ -1,0 +1,56 @@
+<!--
+
+    Copyright (c) 2009, 2022 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<!DOCTYPE html
+        PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+        "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core"
+      xmlns:ui="jakarta.faces.facelets">
+
+<h:head>
+    <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
+    <title>Ajax Request</title>
+    <script type="text/javascript">
+        // <![CDATA[
+        var a = true;
+        var b = false;
+        var c = a && b;
+        // ]]>
+    </script>
+</h:head>
+
+<h:body>
+
+<!-- Ajaxify Individual Controls -->
+
+    <h:form id="form" >
+        <h:outputText id="out" value="testtext"/>
+
+       <h:commandButton id="noneKeyword"
+                        value="@none">
+           <f:ajax execute="@none"
+                   render="@none"/>
+       </h:commandButton>
+
+   </h:form>
+
+</h:body>
+
+</html>

--- a/tck/old-tck-selenium/ajax/src/main/webapp/keyword/ajaxThisKeyword1.xhtml
+++ b/tck/old-tck-selenium/ajax/src/main/webapp/keyword/ajaxThisKeyword1.xhtml
@@ -1,0 +1,50 @@
+<!--
+
+    Copyright (c) 2009, 2022 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+<!DOCTYPE html
+        PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+        "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core"
+      xmlns:ui="jakarta.faces.facelets">
+
+<h:head>
+    <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
+    <title>Ajax Request</title>
+    <script type="text/javascript">
+    </script>
+</h:head>
+
+<h:body>
+
+<!-- Ajaxify Individual Controls -->
+
+    <h:form id="form" >
+        <h:outputText id="out" value="testtext"/>
+
+       <h:commandButton id="thisKeyword"
+                        value="@this">
+           <f:ajax execute="@this"
+                   render="@this"/>
+       </h:commandButton>
+
+   </h:form>
+
+</h:body>
+
+</html>

--- a/tck/old-tck-selenium/ajax/src/main/webapp/keyword/ajaxThisKeyword2.xhtml
+++ b/tck/old-tck-selenium/ajax/src/main/webapp/keyword/ajaxThisKeyword2.xhtml
@@ -1,0 +1,53 @@
+<!--
+
+    Copyright (c) 2009, 2022 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+ 
+<!DOCTYPE html
+        PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+        "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core"
+      xmlns:ui="jakarta.faces.facelets">
+
+<h:head>
+    <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
+    <title>Ajax Request</title>
+    <script type="text/javascript">
+        var a = true;
+        var b = false;
+    </script>
+</h:head>
+
+<h:body>
+
+<!-- Ajaxify Individual Controls -->
+
+    <h:form id="form" >
+        <h:outputText id="out" value="testtext"/>
+
+       <h:commandButton id="thisKeyword"
+                        value="@this">
+           <f:ajax execute="@this"
+                   render="@this"/>
+       </h:commandButton>
+
+   </h:form>
+
+</h:body>
+
+</html>

--- a/tck/old-tck-selenium/ajax/src/main/webapp/keyword/ajaxThisKeyword3.xhtml
+++ b/tck/old-tck-selenium/ajax/src/main/webapp/keyword/ajaxThisKeyword3.xhtml
@@ -1,0 +1,56 @@
+<!--
+
+    Copyright (c) 2009, 2022 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<!DOCTYPE html
+        PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+        "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core"
+      xmlns:ui="jakarta.faces.facelets">
+
+<h:head>
+    <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
+    <title>Ajax Request</title>
+    <script type="text/javascript">
+        // <![CDATA[
+        var a = true;
+        var b = false;
+        var c = a && b;
+        // ]]>
+    </script>
+</h:head>
+
+<h:body>
+
+<!-- Ajaxify Individual Controls -->
+
+    <h:form id="form" >
+        <h:outputText id="out" value="testtext"/>
+
+       <h:commandButton id="thisKeyword"
+                        value="@this">
+           <f:ajax execute="@this"
+                   render="@this"/>
+       </h:commandButton>
+
+   </h:form>
+
+</h:body>
+
+</html>

--- a/tck/old-tck-selenium/ajax/src/main/webapp/tagwrapper/ajaxTagWrap.xhtml
+++ b/tck/old-tck-selenium/ajax/src/main/webapp/tagwrapper/ajaxTagWrap.xhtml
@@ -1,0 +1,58 @@
+<!DOCTYPE html
+        PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+        "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<!--
+
+    Copyright (c) 2013, 2022 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core"
+      xmlns:ui="jakarta.faces.facelets">
+<h:head>
+    <title>Ajax Tag Wrapping Test</title>
+</h:head>
+<h:body>
+    <h1>Test Tag with each component</h1>
+    <h:form id="form1" prependId="false">
+        <h:outputText id="out1" value="#{ajaxtag.count}"/>
+        <br/>
+        <!-- Increment the counter on the server, and the client -->
+        <h:commandButton id="button1" value="Count">
+            <f:ajax render="out1"/>
+        </h:commandButton>
+        <br/>
+        <h:inputText id="intext" value="#{ajaxtag.text}">
+            <f:ajax render="outtext"/>
+            </h:inputText>
+        <h:outputText id="outtext" value="#{ajaxtag.text}"/>
+        <br/>
+        <h:selectBooleanCheckbox id="checkbox" value="#{ajaxtag.checked}">
+            <f:ajax render="checkedvalue"/>
+            </h:selectBooleanCheckbox>
+        <h:outputText id="checkedvalue" value="#{ajaxtag.checked}"/>
+        <br/>
+        <!-- Resets the counter, doesn't refresh the page -->
+        <h:commandButton id="reset" value="reset" actionListener="#{ajaxtag.reset}">
+            <f:ajax execute="reset" render="form"/>
+        </h:commandButton>
+        <br/>
+        <h:commandButton id="reload" value="reload" type="submit" />
+    </h:form>
+
+</h:body>
+</html>

--- a/tck/old-tck-selenium/ajax/src/test/java/ee/jakarta/tck/faces/test/oldtck/ajax/AjaxTestsIT.java
+++ b/tck/old-tck-selenium/ajax/src/test/java/ee/jakarta/tck/faces/test/oldtck/ajax/AjaxTestsIT.java
@@ -34,6 +34,7 @@ import org.jboss.shrinkwrap.api.importer.ZipImporter;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -68,266 +69,202 @@ public class AjaxTestsIT {
         webClient.close();
     }
 
-    public void ajaxTagWrappingTest() throws Fault {
-        StringBuilder messages = new StringBuilder(128);
-        Formatter formatter = new Formatter(messages);
-    
-        HtmlPage page = getPage(CONTEXT_ROOT + "/faces/ajaxTagWrap.xhtml");
-    
-        // First we'll check the first page was output correctly
-        this.validateSpanTag(page, "out1", "0");
-        this.validateSpanTag(page, "checkedvalue", "false");
-        this.validateSpanTag(page, "outtext", "");
-    
-        // Submit the ajax request
-        HtmlInput button1 = (HtmlInput) getElementOfTypeIncludingId(page, "input",
-            "button1");
-    
-        if (!validateExistence("button1", "input", button1, formatter)) {
-          handleTestStatus(messages);
-          return;
-        }
-    
-        try {
-          button1.click();
-        } catch (IOException ex) {
-          formatter.format("Unexpected Execption thrown while clicking '%s'.",
-              button1.getId());
-          ex.printStackTrace();
-        }
-    
-        // Check that the ajax request succeeds - eventually.
-        this.validateSpanTag(page, "out1", "1");
-    
-        // // Check on the text field
-        HtmlInput intext = ((HtmlInput) getElementOfTypeIncludingId(page, "input",
-            "intext"));
-    
-        if (!validateExistence("input", "input", intext, formatter)) {
-          handleTestStatus(messages);
-          return;
-        }
-        try {
-          intext.focus();
-          intext.type("test");
-          intext.blur();
-        } catch (IOException ex) {
-          formatter.format("Unexpected Test failing when setting one or "
-              + "more of the following attributes: focus, type, or blur");
-          ex.printStackTrace();
-        }
-    
-        this.validateSpanTag(page, "outtext", "test");
-    
-        // Check the checkbox
-    
-        HtmlInput checkbox = (HtmlInput) getElementOfTypeIncludingId(page, "input",
-            "checkbox");
-    
-        if (!validateExistence("checkbox", "input", checkbox, formatter)) {
-          handleTestStatus(messages);
-          return;
-        }
-    
-        checkbox.setChecked(true);
-    
-        if (!checkbox.isChecked()) {
-          formatter.format(
-              "Unexpected value for '%s'!" + NL + "Expected: '%s'" + NL
-                  + "Received: '%s'" + NL,
-              checkbox.getId(), "true", checkbox.isChecked());
-        }
-    
-        handleTestStatus(messages);
-      }// End ajaxAllKeywordTest
+
+    @Test
+    public void ajaxTagWrappingTest() throws Exception {
+      HtmlPage page = webClient.getPage(webUrl + "/faces/tagwrapper/ajaxTagWrap.xhtml");
+
+      // First we'll check the first page was output correctly
+      HtmlSpan span1 = (HtmlSpan) page.getElementById("out1");
+      assertNotNull(span1);
+      assertEquals("0", span1.asNormalizedText());
+
+      HtmlSpan span2 = (HtmlSpan) page.getElementById("checkedvalue");
+      assertNotNull(span2);
+      assertEquals("false", span2.asNormalizedText());
+
+      HtmlSpan span3 = (HtmlSpan) page.getElementById("outtext");
+      assertNotNull(span3);
+      assertEquals("", span3.asNormalizedText());
   
-      https://github.com/jakartaee/faces/blob/3fae98234692ec16545a6d27cf36fabaeb883f9b/tck/old-tck/source/src/com/sun/ts/tests/jsf/spec/ajax/keyword/URLClient.java
-    /**
-     * @testName: ajaxAllKeywordTest
-     * @assertion_ids: PENDING
-     * @test_Strategy: Unsure the keyword 'all' works correctly with the f:ajax
-     *                 tag as value to 'execute' and 'render' attributes.
-     * 
-     * @since 2.0
-     */
-    public void ajaxAllKeywordTest() throws Fault {
+      // Submit the ajax request
+      HtmlInput button1 = (HtmlInput) page.getElementById("button1");
+      assertNotNull(button1);
+      page = button1.click();
   
-      List<HtmlPage> pages = new ArrayList<HtmlPage>();
-      pages.add(getPage(CONTEXT_ROOT + "/faces/ajaxAllKeyword1.xhtml"));
-      pages.add(getPage(CONTEXT_ROOT + "/faces/ajaxAllKeyword2.xhtml"));
-      pages.add(getPage(CONTEXT_ROOT + "/faces/ajaxAllKeyword3.xhtml"));
+      webClient.waitForBackgroundJavaScript(3000);
+
+      // Check that the ajax request succeeds - eventually.
+      span1 = (HtmlSpan) page.getElementById("out1");
+      assertEquals("1",span1.asNormalizedText());
   
-      String buttonId = "allKeyword";
-      String spanId = "out";
+      // // Check on the text field
+      HtmlInput intext = (HtmlInput) page.getElementById("intext");
+      assertNotNull(intext);
+      intext.focus();
+      intext.type("test");
+      intext.blur();
+      webClient.waitForBackgroundJavaScript(3000);
+
+      span3 = (HtmlSpan) page.getElementById("outtext");
+      assertNotNull(span3);
+      assertEquals("test", span3.asNormalizedText());
   
-      this.validateKeyword(pages, buttonId, spanId, EXPECTED);
+      // Check the checkbox
+      HtmlInput checkbox = (HtmlInput) page.getElementById("checkbox");
+      assertNotNull(checkbox);
+      page = (HtmlPage) checkbox.setChecked(true);
+      checkbox = (HtmlInput) page.getElementById("checkbox");
+      assertTrue(checkbox.isChecked());
+
+      // Check for "true" in outtext? Not originally tested (maybe due to HTMLUnit issues?). Will add to selenium run.
   
     }// End ajaxAllKeywordTest
-  
-    /**
-     * @testName: ajaxThisKeywordTest
-     * @assertion_ids: PENDING
-     * @test_Strategy: Unsure the keyword 'this' works correctly with the f:ajax
-     *                 tag as value to 'execute' and 'render' attributes.
-     * 
-     * @since 2.0
-     */
-    public void ajaxThisKeywordTest() throws Fault {
-      List<HtmlPage> pages = new ArrayList<HtmlPage>();
-      pages.add(getPage(CONTEXT_ROOT + "/faces/ajaxThisKeyword1.xhtml"));
-      pages.add(getPage(CONTEXT_ROOT + "/faces/ajaxThisKeyword2.xhtml"));
-      pages.add(getPage(CONTEXT_ROOT + "/faces/ajaxThisKeyword3.xhtml"));
-  
-      String buttonId = "thisKeyword";
-      String spanId = "out";
-  
-      this.validateKeyword(pages, buttonId, spanId, EXPECTED);
-    } // End ajaxThisKeywordTest
-  
-    /**
-     * @testName: ajaxFormKeywordTest
-     * @assertion_ids: PENDING
-     * @test_Strategy: Unsure the keyword 'form' works correctly with the f:ajax
-     *                 tag as value to 'execute' and 'render' attributes.
-     * 
-     * @since 2.0
-     */
-    public void ajaxFormKeywordTest() throws Fault {
-      List<HtmlPage> pages = new ArrayList<HtmlPage>();
-      pages.add(getPage(CONTEXT_ROOT + "/faces/ajaxFormKeyword1.xhtml"));
-      pages.add(getPage(CONTEXT_ROOT + "/faces/ajaxFormKeyword2.xhtml"));
-      pages.add(getPage(CONTEXT_ROOT + "/faces/ajaxFormKeyword3.xhtml"));
-  
-      String buttonId = "formKeyword";
-      String spanId = "out";
-  
-      this.validateKeyword(pages, buttonId, spanId, EXPECTED);
-    } // End ajaxThisKeywordTest
-  
-    /**
-     * @testName: ajaxNoneKeywordTest
-     * @assertion_ids: PENDING
-     * @test_Strategy: Unsure the keyword 'none' works correctly with the f:ajax
-     *                 tag as value to 'execute' and 'render' attributes.
-     * 
-     * @since 2.0
-     */
-    public void ajaxNoneKeywordTest() throws Fault {
-      List<HtmlPage> pages = new ArrayList<HtmlPage>();
-      pages.add(getPage(CONTEXT_ROOT + "/faces/ajaxNoneKeyword1.xhtml"));
-      pages.add(getPage(CONTEXT_ROOT + "/faces/ajaxNoneKeyword2.xhtml"));
-      pages.add(getPage(CONTEXT_ROOT + "/faces/ajaxNoneKeyword3.xhtml"));
-  
-      String buttonId = "noneKeyword";
-      String spanId = "out";
-  
-      this.validateKeyword(pages, buttonId, spanId, EXPECTED);
-    } // End ajaxThisKeywordTest
-  
-    /**
-     * @testName: ajaxPDLResourceTest
-     * 
-     * @assertion_ids: JSF:SPEC:225; JSF:SPEC:226; JSF:SPEC:227
-     * 
-     * @test_Strategy: Validate that the jsf.js Resource is available via the
-     *                 "Page Declaration Language Approach".
-     * 
-     * @since 2.0
-     */
-    public void ajaxPDLResourceTest() throws Fault {
-  
-      this.validateScript(getPage(CONTEXT_ROOT + "/faces/pdlApproach.xhtml"));
-  
-    }// End ajaxPDLResourceTest
-  
-    private void validateScript(HtmlPage page) throws Fault {
-      StringBuilder messages = new StringBuilder(128);
-      Formatter formatter = new Formatter(messages);
-      String script = "script";
-  
-      // Test by Resource name.
-      HtmlScript resn = (HtmlScript) getElementOfTypeIncludingSrc(page, script,
-          RES_NAME);
-  
-      if (resn == null) {
-        formatter.format("Unexpected Test Result For %s Tag! %n"
-            + "Expected Src Attribute to contain: %s %n", script, RES_NAME);
-      }
-  
-      // Test by Resource Library name.
-      HtmlScript resl = (HtmlScript) getElementOfTypeIncludingSrc(page, script,
-          LIB_NAME);
-  
-      if (resl == null) {
-        formatter.format("Unexpected Test Result For %s Tag! %n"
-            + "Expected Src Attribute to contain: %s %n", script, LIB_NAME);
-      }
-  
-      handleTestStatus(messages);
-      formatter.close();
-    }
-  
-    private void validateKeyword(List<HtmlPage> pages, String buttonId,
-      String spanId, String expectedValue) throws Fault {
-      StringBuilder messages = new StringBuilder(128);
-      Formatter formatter = new Formatter(messages);
-  
-      String span = "span";
-      for (HtmlPage page : pages) {
-        HtmlSpan output = (HtmlSpan) getElementOfTypeIncludingId(page, span,
-            spanId);
-  
-        if (!validateExistence(spanId, span, output, formatter)) {
-          handleTestStatus(messages);
-          return;
-        }
-  
+
+  /**
+   * @testName: ajaxAllKeywordTest
+   * @assertion_ids: PENDING
+   * @test_Strategy: Unsure the keyword 'all' works correctly with the f:ajax
+   *                 tag as value to 'execute' and 'render' attributes.
+   * 
+   * @since 2.0
+   */
+  @Test
+  public void ajaxAllKeywordTest() throws Exception {
+
+    String EXPECTED = "testtext";
+
+    List<String> urls = new ArrayList<String>();
+    urls.add(webUrl + "/faces/keyword/ajaxAllKeyword1.xhtml");
+    urls.add(webUrl + "/faces/keyword/ajaxAllKeyword2.xhtml");
+    urls.add(webUrl + "/faces/keyword/ajaxAllKeyword3.xhtml");
+
+    String buttonId = "form:allKeyword";
+    String spanId = "form:out";
+
+    this.validateKeyword(urls, buttonId, spanId, EXPECTED);
+
+  }// End ajaxAllKeywordTest
+
+  /**
+   * @testName: ajaxThisKeywordTest
+   * @assertion_ids: PENDING
+   * @test_Strategy: Unsure the keyword 'this' works correctly with the f:ajax
+   *                 tag as value to 'execute' and 'render' attributes.
+   * 
+   * @since 2.0
+   */
+  @Test
+  public void ajaxThisKeywordTest() throws Exception {
+
+    String EXPECTED = "testtext";
+
+    List<String> urls = new ArrayList<String>();
+    urls.add(webUrl + "/faces/keyword/ajaxThisKeyword1.xhtml");
+    urls.add(webUrl + "/faces/keyword/ajaxThisKeyword2.xhtml");
+    urls.add(webUrl + "/faces/keyword/ajaxThisKeyword3.xhtml");
+
+    String buttonId = "form:thisKeyword";
+    String spanId = "form:out";
+
+    this.validateKeyword(urls, buttonId, spanId, EXPECTED);
+  } // End ajaxThisKeywordTest
+
+  /**
+   * @testName: ajaxFormKeywordTest
+   * @assertion_ids: PENDING
+   * @test_Strategy: Unsure the keyword 'form' works correctly with the f:ajax
+   *                 tag as value to 'execute' and 'render' attributes.
+   * 
+   * @since 2.0
+   */
+  public void ajaxFormKeywordTest() throws Exception {
+
+    String EXPECTED = "testtext";
+
+    List<String> urls = new ArrayList<String>();
+    urls.add(webUrl + "/faces/keyword/ajaxFormKeyword1.xhtml");
+    urls.add(webUrl + "/faces/keyword/ajaxFormKeyword2.xhtml");
+    urls.add(webUrl + "/faces/keyword/ajaxFormKeyword3.xhtml");
+
+    String buttonId = "form:formKeyword";
+    String spanId = "form:out";
+
+    this.validateKeyword(urls, buttonId, spanId, EXPECTED);
+  } // End ajaxThisKeywordTest
+
+  /**
+   * @testName: ajaxNoneKeywordTest
+   * @assertion_ids: PENDING
+   * @test_Strategy: Unsure the keyword 'none' works correctly with the f:ajax
+   *                 tag as value to 'execute' and 'render' attributes.
+   * 
+   * @since 2.0
+   */
+  public void ajaxNoneKeywordTest() throws Exception {
+
+    String EXPECTED = "testtext";
+
+    List<String> urls = new ArrayList<String>();
+    urls.add(webUrl + "/faces/keyword/ajaxNoneKeyword1.xhtml");
+    urls.add(webUrl + "/faces/keyword/ajaxNoneKeyword2.xhtml");
+    urls.add(webUrl + "/faces/keyword/ajaxNoneKeyword3.xhtml");
+
+    String buttonId = "form:noneKeyword";
+    String spanId = "form:out";
+
+    this.validateKeyword(urls, buttonId, spanId, EXPECTED);
+  } // End ajaxThisKeywordTest
+
+  /**
+   * @testName: ajaxPDLResourceTest
+   * 
+   * @assertion_ids: JSF:SPEC:225; JSF:SPEC:226; JSF:SPEC:227
+   * 
+   * @test_Strategy: Validate that the jsf.js Resource is available via the
+   *                 "Page Declaration Language Approach".
+   * 
+   * @since 2.0
+   */
+  @Ignore("Skipped in  Old TCK for EE10")
+  @Test
+  public void ajaxPDLResourceTest() throws Exception {
+
+    HtmlPage page = webClient.getPage( webUrl + "/faces/jsresource/pdlApproach.xhtml");
+    HtmlScript script = (HtmlScript) page.getElementsByTagName("script").get(0);
+    assertNotNull(script);
+
+    // Test by Resource name.
+    assertTrue(script.getSrcAttribute().contains("faces.js"));
+    // Test by Resource Library name.
+    assertTrue(script.getSrcAttribute().contains("jakarta.faces"));
+
+  }// End ajaxPDLResourceTest
+
+
+  // HELPER METHODS
+  private void validateKeyword(List<String> urls, String buttonId,
+      String spanId, String expectedValue) throws Exception {
+
+      for (String url : urls) {
+        HtmlPage page = webClient.getPage(url);
+        HtmlSpan output = (HtmlSpan) page.getElementById(spanId);
+        assertNotNull(output);
+
         // First we'll check the first page was output correctly
-        validateElementValue(output, expectedValue, formatter);
-  
+        assertEquals(expectedValue, output.asNormalizedText());
+
         // Submit the ajax request
-        HtmlSubmitInput button = (HtmlSubmitInput) getElementOfTypeIncludingId(
-            page, "input", buttonId);
-        try {
-          button.click();
-        } catch (IOException ex) {
-          formatter.format("Unexpected Execption thrown while clicking '%s'.",
-              button.getId());
-          ex.printStackTrace();
-        }
-  
+        HtmlSubmitInput button = (HtmlSubmitInput) page.getElementById(buttonId);
+        page = button.click();
+
+        webClient.waitForBackgroundJavaScript(3000);
+
         // Check that the ajax request succeeds - if the page is rewritten,
         // this will be the same
-        validateElementValue(output, expectedValue, formatter);
-  
-        handleTestStatus(messages);
+        output = (HtmlSpan) page.getElementById(spanId);
+        assertNotNull(output);
+        assertEquals(expectedValue, output.asNormalizedText());
       }
-    }
-  
-      /**
-     * Test for a the give @String "expectedValue" to match the value of the
-     * named @HtmlSpan "element "spanID".
-     * 
-     * @param page
-     *          - @HtmlPage that contains @HtmlSpan element.
-     * @param expectedValue
-     *          - The expected result.
-     * @param formatter
-     *          - used to gather test result output.
-     */
-    private void validateSpanTag(HtmlPage page, String spanId,
-        String expectedValue) throws Fault {
-      StringBuilder messages = new StringBuilder(128);
-      Formatter formatter = new Formatter(messages);
-  
-      HtmlSpan output = (HtmlSpan) getElementOfTypeIncludingId(page, SPAN,
-          spanId);
-  
-      if (!validateExistence(spanId, SPAN, output, formatter)) {
-        handleTestStatus(messages);
-        return;
-      }
-      validateElementValue(output, expectedValue, formatter);
-  
-    }// End validateSpanTag
+  }
 }

--- a/tck/old-tck-selenium/ajax/src/test/java/ee/jakarta/tck/faces/test/oldtck/ajax/AjaxTestsIT.java
+++ b/tck/old-tck-selenium/ajax/src/test/java/ee/jakarta/tck/faces/test/oldtck/ajax/AjaxTestsIT.java
@@ -68,4 +68,266 @@ public class AjaxTestsIT {
         webClient.close();
     }
 
+    public void ajaxTagWrappingTest() throws Fault {
+        StringBuilder messages = new StringBuilder(128);
+        Formatter formatter = new Formatter(messages);
+    
+        HtmlPage page = getPage(CONTEXT_ROOT + "/faces/ajaxTagWrap.xhtml");
+    
+        // First we'll check the first page was output correctly
+        this.validateSpanTag(page, "out1", "0");
+        this.validateSpanTag(page, "checkedvalue", "false");
+        this.validateSpanTag(page, "outtext", "");
+    
+        // Submit the ajax request
+        HtmlInput button1 = (HtmlInput) getElementOfTypeIncludingId(page, "input",
+            "button1");
+    
+        if (!validateExistence("button1", "input", button1, formatter)) {
+          handleTestStatus(messages);
+          return;
+        }
+    
+        try {
+          button1.click();
+        } catch (IOException ex) {
+          formatter.format("Unexpected Execption thrown while clicking '%s'.",
+              button1.getId());
+          ex.printStackTrace();
+        }
+    
+        // Check that the ajax request succeeds - eventually.
+        this.validateSpanTag(page, "out1", "1");
+    
+        // // Check on the text field
+        HtmlInput intext = ((HtmlInput) getElementOfTypeIncludingId(page, "input",
+            "intext"));
+    
+        if (!validateExistence("input", "input", intext, formatter)) {
+          handleTestStatus(messages);
+          return;
+        }
+        try {
+          intext.focus();
+          intext.type("test");
+          intext.blur();
+        } catch (IOException ex) {
+          formatter.format("Unexpected Test failing when setting one or "
+              + "more of the following attributes: focus, type, or blur");
+          ex.printStackTrace();
+        }
+    
+        this.validateSpanTag(page, "outtext", "test");
+    
+        // Check the checkbox
+    
+        HtmlInput checkbox = (HtmlInput) getElementOfTypeIncludingId(page, "input",
+            "checkbox");
+    
+        if (!validateExistence("checkbox", "input", checkbox, formatter)) {
+          handleTestStatus(messages);
+          return;
+        }
+    
+        checkbox.setChecked(true);
+    
+        if (!checkbox.isChecked()) {
+          formatter.format(
+              "Unexpected value for '%s'!" + NL + "Expected: '%s'" + NL
+                  + "Received: '%s'" + NL,
+              checkbox.getId(), "true", checkbox.isChecked());
+        }
+    
+        handleTestStatus(messages);
+      }// End ajaxAllKeywordTest
+  
+      https://github.com/jakartaee/faces/blob/3fae98234692ec16545a6d27cf36fabaeb883f9b/tck/old-tck/source/src/com/sun/ts/tests/jsf/spec/ajax/keyword/URLClient.java
+    /**
+     * @testName: ajaxAllKeywordTest
+     * @assertion_ids: PENDING
+     * @test_Strategy: Unsure the keyword 'all' works correctly with the f:ajax
+     *                 tag as value to 'execute' and 'render' attributes.
+     * 
+     * @since 2.0
+     */
+    public void ajaxAllKeywordTest() throws Fault {
+  
+      List<HtmlPage> pages = new ArrayList<HtmlPage>();
+      pages.add(getPage(CONTEXT_ROOT + "/faces/ajaxAllKeyword1.xhtml"));
+      pages.add(getPage(CONTEXT_ROOT + "/faces/ajaxAllKeyword2.xhtml"));
+      pages.add(getPage(CONTEXT_ROOT + "/faces/ajaxAllKeyword3.xhtml"));
+  
+      String buttonId = "allKeyword";
+      String spanId = "out";
+  
+      this.validateKeyword(pages, buttonId, spanId, EXPECTED);
+  
+    }// End ajaxAllKeywordTest
+  
+    /**
+     * @testName: ajaxThisKeywordTest
+     * @assertion_ids: PENDING
+     * @test_Strategy: Unsure the keyword 'this' works correctly with the f:ajax
+     *                 tag as value to 'execute' and 'render' attributes.
+     * 
+     * @since 2.0
+     */
+    public void ajaxThisKeywordTest() throws Fault {
+      List<HtmlPage> pages = new ArrayList<HtmlPage>();
+      pages.add(getPage(CONTEXT_ROOT + "/faces/ajaxThisKeyword1.xhtml"));
+      pages.add(getPage(CONTEXT_ROOT + "/faces/ajaxThisKeyword2.xhtml"));
+      pages.add(getPage(CONTEXT_ROOT + "/faces/ajaxThisKeyword3.xhtml"));
+  
+      String buttonId = "thisKeyword";
+      String spanId = "out";
+  
+      this.validateKeyword(pages, buttonId, spanId, EXPECTED);
+    } // End ajaxThisKeywordTest
+  
+    /**
+     * @testName: ajaxFormKeywordTest
+     * @assertion_ids: PENDING
+     * @test_Strategy: Unsure the keyword 'form' works correctly with the f:ajax
+     *                 tag as value to 'execute' and 'render' attributes.
+     * 
+     * @since 2.0
+     */
+    public void ajaxFormKeywordTest() throws Fault {
+      List<HtmlPage> pages = new ArrayList<HtmlPage>();
+      pages.add(getPage(CONTEXT_ROOT + "/faces/ajaxFormKeyword1.xhtml"));
+      pages.add(getPage(CONTEXT_ROOT + "/faces/ajaxFormKeyword2.xhtml"));
+      pages.add(getPage(CONTEXT_ROOT + "/faces/ajaxFormKeyword3.xhtml"));
+  
+      String buttonId = "formKeyword";
+      String spanId = "out";
+  
+      this.validateKeyword(pages, buttonId, spanId, EXPECTED);
+    } // End ajaxThisKeywordTest
+  
+    /**
+     * @testName: ajaxNoneKeywordTest
+     * @assertion_ids: PENDING
+     * @test_Strategy: Unsure the keyword 'none' works correctly with the f:ajax
+     *                 tag as value to 'execute' and 'render' attributes.
+     * 
+     * @since 2.0
+     */
+    public void ajaxNoneKeywordTest() throws Fault {
+      List<HtmlPage> pages = new ArrayList<HtmlPage>();
+      pages.add(getPage(CONTEXT_ROOT + "/faces/ajaxNoneKeyword1.xhtml"));
+      pages.add(getPage(CONTEXT_ROOT + "/faces/ajaxNoneKeyword2.xhtml"));
+      pages.add(getPage(CONTEXT_ROOT + "/faces/ajaxNoneKeyword3.xhtml"));
+  
+      String buttonId = "noneKeyword";
+      String spanId = "out";
+  
+      this.validateKeyword(pages, buttonId, spanId, EXPECTED);
+    } // End ajaxThisKeywordTest
+  
+    /**
+     * @testName: ajaxPDLResourceTest
+     * 
+     * @assertion_ids: JSF:SPEC:225; JSF:SPEC:226; JSF:SPEC:227
+     * 
+     * @test_Strategy: Validate that the jsf.js Resource is available via the
+     *                 "Page Declaration Language Approach".
+     * 
+     * @since 2.0
+     */
+    public void ajaxPDLResourceTest() throws Fault {
+  
+      this.validateScript(getPage(CONTEXT_ROOT + "/faces/pdlApproach.xhtml"));
+  
+    }// End ajaxPDLResourceTest
+  
+    private void validateScript(HtmlPage page) throws Fault {
+      StringBuilder messages = new StringBuilder(128);
+      Formatter formatter = new Formatter(messages);
+      String script = "script";
+  
+      // Test by Resource name.
+      HtmlScript resn = (HtmlScript) getElementOfTypeIncludingSrc(page, script,
+          RES_NAME);
+  
+      if (resn == null) {
+        formatter.format("Unexpected Test Result For %s Tag! %n"
+            + "Expected Src Attribute to contain: %s %n", script, RES_NAME);
+      }
+  
+      // Test by Resource Library name.
+      HtmlScript resl = (HtmlScript) getElementOfTypeIncludingSrc(page, script,
+          LIB_NAME);
+  
+      if (resl == null) {
+        formatter.format("Unexpected Test Result For %s Tag! %n"
+            + "Expected Src Attribute to contain: %s %n", script, LIB_NAME);
+      }
+  
+      handleTestStatus(messages);
+      formatter.close();
+    }
+  
+    private void validateKeyword(List<HtmlPage> pages, String buttonId,
+      String spanId, String expectedValue) throws Fault {
+      StringBuilder messages = new StringBuilder(128);
+      Formatter formatter = new Formatter(messages);
+  
+      String span = "span";
+      for (HtmlPage page : pages) {
+        HtmlSpan output = (HtmlSpan) getElementOfTypeIncludingId(page, span,
+            spanId);
+  
+        if (!validateExistence(spanId, span, output, formatter)) {
+          handleTestStatus(messages);
+          return;
+        }
+  
+        // First we'll check the first page was output correctly
+        validateElementValue(output, expectedValue, formatter);
+  
+        // Submit the ajax request
+        HtmlSubmitInput button = (HtmlSubmitInput) getElementOfTypeIncludingId(
+            page, "input", buttonId);
+        try {
+          button.click();
+        } catch (IOException ex) {
+          formatter.format("Unexpected Execption thrown while clicking '%s'.",
+              button.getId());
+          ex.printStackTrace();
+        }
+  
+        // Check that the ajax request succeeds - if the page is rewritten,
+        // this will be the same
+        validateElementValue(output, expectedValue, formatter);
+  
+        handleTestStatus(messages);
+      }
+    }
+  
+      /**
+     * Test for a the give @String "expectedValue" to match the value of the
+     * named @HtmlSpan "element "spanID".
+     * 
+     * @param page
+     *          - @HtmlPage that contains @HtmlSpan element.
+     * @param expectedValue
+     *          - The expected result.
+     * @param formatter
+     *          - used to gather test result output.
+     */
+    private void validateSpanTag(HtmlPage page, String spanId,
+        String expectedValue) throws Fault {
+      StringBuilder messages = new StringBuilder(128);
+      Formatter formatter = new Formatter(messages);
+  
+      HtmlSpan output = (HtmlSpan) getElementOfTypeIncludingId(page, SPAN,
+          spanId);
+  
+      if (!validateExistence(spanId, SPAN, output, formatter)) {
+        handleTestStatus(messages);
+        return;
+      }
+      validateElementValue(output, expectedValue, formatter);
+  
+    }// End validateSpanTag
 }

--- a/tck/old-tck-selenium/ajax/src/test/java/ee/jakarta/tck/faces/test/oldtck/ajax/AjaxTestsIT.java
+++ b/tck/old-tck-selenium/ajax/src/test/java/ee/jakarta/tck/faces/test/oldtck/ajax/AjaxTestsIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Contributors to the Eclipse Foundation.
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -28,7 +28,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.shrinkwrap.api.importer.ZipImporter;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
@@ -36,7 +35,6 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
-import org.junit.runner.RunWith;
 
 import com.gargoylesoftware.htmlunit.WebClient;
 import com.gargoylesoftware.htmlunit.html.HtmlInput;
@@ -45,8 +43,9 @@ import com.gargoylesoftware.htmlunit.html.HtmlScript;
 import com.gargoylesoftware.htmlunit.html.HtmlSpan;
 import com.gargoylesoftware.htmlunit.html.HtmlSubmitInput;
 
-@RunWith(Arquillian.class)
-public class AjaxTestsIT {
+import ee.jakarta.tck.faces.test.util.arquillian.ITBase;
+
+public class AjaxTestsIT extends ITBase {
 
     @ArquillianResource
     private URL webUrl;
@@ -178,6 +177,7 @@ public class AjaxTestsIT {
    * 
    * @since 2.0
    */
+  @Test
   public void ajaxFormKeywordTest() throws Exception {
 
     String EXPECTED = "testtext";
@@ -201,6 +201,7 @@ public class AjaxTestsIT {
    * 
    * @since 2.0
    */
+  @Test
   public void ajaxNoneKeywordTest() throws Exception {
 
     String EXPECTED = "testtext";

--- a/tck/old-tck-selenium/ajax/src/test/java/ee/jakarta/tck/faces/test/oldtck/ajax/AjaxTestsIT.java
+++ b/tck/old-tck-selenium/ajax/src/test/java/ee/jakarta/tck/faces/test/oldtck/ajax/AjaxTestsIT.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.faces.test.oldtck.ajax;
+
+import static java.lang.System.getProperty;
+import static org.jboss.shrinkwrap.api.ShrinkWrap.create;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.importer.ZipImporter;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import com.gargoylesoftware.htmlunit.WebClient;
+import com.gargoylesoftware.htmlunit.html.HtmlInput;
+import com.gargoylesoftware.htmlunit.html.HtmlPage;
+import com.gargoylesoftware.htmlunit.html.HtmlScript;
+import com.gargoylesoftware.htmlunit.html.HtmlSpan;
+import com.gargoylesoftware.htmlunit.html.HtmlSubmitInput;
+
+@RunWith(Arquillian.class)
+public class AjaxTestsIT {
+
+    @ArquillianResource
+    private URL webUrl;
+    private WebClient webClient;
+
+    @Deployment(testable = false)
+    public static WebArchive createDeployment() {
+        return create(ZipImporter.class, getProperty("finalName") + ".war")
+                .importFrom(new File("target/" + getProperty("finalName") + ".war"))
+                .as(WebArchive.class);
+    }
+
+    @Before
+    public void setUp() {
+        webClient = new WebClient();
+    }
+
+    @After
+    public void tearDown() {
+        webClient.close();
+    }
+
+}

--- a/tck/old-tck-selenium/ajax/src/test/java/ee/jakarta/tck/faces/test/oldtck/ajax_selenium/AjaxTestsIT.java
+++ b/tck/old-tck-selenium/ajax/src/test/java/ee/jakarta/tck/faces/test/oldtck/ajax_selenium/AjaxTestsIT.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.faces.test.oldtck.ajax_selenium;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.openqa.selenium.Keys.TAB;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+
+import ee.jakarta.tck.faces.test.util.selenium.BaseITNG;
+import ee.jakarta.tck.faces.test.util.selenium.WebPage;
+
+public class AjaxTestsIT extends BaseITNG {
+
+}

--- a/tck/old-tck-selenium/ajax/src/test/java/ee/jakarta/tck/faces/test/oldtck/ajax_selenium/AjaxTestsIT.java
+++ b/tck/old-tck-selenium/ajax/src/test/java/ee/jakarta/tck/faces/test/oldtck/ajax_selenium/AjaxTestsIT.java
@@ -33,54 +33,45 @@ import ee.jakarta.tck.faces.test.util.selenium.WebPage;
 
 public class AjaxTestsIT extends BaseITNG {
 
+
     @Test
     public void ajaxTagWrappingTest() throws Exception {
-      HtmlPage page = webClient.getPage(webUrl + "/faces/tagwrapper/ajaxTagWrap.xhtml");
+      WebPage page = getPage("faces/tagwrapper/ajaxTagWrap.xhtml");
 
       // First we'll check the first page was output correctly
-      HtmlSpan span1 = (HtmlSpan) page.getElementById("out1");
-      assertNotNull(span1);
-      assertEquals("0", span1.asNormalizedText());
+      WebElement span1 = page.findElement(By.id("out1"));
+      assertEquals("0", span1.getText());
 
-      HtmlSpan span2 = (HtmlSpan) page.getElementById("checkedvalue");
-      assertNotNull(span2);
-      assertEquals("false", span2.asNormalizedText());
+      WebElement span2 = page.findElement(By.id("checkedvalue"));
+      assertEquals("false", span2.getText());
 
-      HtmlSpan span3 = (HtmlSpan) page.getElementById("outtext");
-      assertNotNull(span3);
-      assertEquals("", span3.asNormalizedText());
+      WebElement span3 = page.findElement(By.id("outtext"));
+      assertEquals("", span3.getText());
   
       // Submit the ajax request
-      HtmlInput button1 = (HtmlInput) page.getElementById("button1");
+      WebElement button1 = page.findElement(By.id("button1"));
       assertNotNull(button1);
-      page = button1.click();
+      button1.click();
   
-      webClient.waitForBackgroundJavaScript(3000);
+      page.waitReqJs();
 
-      // Check that the ajax request succeeds - eventually.
-      span1 = (HtmlSpan) page.getElementById("out1");
-      assertEquals("1",span1.asNormalizedText());
+      // Check that the ajax request succeeds
+      span1 = page.findElement(By.id("out1"));
+      assertEquals("1", span1.getText());
   
-      // // Check on the text field
-      HtmlInput intext = (HtmlInput) page.getElementById("intext");
-      assertNotNull(intext);
-      intext.focus();
-      intext.type("test");
-      intext.blur();
-      webClient.waitForBackgroundJavaScript(3000);
-
-      span3 = (HtmlSpan) page.getElementById("outtext");
-      assertNotNull(span3);
-      assertEquals("test", span3.asNormalizedText());
+      // Check on the text field
+      WebElement intext = page.findElement(By.id("intext"));
+      intext.sendKeys("test");
+      intext.sendKeys(TAB); // click out of intext to force onchange event
+      page.waitReqJs();
+      assertTrue(page.findElement(By.id("outtext")).getText().equals("test"));
   
       // Check the checkbox
-      HtmlInput checkbox = (HtmlInput) page.getElementById("checkbox");
-      assertNotNull(checkbox);
-      page = (HtmlPage) checkbox.setChecked(true);
-      checkbox = (HtmlInput) page.getElementById("checkbox");
-      assertTrue(checkbox.isChecked());
-
-      // Check for "true" in outtext? Not originally tested (maybe due to HTMLUnit issues?). Will add to selenium run.
+      WebElement checkbox = page.findElement(By.id("checkbox"));
+      checkbox.click();
+      page.waitReqJs();
+      span2 = page.findElement(By.id("checkedvalue"));
+      assertEquals("true", span2.getText());
   
     }// End ajaxAllKeywordTest
 
@@ -98,9 +89,9 @@ public class AjaxTestsIT extends BaseITNG {
     String EXPECTED = "testtext";
 
     List<String> urls = new ArrayList<String>();
-    urls.add(webUrl + "/faces/keyword/ajaxAllKeyword1.xhtml");
-    urls.add(webUrl + "/faces/keyword/ajaxAllKeyword2.xhtml");
-    urls.add(webUrl + "/faces/keyword/ajaxAllKeyword3.xhtml");
+    urls.add("faces/keyword/ajaxAllKeyword1.xhtml");
+    urls.add("faces/keyword/ajaxAllKeyword2.xhtml");
+    urls.add("faces/keyword/ajaxAllKeyword3.xhtml");
 
     String buttonId = "form:allKeyword";
     String spanId = "form:out";
@@ -123,9 +114,9 @@ public class AjaxTestsIT extends BaseITNG {
     String EXPECTED = "testtext";
 
     List<String> urls = new ArrayList<String>();
-    urls.add(webUrl + "/faces/keyword/ajaxThisKeyword1.xhtml");
-    urls.add(webUrl + "/faces/keyword/ajaxThisKeyword2.xhtml");
-    urls.add(webUrl + "/faces/keyword/ajaxThisKeyword3.xhtml");
+    urls.add("faces/keyword/ajaxThisKeyword1.xhtml");
+    urls.add("faces/keyword/ajaxThisKeyword2.xhtml");
+    urls.add("faces/keyword/ajaxThisKeyword3.xhtml");
 
     String buttonId = "form:thisKeyword";
     String spanId = "form:out";
@@ -141,14 +132,15 @@ public class AjaxTestsIT extends BaseITNG {
    * 
    * @since 2.0
    */
+  @Test
   public void ajaxFormKeywordTest() throws Exception {
 
     String EXPECTED = "testtext";
 
     List<String> urls = new ArrayList<String>();
-    urls.add(webUrl + "/faces/keyword/ajaxFormKeyword1.xhtml");
-    urls.add(webUrl + "/faces/keyword/ajaxFormKeyword2.xhtml");
-    urls.add(webUrl + "/faces/keyword/ajaxFormKeyword3.xhtml");
+    urls.add("faces/keyword/ajaxFormKeyword1.xhtml");
+    urls.add("faces/keyword/ajaxFormKeyword2.xhtml");
+    urls.add("faces/keyword/ajaxFormKeyword3.xhtml");
 
     String buttonId = "form:formKeyword";
     String spanId = "form:out";
@@ -156,7 +148,7 @@ public class AjaxTestsIT extends BaseITNG {
     this.validateKeyword(urls, buttonId, spanId, EXPECTED);
   } // End ajaxThisKeywordTest
 
-  /**
+   /**
    * @testName: ajaxNoneKeywordTest
    * @assertion_ids: PENDING
    * @test_Strategy: Unsure the keyword 'none' works correctly with the f:ajax
@@ -164,14 +156,15 @@ public class AjaxTestsIT extends BaseITNG {
    * 
    * @since 2.0
    */
+  @Test
   public void ajaxNoneKeywordTest() throws Exception {
 
     String EXPECTED = "testtext";
 
     List<String> urls = new ArrayList<String>();
-    urls.add(webUrl + "/faces/keyword/ajaxNoneKeyword1.xhtml");
-    urls.add(webUrl + "/faces/keyword/ajaxNoneKeyword2.xhtml");
-    urls.add(webUrl + "/faces/keyword/ajaxNoneKeyword3.xhtml");
+    urls.add("faces/keyword/ajaxNoneKeyword1.xhtml");
+    urls.add("faces/keyword/ajaxNoneKeyword2.xhtml");
+    urls.add("faces/keyword/ajaxNoneKeyword3.xhtml");
 
     String buttonId = "form:noneKeyword";
     String spanId = "form:out";
@@ -189,18 +182,16 @@ public class AjaxTestsIT extends BaseITNG {
    * 
    * @since 2.0
    */
-  @Ignore("Skipped in  Old TCK for EE10")
   @Test
   public void ajaxPDLResourceTest() throws Exception {
 
-    HtmlPage page = webClient.getPage( webUrl + "/faces/jsresource/pdlApproach.xhtml");
-    HtmlScript script = (HtmlScript) page.getElementsByTagName("script").get(0);
-    assertNotNull(script);
+    WebPage page = getPage("faces/jsresource/pdlApproach.xhtml");
+    WebElement script = page.findElement(By.tagName("script"));
 
-    // Test by Resource name.
-    assertTrue(script.getSrcAttribute().contains("faces.js"));
-    // Test by Resource Library name.
-    assertTrue(script.getSrcAttribute().contains("jakarta.faces"));
+    // Verify Resource name.
+    assertTrue(script.getDomAttribute​("src").contains("faces.js"));
+    // Verify Resource Library name.
+    assertTrue(script.getDomAttribute​("src").contains("jakarta.faces"));
 
   }// End ajaxPDLResourceTest
 
@@ -210,25 +201,22 @@ public class AjaxTestsIT extends BaseITNG {
       String spanId, String expectedValue) throws Exception {
 
       for (String url : urls) {
-        HtmlPage page = webClient.getPage(url);
-        HtmlSpan output = (HtmlSpan) page.getElementById(spanId);
-        assertNotNull(output);
+        WebPage page = getPage(url);
+
+        WebElement output = page.findElement(By.id(spanId));
 
         // First we'll check the first page was output correctly
-        assertEquals(expectedValue, output.asNormalizedText());
+        assertEquals(expectedValue, output.getText());
 
         // Submit the ajax request
-        HtmlSubmitInput button = (HtmlSubmitInput) page.getElementById(buttonId);
-        page = button.click();
-
-        webClient.waitForBackgroundJavaScript(3000);
+        WebElement button = page.findElement(By.id(buttonId));
+        button.click();
+        page.waitReqJs();
 
         // Check that the ajax request succeeds - if the page is rewritten,
         // this will be the same
-        output = (HtmlSpan) page.getElementById(spanId);
-        assertNotNull(output);
-        assertEquals(expectedValue, output.asNormalizedText());
+        output = page.findElement(By.id(spanId));
+        assertEquals(expectedValue, output.getText());
       }
-  }
-  
+
 }

--- a/tck/old-tck-selenium/ajax/src/test/java/ee/jakarta/tck/faces/test/oldtck/ajax_selenium/AjaxTestsIT.java
+++ b/tck/old-tck-selenium/ajax/src/test/java/ee/jakarta/tck/faces/test/oldtck/ajax_selenium/AjaxTestsIT.java
@@ -33,4 +33,202 @@ import ee.jakarta.tck.faces.test.util.selenium.WebPage;
 
 public class AjaxTestsIT extends BaseITNG {
 
+    @Test
+    public void ajaxTagWrappingTest() throws Exception {
+      HtmlPage page = webClient.getPage(webUrl + "/faces/tagwrapper/ajaxTagWrap.xhtml");
+
+      // First we'll check the first page was output correctly
+      HtmlSpan span1 = (HtmlSpan) page.getElementById("out1");
+      assertNotNull(span1);
+      assertEquals("0", span1.asNormalizedText());
+
+      HtmlSpan span2 = (HtmlSpan) page.getElementById("checkedvalue");
+      assertNotNull(span2);
+      assertEquals("false", span2.asNormalizedText());
+
+      HtmlSpan span3 = (HtmlSpan) page.getElementById("outtext");
+      assertNotNull(span3);
+      assertEquals("", span3.asNormalizedText());
+  
+      // Submit the ajax request
+      HtmlInput button1 = (HtmlInput) page.getElementById("button1");
+      assertNotNull(button1);
+      page = button1.click();
+  
+      webClient.waitForBackgroundJavaScript(3000);
+
+      // Check that the ajax request succeeds - eventually.
+      span1 = (HtmlSpan) page.getElementById("out1");
+      assertEquals("1",span1.asNormalizedText());
+  
+      // // Check on the text field
+      HtmlInput intext = (HtmlInput) page.getElementById("intext");
+      assertNotNull(intext);
+      intext.focus();
+      intext.type("test");
+      intext.blur();
+      webClient.waitForBackgroundJavaScript(3000);
+
+      span3 = (HtmlSpan) page.getElementById("outtext");
+      assertNotNull(span3);
+      assertEquals("test", span3.asNormalizedText());
+  
+      // Check the checkbox
+      HtmlInput checkbox = (HtmlInput) page.getElementById("checkbox");
+      assertNotNull(checkbox);
+      page = (HtmlPage) checkbox.setChecked(true);
+      checkbox = (HtmlInput) page.getElementById("checkbox");
+      assertTrue(checkbox.isChecked());
+
+      // Check for "true" in outtext? Not originally tested (maybe due to HTMLUnit issues?). Will add to selenium run.
+  
+    }// End ajaxAllKeywordTest
+
+  /**
+   * @testName: ajaxAllKeywordTest
+   * @assertion_ids: PENDING
+   * @test_Strategy: Unsure the keyword 'all' works correctly with the f:ajax
+   *                 tag as value to 'execute' and 'render' attributes.
+   * 
+   * @since 2.0
+   */
+  @Test
+  public void ajaxAllKeywordTest() throws Exception {
+
+    String EXPECTED = "testtext";
+
+    List<String> urls = new ArrayList<String>();
+    urls.add(webUrl + "/faces/keyword/ajaxAllKeyword1.xhtml");
+    urls.add(webUrl + "/faces/keyword/ajaxAllKeyword2.xhtml");
+    urls.add(webUrl + "/faces/keyword/ajaxAllKeyword3.xhtml");
+
+    String buttonId = "form:allKeyword";
+    String spanId = "form:out";
+
+    this.validateKeyword(urls, buttonId, spanId, EXPECTED);
+
+  }// End ajaxAllKeywordTest
+
+  /**
+   * @testName: ajaxThisKeywordTest
+   * @assertion_ids: PENDING
+   * @test_Strategy: Unsure the keyword 'this' works correctly with the f:ajax
+   *                 tag as value to 'execute' and 'render' attributes.
+   * 
+   * @since 2.0
+   */
+  @Test
+  public void ajaxThisKeywordTest() throws Exception {
+
+    String EXPECTED = "testtext";
+
+    List<String> urls = new ArrayList<String>();
+    urls.add(webUrl + "/faces/keyword/ajaxThisKeyword1.xhtml");
+    urls.add(webUrl + "/faces/keyword/ajaxThisKeyword2.xhtml");
+    urls.add(webUrl + "/faces/keyword/ajaxThisKeyword3.xhtml");
+
+    String buttonId = "form:thisKeyword";
+    String spanId = "form:out";
+
+    this.validateKeyword(urls, buttonId, spanId, EXPECTED);
+  } // End ajaxThisKeywordTest
+
+  /**
+   * @testName: ajaxFormKeywordTest
+   * @assertion_ids: PENDING
+   * @test_Strategy: Unsure the keyword 'form' works correctly with the f:ajax
+   *                 tag as value to 'execute' and 'render' attributes.
+   * 
+   * @since 2.0
+   */
+  public void ajaxFormKeywordTest() throws Exception {
+
+    String EXPECTED = "testtext";
+
+    List<String> urls = new ArrayList<String>();
+    urls.add(webUrl + "/faces/keyword/ajaxFormKeyword1.xhtml");
+    urls.add(webUrl + "/faces/keyword/ajaxFormKeyword2.xhtml");
+    urls.add(webUrl + "/faces/keyword/ajaxFormKeyword3.xhtml");
+
+    String buttonId = "form:formKeyword";
+    String spanId = "form:out";
+
+    this.validateKeyword(urls, buttonId, spanId, EXPECTED);
+  } // End ajaxThisKeywordTest
+
+  /**
+   * @testName: ajaxNoneKeywordTest
+   * @assertion_ids: PENDING
+   * @test_Strategy: Unsure the keyword 'none' works correctly with the f:ajax
+   *                 tag as value to 'execute' and 'render' attributes.
+   * 
+   * @since 2.0
+   */
+  public void ajaxNoneKeywordTest() throws Exception {
+
+    String EXPECTED = "testtext";
+
+    List<String> urls = new ArrayList<String>();
+    urls.add(webUrl + "/faces/keyword/ajaxNoneKeyword1.xhtml");
+    urls.add(webUrl + "/faces/keyword/ajaxNoneKeyword2.xhtml");
+    urls.add(webUrl + "/faces/keyword/ajaxNoneKeyword3.xhtml");
+
+    String buttonId = "form:noneKeyword";
+    String spanId = "form:out";
+
+    this.validateKeyword(urls, buttonId, spanId, EXPECTED);
+  } // End ajaxThisKeywordTest
+
+  /**
+   * @testName: ajaxPDLResourceTest
+   * 
+   * @assertion_ids: JSF:SPEC:225; JSF:SPEC:226; JSF:SPEC:227
+   * 
+   * @test_Strategy: Validate that the jsf.js Resource is available via the
+   *                 "Page Declaration Language Approach".
+   * 
+   * @since 2.0
+   */
+  @Ignore("Skipped in  Old TCK for EE10")
+  @Test
+  public void ajaxPDLResourceTest() throws Exception {
+
+    HtmlPage page = webClient.getPage( webUrl + "/faces/jsresource/pdlApproach.xhtml");
+    HtmlScript script = (HtmlScript) page.getElementsByTagName("script").get(0);
+    assertNotNull(script);
+
+    // Test by Resource name.
+    assertTrue(script.getSrcAttribute().contains("faces.js"));
+    // Test by Resource Library name.
+    assertTrue(script.getSrcAttribute().contains("jakarta.faces"));
+
+  }// End ajaxPDLResourceTest
+
+
+  // HELPER METHODS
+  private void validateKeyword(List<String> urls, String buttonId,
+      String spanId, String expectedValue) throws Exception {
+
+      for (String url : urls) {
+        HtmlPage page = webClient.getPage(url);
+        HtmlSpan output = (HtmlSpan) page.getElementById(spanId);
+        assertNotNull(output);
+
+        // First we'll check the first page was output correctly
+        assertEquals(expectedValue, output.asNormalizedText());
+
+        // Submit the ajax request
+        HtmlSubmitInput button = (HtmlSubmitInput) page.getElementById(buttonId);
+        page = button.click();
+
+        webClient.waitForBackgroundJavaScript(3000);
+
+        // Check that the ajax request succeeds - if the page is rewritten,
+        // this will be the same
+        output = (HtmlSpan) page.getElementById(spanId);
+        assertNotNull(output);
+        assertEquals(expectedValue, output.asNormalizedText());
+      }
+  }
+  
 }

--- a/tck/old-tck-selenium/ajax/src/test/java/ee/jakarta/tck/faces/test/oldtck/ajax_selenium/AjaxTestsIT.java
+++ b/tck/old-tck-selenium/ajax/src/test/java/ee/jakarta/tck/faces/test/oldtck/ajax_selenium/AjaxTestsIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Contributors to the Eclipse Foundation.
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -24,6 +24,7 @@ import static org.openqa.selenium.Keys.TAB;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.junit.Ignore;
 import org.junit.Test;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
@@ -182,6 +183,7 @@ public class AjaxTestsIT extends BaseITNG {
    * 
    * @since 2.0
    */
+  @Ignore("Skipped in  Old TCK for EE10")
   @Test
   public void ajaxPDLResourceTest() throws Exception {
 
@@ -218,5 +220,6 @@ public class AjaxTestsIT extends BaseITNG {
         output = page.findElement(By.id(spanId));
         assertEquals(expectedValue, output.getText());
       }
+    }
 
 }

--- a/tck/old-tck-selenium/ajax/src/test/java/ee/jakarta/tck/faces/test/oldtck/ajax_selenium/Deployments.java
+++ b/tck/old-tck-selenium/ajax/src/test/java/ee/jakarta/tck/faces/test/oldtck/ajax_selenium/Deployments.java
@@ -1,0 +1,21 @@
+package ee.jakarta.tck.faces.test.oldtck.ajax_selenium;
+
+import ee.jakarta.tck.faces.test.util.selenium.BaseITNG;
+import org.eu.ingwar.tools.arquillian.extension.suite.annotations.ArquillianSuiteDeployment;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+
+/**
+ * Given Arquilian has no single deployment testsuite
+ * mechanism we have to rely on a third party library.
+ * This improves the performance in a major area, namely
+ * we are only deploying once and then run all tests
+ * on the same deployment (cuts down by 95% the test time)
+ */
+@ArquillianSuiteDeployment
+public class Deployments {
+    @Deployment(testable = false)
+    public static WebArchive createDeployment() {
+        return BaseITNG.createDeployment();
+    }
+}

--- a/tck/old-tck-selenium/ajax/src/test/java/ee/jakarta/tck/faces/test/oldtck/ajax_selenium/Deployments.java
+++ b/tck/old-tck-selenium/ajax/src/test/java/ee/jakarta/tck/faces/test/oldtck/ajax_selenium/Deployments.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ * 
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GPL-2.0 with Classpath-exception-2.0 which 
+ * is available at https://openjdk.java.net/legal/gplv2+ce.html.
+ * 
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 or Apache-2.0
+ */
+
 package ee.jakarta.tck.faces.test.oldtck.ajax_selenium;
 
 import ee.jakarta.tck.faces.test.util.selenium.BaseITNG;

--- a/tck/old-tck-selenium/commandLink/pom.xml
+++ b/tck/old-tck-selenium/commandLink/pom.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2021 Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.eclipse.ee4j.tck.faces.old-tck-selenium</groupId>
+        <artifactId>pom</artifactId>
+        <version>4.0.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>commandLink</artifactId>
+    <packaging>war</packaging>
+
+    <name>Jakarta Faces TCK ${project.version} - Test - Old TCK Port - commandLink</name>
+
+    <build>
+        <finalName>old-tck-commandLink</finalName>
+    </build>
+</project>

--- a/tck/old-tck-selenium/commandLink/pom.xml
+++ b/tck/old-tck-selenium/commandLink/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2021 Contributors to Eclipse Foundation.
+    Copyright (c) 2023 Contributors to Eclipse Foundation.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/tck/old-tck-selenium/commandLink/src/main/java/com/sun/ts/tests/jsf/spec/render/commandlink/AttributeBean.java
+++ b/tck/old-tck-selenium/commandLink/src/main/java/com/sun/ts/tests/jsf/spec/render/commandlink/AttributeBean.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2012, 2018 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+/*
+ * $Id$
+ */
+
+ package com.sun.ts.tests.jsf.spec.render.commandlink;
+
+ import java.util.HashMap;
+ import java.util.Map;
+ import java.io.Serializable;
+ 
+ @jakarta.inject.Named("Attribute") @jakarta.enterprise.context.SessionScoped
+ public class AttributeBean implements Serializable {
+ 
+   private static final long serialVersionUID = -2564380871083456327L;
+   
+   private Map<String, Object> attMap = new HashMap<String, Object>();
+ 
+   {
+     attMap.put("manyattone", "manyOne");
+     attMap.put("manyatttwo", "manyTwo");
+     attMap.put("manyattthree", "manyThree");
+   }
+ 
+   public Map<String, Object> getAttMap() {
+     return attMap;
+   }
+ 
+   public void setAttMap(Map<String, Object> attMap) {
+     this.attMap = attMap;
+   }
+ 
+ }
+ 

--- a/tck/old-tck-selenium/commandLink/src/main/java/com/sun/ts/tests/jsf/spec/render/commandlink/CommandLinkUIBean.java
+++ b/tck/old-tck-selenium/commandLink/src/main/java/com/sun/ts/tests/jsf/spec/render/commandlink/CommandLinkUIBean.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+/*
+ * $Id$
+ */
+
+ package com.sun.ts.tests.jsf.spec.render.commandlink;
+
+ import jakarta.faces.component.html.HtmlCommandLink;
+ 
+ @jakarta.inject.Named("linker") @jakarta.enterprise.context.RequestScoped
+ public class CommandLinkUIBean {
+ 
+   private HtmlCommandLink gothere;
+ 
+   public HtmlCommandLink getGothere() {
+     return gothere;
+   }
+ 
+   public void setGothere(HtmlCommandLink gothere) {
+     // Set some defaults for testing.
+     gothere.setStyleClass("sansserif");
+     gothere.setTitle("gone");
+     gothere.setShape("rectangle");
+ 
+     this.gothere = gothere;
+   }
+ 
+ }
+ 

--- a/tck/old-tck-selenium/commandLink/src/main/java/com/sun/ts/tests/jsf/spec/render/commandlink/SimpleActionListener.java
+++ b/tck/old-tck-selenium/commandLink/src/main/java/com/sun/ts/tests/jsf/spec/render/commandlink/SimpleActionListener.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+/*
+ * $Id$
+ */
+
+ package com.sun.ts.tests.jsf.spec.render.commandlink;
+
+ import java.util.Map;
+ import java.io.Serializable;
+ 
+ import jakarta.faces.component.UIComponent;
+ import jakarta.faces.context.ExternalContext;
+ import jakarta.faces.context.FacesContext;
+ import jakarta.faces.event.AbortProcessingException;
+ import jakarta.faces.event.ActionEvent;
+ import jakarta.faces.event.ActionListener;
+ import jakarta.servlet.http.HttpServletResponse;
+ 
+ @jakarta.inject.Named("ActionListener") @jakarta.enterprise.context.SessionScoped
+ public class SimpleActionListener implements ActionListener, Serializable {
+ 
+   private static final long serialVersionUID = -2123380871083456327L;
+ 
+   /**
+    * <p>
+    * Invoked when the action described by the specified
+    * {@link jakarta.faces.event.ActionEvent} occurs.
+    * </p>
+    *
+    * @param event
+    *          The {@link jakarta.faces.event.ActionEvent} that has occurred
+    *
+    * @throws jakarta.faces.event.AbortProcessingException
+    *           Signal the JavaServer Faces implementation that no further
+    *           processing on the current event should be performed
+    */
+   public void processAction(ActionEvent event) throws AbortProcessingException {
+ 
+     UIComponent component = event.getComponent();
+     ExternalContext extContext = FacesContext.getCurrentInstance()
+         .getExternalContext();
+     HttpServletResponse response = (HttpServletResponse) extContext
+         .getResponse();
+     Map<String, String> requestParamMap = extContext.getRequestParameterMap();
+     String expectedId = requestParamMap.get("expectedId");
+ 
+     if (expectedId == null) {
+       response.addHeader("actionEvent",
+           "Test error.  Can't find expected" + " component ID.");
+     } else {
+ 
+       if (!expectedId.equals(component.getId())) {
+         response.addHeader("actionEvent", "Expected component ID '" + expectedId
+             + "', received: '" + component.getId() + '\'');
+       } else {
+         response.addHeader("actionEventOK", "PASSED");
+       }
+     }
+   }
+ }
+ 

--- a/tck/old-tck-selenium/commandLink/src/main/java/com/sun/ts/tests/jsf/spec/render/commandlink/SimpleActionListener.java
+++ b/tck/old-tck-selenium/commandLink/src/main/java/com/sun/ts/tests/jsf/spec/render/commandlink/SimpleActionListener.java
@@ -31,7 +31,7 @@
  import jakarta.faces.event.ActionListener;
  import jakarta.servlet.http.HttpServletResponse;
  
- @jakarta.inject.Named("ActionListener") @jakarta.enterprise.context.RequestScoped
+ @jakarta.inject.Named("ActionListener") @jakarta.enterprise.context.SessionScoped
  public class SimpleActionListener implements ActionListener, Serializable {
  
    private static final long serialVersionUID = -2123380871083456327L;
@@ -67,7 +67,7 @@
        response.addHeader("actionEvent",
            "Test error.  Can't find expected" + " component ID.");
        // Selenium Result ID Check
-       result = "FAILED. Can't find expected component ID"
+       result = "FAILED. Can't find expected component ID";
      } else {
  
        if (!expectedId.equals(component.getId())) {

--- a/tck/old-tck-selenium/commandLink/src/main/java/com/sun/ts/tests/jsf/spec/render/commandlink/SimpleActionListener.java
+++ b/tck/old-tck-selenium/commandLink/src/main/java/com/sun/ts/tests/jsf/spec/render/commandlink/SimpleActionListener.java
@@ -31,11 +31,15 @@
  import jakarta.faces.event.ActionListener;
  import jakarta.servlet.http.HttpServletResponse;
  
- @jakarta.inject.Named("ActionListener") @jakarta.enterprise.context.SessionScoped
+ @jakarta.inject.Named("ActionListener") @jakarta.enterprise.context.RequestScoped
  public class SimpleActionListener implements ActionListener, Serializable {
  
    private static final long serialVersionUID = -2123380871083456327L;
  
+   
+   /* Selenium doens't allow response header inspection, so the result is set here and displayed on the page */
+   private String result = "";
+
    /**
     * <p>
     * Invoked when the action described by the specified
@@ -62,15 +66,27 @@
      if (expectedId == null) {
        response.addHeader("actionEvent",
            "Test error.  Can't find expected" + " component ID.");
+       // Selenium Result ID Check
+       result = "FAILED. Can't find expected component ID"
      } else {
  
        if (!expectedId.equals(component.getId())) {
          response.addHeader("actionEvent", "Expected component ID '" + expectedId
              + "', received: '" + component.getId() + '\'');
+         // For Selenium    
+         result = "FAILED. " + "Expected component ID '" + expectedId
+             + "', received: '" + component.getId() + '\'';
        } else {
          response.addHeader("actionEventOK", "PASSED");
+         // Selenium
+         result = "PASSED";
        }
      }
    }
+
+   public String getResult() {
+    return result;
+   }
+
  }
  

--- a/tck/old-tck-selenium/commandLink/src/main/webapp/WEB-INF/beans.xml
+++ b/tck/old-tck-selenium/commandLink/src/main/webapp/WEB-INF/beans.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2022 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+
+<beans xmlns="https://jakarta.ee/xml/ns/jakartaee" 
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_4_0.xsd" 
+        bean-discovery-mode="all">
+</beans>

--- a/tck/old-tck-selenium/commandLink/src/main/webapp/WEB-INF/beans.xml
+++ b/tck/old-tck-selenium/commandLink/src/main/webapp/WEB-INF/beans.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2022 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2022, 2023 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/tck/old-tck-selenium/commandLink/src/main/webapp/WEB-INF/faces-config.xml
+++ b/tck/old-tck-selenium/commandLink/src/main/webapp/WEB-INF/faces-config.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2009, 2018 Oracle and/or its affiliates. All rights reserved.
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+-->
+
+<faces-config xmlns="https://jakarta.ee/xml/ns/jakartaee"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-facesconfig_3_0.xsd"
+    version="3.0">
+</faces-config>

--- a/tck/old-tck-selenium/commandLink/src/main/webapp/WEB-INF/faces-config.xml
+++ b/tck/old-tck-selenium/commandLink/src/main/webapp/WEB-INF/faces-config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2009, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2005, 2023 Oracle and/or its affiliates. All rights reserved.
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
     http://www.eclipse.org/legal/epl-2.0.
@@ -14,6 +14,6 @@
 
 <faces-config xmlns="https://jakarta.ee/xml/ns/jakartaee"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-facesconfig_3_0.xsd"
-    version="3.0">
+    xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-facesconfig_4_0.xsd"
+    version="4.0">
 </faces-config>

--- a/tck/old-tck-selenium/commandLink/src/main/webapp/WEB-INF/web.xml
+++ b/tck/old-tck-selenium/commandLink/src/main/webapp/WEB-INF/web.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2005, 2020 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<web-app version="5.0"
+         xmlns="https://jakarta.ee/xml/ns/jakartaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-app_5_0.xsd">
+    <display-name>jsf_render_clink</display-name>
+
+    <context-param>
+        <param-name>com.sun.faces.validateXml</param-name>
+        <param-value>true</param-value>
+    </context-param>
+    
+    <servlet>
+        <servlet-name>Faces Servlet</servlet-name>
+        <servlet-class>jakarta.faces.webapp.FacesServlet</servlet-class>
+    </servlet>
+    <servlet-mapping>
+        <servlet-name>Faces Servlet</servlet-name>
+        <url-pattern>/faces/*</url-pattern>
+    </servlet-mapping>    
+    <session-config>
+        <session-timeout>54</session-timeout>
+    </session-config>
+</web-app>

--- a/tck/old-tck-selenium/commandLink/src/main/webapp/WEB-INF/web.xml
+++ b/tck/old-tck-selenium/commandLink/src/main/webapp/WEB-INF/web.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2005, 2020 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2005, 2023 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -16,11 +16,12 @@
     SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
 
 -->
+<web-app
+    xmlns="https://jakarta.ee/xml/ns/jakartaee"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-app_6_0.xsd"
+    version="6.0">
 
-<web-app version="5.0"
-         xmlns="https://jakarta.ee/xml/ns/jakartaee"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-app_5_0.xsd">
     <display-name>jsf_render_clink</display-name>
 
     <context-param>

--- a/tck/old-tck-selenium/commandLink/src/main/webapp/decodetest_facelet.xhtml
+++ b/tck/old-tck-selenium/commandLink/src/main/webapp/decodetest_facelet.xhtml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2009, 2022 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en"
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core">
+    <head>
+        <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+        <title>decodetest_facelet</title>
+    </head>
+    <body>
+    <h:form>
+        <h:commandLink id="link1"
+                       value="Click Me"
+                       actionListener="#{ActionListener.processAction}"/>
+        <h:commandLink id="link2"
+                       value="#{'Click Me'}"
+                       type="submit"/>
+        <input type="hidden" name="expectedId" value="link1"/>
+    </h:form>
+  </body>
+</html>

--- a/tck/old-tck-selenium/commandLink/src/main/webapp/decodetest_facelet.xhtml
+++ b/tck/old-tck-selenium/commandLink/src/main/webapp/decodetest_facelet.xhtml
@@ -35,5 +35,6 @@
                        type="submit"/>
         <input type="hidden" name="expectedId" value="link1"/>
     </h:form>
+    <h:outputText id="result" value="#{ActionListener.result}"/>
   </body>
 </html>

--- a/tck/old-tck-selenium/commandLink/src/main/webapp/decodetest_facelet.xhtml
+++ b/tck/old-tck-selenium/commandLink/src/main/webapp/decodetest_facelet.xhtml
@@ -26,7 +26,7 @@
         <title>decodetest_facelet</title>
     </head>
     <body>
-    <h:form>
+    <h:form id="form">
         <h:commandLink id="link1"
                        value="Click Me"
                        actionListener="#{ActionListener.processAction}"/>

--- a/tck/old-tck-selenium/commandLink/src/main/webapp/encodetest_facelet.xhtml
+++ b/tck/old-tck-selenium/commandLink/src/main/webapp/encodetest_facelet.xhtml
@@ -29,7 +29,7 @@
     <p>
       TODO write content
     </p>
-    <h:form>
+    <h:form id="form">
       <p>
         CommandLink 1
       </p>

--- a/tck/old-tck-selenium/commandLink/src/main/webapp/encodetest_facelet.xhtml
+++ b/tck/old-tck-selenium/commandLink/src/main/webapp/encodetest_facelet.xhtml
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2009, 2022 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en"
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+    <title>encodetest_facelet</title>
+  </head>
+  <body>
+    <p>
+      TODO write content
+    </p>
+    <h:form>
+      <p>
+        CommandLink 1
+      </p>
+      <h:commandLink id="link1" value="Click Me1"/>
+      <p>
+        CommandLink 2
+      </p>
+      <h:commandLink id="link2"
+                     styleClass="#{'sansserif'}"
+                     value="Click Me2"/>
+      <p>
+        CommandLink 3
+      </p>
+      <h:commandLink id="link3">
+        <h:outputText value="Click Me3"/>
+      </h:commandLink>
+      <p>
+        CommandLink 4
+      </p>
+      <h:commandLink id="link4" value="#{'Click Me4'}">
+        <f:param name="param1" value="value1"/>
+        <f:param name="param2" value="value2"/>
+      </h:commandLink>
+      <p>
+        CommandLink 5
+      </p>
+      <h:commandLink id="link5"
+                     value="Disabled Link"
+                     disabled="true"
+                     styleClass="sansserif"/>
+      <p>
+        CommandLink 6
+      </p>
+      <h:commandLink id="link6"
+                     disabled="true">
+        <h:outputText value="Disabled Link(Nested)"/>
+      </h:commandLink>
+      <p>
+        CommandLink 7
+      </p>
+      <h:commandLink id="link7"
+                     value="go there"
+                     binding="#{linker.gothere}"/>
+    </h:form>
+  </body>
+</html>

--- a/tck/old-tck-selenium/commandLink/src/main/webapp/passthroughtest.xhtml
+++ b/tck/old-tck-selenium/commandLink/src/main/webapp/passthroughtest.xhtml
@@ -1,0 +1,79 @@
+<!--
+
+    Copyright (c) 2009, 2018 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+
+
+
+<html xmlns:f="jakarta.faces.core" xmlns:h="jakarta.faces.html">
+<head>
+    <title>passthroughtest</title>
+</head>
+
+<body>
+<f:view>
+    <h:form>
+        <h:commandLink id="link1"
+                       accesskey="U"
+                       charset="ISO-8859-1"
+                       coords="31,45"
+                       dir="LTR"                       
+                       hreflang="en"
+                       lang="en"
+                       onblur="js1"                                              
+                       ondblclick="js3"
+                       onfocus="js4"
+                       onkeydown="js5"
+                       onkeypress="js6"
+                       onkeyup="js7"
+                       onmousedown="js8"
+                       onmousemove="js9"
+                       onmouseout="js10"
+                       onmouseover="js11"
+                       onmouseup="js12"                        
+                       rel="somevalue"
+                       rev="revsomevalue"
+                       shape="rect"
+                       style="Color: red;"
+                       tabindex="0"
+                       title="sample"
+                       type="type"
+                       value="link1"/>
+        <h:commandLink id="link2"
+                       accesskey="U"
+                       dir="LTR"
+                       disabled="true"
+                       lang="en"
+                       onblur="js1"                                               
+                       ondblclick="js3"
+                       onfocus="js4"
+                       onkeydown="js5"
+                       onkeypress="js6"
+                       onkeyup="js7"
+                       onmousedown="js8"
+                       onmousemove="js9"
+                       onmouseout="js10"
+                       onmouseover="js11"
+                       onmouseup="js12"                        
+                       style="Color: red;"
+                       tabindex="0"
+                       title="sample"
+                       value="link2"/>
+    </h:form>
+</f:view>
+</body>
+</html>

--- a/tck/old-tck-selenium/commandLink/src/main/webapp/passthroughtest.xhtml
+++ b/tck/old-tck-selenium/commandLink/src/main/webapp/passthroughtest.xhtml
@@ -26,7 +26,7 @@
 
 <body>
 <f:view>
-    <h:form>
+    <h:form id="form">
         <h:commandLink id="link1"
                        accesskey="U"
                        charset="ISO-8859-1"

--- a/tck/old-tck-selenium/commandLink/src/main/webapp/passthroughtest_facelet.xhtml
+++ b/tck/old-tck-selenium/commandLink/src/main/webapp/passthroughtest_facelet.xhtml
@@ -30,7 +30,7 @@
 <title>passthroughtest_facelet</title>
 </head>
 <body>
-	<h:form>
+	<h:form id="form">
 		<p>CommandLink 1</p>
 		<h:commandLink p:foo="bar" id="link1" accesskey="U"
 			charset="ISO-8859-1" coords="31,45" dir="LTR" hreflang="en" lang="en"

--- a/tck/old-tck-selenium/commandLink/src/main/webapp/passthroughtest_facelet.xhtml
+++ b/tck/old-tck-selenium/commandLink/src/main/webapp/passthroughtest_facelet.xhtml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2009, 2022 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<!-- 
+	$Id$
+ -->
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en"
+	xmlns:h="jakarta.faces.html"
+	xmlns:f="jakarta.faces.core"
+	xmlns:p="jakarta.faces.passthrough">
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+<title>passthroughtest_facelet</title>
+</head>
+<body>
+	<h:form>
+		<p>CommandLink 1</p>
+		<h:commandLink p:foo="bar" id="link1" accesskey="U"
+			charset="ISO-8859-1" coords="31,45" dir="LTR" hreflang="en" lang="en"
+			onblur="js1" ondblclick="js3" onfocus="js4" onkeydown="js5"
+			onkeypress="js6" onkeyup="js7" onmousedown="js8" onmousemove="js9"
+			onmouseout="js10" onmouseover="js11" onmouseup="js12" rel="somevalue"
+			rev="revsomevalue" shape="rect" style="Color: red;" tabindex="0"
+			title="sample" type="type" value="link1">
+
+			<f:passThroughAttribute name="singleatt" value="singleAtt" />
+			<f:passThroughAttributes value="#{Attribute.attMap}" />
+
+		</h:commandLink>
+
+		<p>CommandLink 2</p>
+		<h:commandLink p:foo="bar" id="link2" accesskey="U"
+			dir="LTR" disabled="true"
+			lang="en" onblur="js1" ondblclick="js3" onfocus="js4"
+			onkeydown="js5" onkeypress="js6" onkeyup="js7" onmousedown="js8"
+			onmousemove="js9" onmouseout="js10" onmouseover="js11"
+			onmouseup="js12"
+			style="Color: red;" tabindex="0" title="sample"
+			value="link2">
+
+			<f:passThroughAttribute name="singleatt" value="singleAtt" />
+			<f:passThroughAttributes value="#{Attribute.attMap}" />
+			
+		</h:commandLink>
+	</h:form>
+</body>
+</html>

--- a/tck/old-tck-selenium/commandLink/src/test/java/ee/jakarta/tck/faces/test/oldtck/commandlink/CommandLinkTestsIT.java
+++ b/tck/old-tck-selenium/commandLink/src/test/java/ee/jakarta/tck/faces/test/oldtck/commandlink/CommandLinkTestsIT.java
@@ -71,5 +71,408 @@ public class CommandLinkTestsIT {
         webClient.close();
     }
 
+     /*
+   * @class.setup_props: webServerHost; webServerPort; ts_home;
+   */
+  /**
+   * @testName: clinkRenderEncodeTest
+   * 
+   * @assertion_ids: PENDING
+   * 
+   * @test_Strategy: Ensure proper CommandLink rendering: - case 1: Anchor has
+   *                 href value of '#' Anchor display value is "Click Me1"
+   *                 Anchor onclick attribute value has a non-zero length
+   * 
+   *                 - case 2: Anchor has href value of '#' Anchor display value
+   *                 is "Click Me2" The styleClass tag attribute is rendered as
+   *                 the class attribute on the rendered anchor Anchor onclick
+   *                 attribute value has a non-zero length
+   * 
+   *                 - case 3: Anchor has href value of '#' Anchor has display
+   *                 value of "Click Me3" which is specified as a nested
+   *                 HtmlOutput tag. Anchor onclick attribute value has a
+   *                 non-zero length
+   * 
+   *                 - case 4: REMOVED CODE DUE TO BUG ID:6460959
+   * 
+   *                 - case 5: CommandLink has the disabled attribute set to
+   *                 true. Ensure that: A span element is rendered instead of an
+   *                 anchor The span has no onclick content The display value of
+   *                 the span is 'Disabled Link' The styleClass tag attribute is
+   *                 rendered as the class attribute on the rendered span
+   *                 element
+   * 
+   *                 - case 6: CommandLink has the disabled attribute set to
+   *                 true with a nested output component as the link's textual
+   *                 value.
+   * 
+   *                 - case 7: CommandLink is tied to a backend bean via the
+   *                 "binding" attribute. Test to make sure that the "title",
+   *                 "shape" & "styleclass" are set and rendered correctly.
+   * 
+   * @since 1.2
+   */
+  public void clinkRenderEncodeTest() throws Fault {
+
+    StringBuilder messages = new StringBuilder(64);
+    Formatter formatter = new Formatter(messages);
+
+    List<HtmlPage> pages = new ArrayList<HtmlPage>();
+    pages.add(getPage(CONTEXT_ROOT + "/faces/encodetest_facelet.xhtml"));
+
+    for (HtmlPage page : pages) {
+
+      HtmlAnchor link1 = (HtmlAnchor) getElementOfTypeIncludingId(page, "a",
+          "link1");
+
+      if (link1 == null) {
+        formatter.format("Unable to find achor with ID containing 'link1'. %n");
+      } else {
+        if (!"#".equals(link1.getHrefAttribute())) {
+          formatter.format(
+              "Unexpected value for attribute 'href'. "
+                  + "Expected '#', received: '%s' %n",
+              link1.getHrefAttribute());
+        }
+
+        if (!"Click Me1".equals(link1.asNormalizedText())) {
+          formatter.format("Unexpected anchor text. %n" + "Expected: '%s' %n"
+              + "Received: '%s' %n", "Click Me1", link1.asNormalizedText());
+        }
+
+        if (link1.getOnClickAttribute().length() < 0) {
+          formatter.format("Expected some render specific content "
+              + "to be rendered in the 'onclick' attribute for "
+              + "the anchor, but no content was found. %n");
+        }
+      }
+
+      HtmlAnchor link2 = (HtmlAnchor) getElementOfTypeIncludingId(page, "a",
+          "link2");
+
+      if (link2 == null) {
+        formatter.format("Unable to find achor with ID containing 'link1'. %n");
+      } else {
+        if (!"#".equals(link2.getHrefAttribute())) {
+          formatter.format(
+              "Unexpected value for attribute 'href'. "
+                  + "Expected '#', received: '%s' %n",
+              link2.getHrefAttribute());
+        }
+
+        if (!"Click Me2".equals(link2.asNormalizedText())) {
+          formatter.format("Unexpected anchor text. %n" + "Expected '%s' %n"
+              + "Received: '%s' %n", "Click Me2", link2.asNormalizedText());
+        }
+
+        if (!"sansserif".equals(link2.getAttribute("class"))) {
+          formatter.format(
+              "Unexpected value for class attribute. "
+                  + "Expected 'sansserif' %n" + "Received: '%s'",
+              link2.getAttribute("style"));
+        }
+
+        if (link2.getOnClickAttribute().length() < 0) {
+          formatter.format("Expected some render specific content "
+              + "to be rendered in the 'onclick' attribute for "
+              + "the anchor, but no content was found. %n");
+        }
+      }
+
+      HtmlAnchor link3 = (HtmlAnchor) getElementOfTypeIncludingId(page, "a",
+          "link3");
+
+      if (link3 == null) {
+        formatter.format("Unable to find achor with ID containing 'link3'. %n");
+      } else {
+        if (!"#".equals(link3.getHrefAttribute())) {
+          formatter.format(
+              "Unexpected value for attribute 'href'. "
+                  + "Expected '#', received: '%s' %n",
+              link3.getHrefAttribute());
+        }
+
+        if (!"Click Me3".equals(link3.asNormalizedText())) {
+          formatter.format("Unexpected anchor text.  "
+              + "Expected 'Click M3'to be the anchor text "
+              + "when specified as a nested child (HtmlOutput), "
+              + "but received: '%s' %n", link3.asNormalizedText());
+        }
+
+        if (link3.getOnClickAttribute().length() < 0) {
+          formatter.format("Expected some render specific content "
+              + "to be rendered in the 'onclick' attribute for "
+              + "the anchor, but no content was found. %n");
+        }
+      }
+
+      // ----------------------------------------------------------- case
+      // 5
+      HtmlSpan span = (HtmlSpan) getElementOfTypeIncludingId(page, "span",
+          "link5");
+
+      if (span == null) {
+        formatter.format("Unable to find a span element with an ID"
+            + " containing 'link5' %n");
+      } else {
+        if (!"sansserif".equals(span.getAttribute("class"))) {
+          formatter.format("Unexpected value for class attribute "
+              + "for the rendered span element when CommandLink "
+              + "is disabled. Expected 'sansserif'%n, " + "but received '%s'%n",
+              span.getAttribute("class"));
+        }
+
+        if (!"Disabled Link".equals(span.asNormalizedText())) {
+          formatter.format(
+              "Unexpected textual value for rendered "
+                  + "span element when command link is disabled%n.  "
+                  + "Expected 'Disabled Link'%n, but received '%s'%n",
+              span.asNormalizedText());
+        }
+
+        if (span.getOnClickAttribute().length() > 0) {
+          formatter.format("Expected no render specific content "
+              + "to be rendered in the 'onclick' attribute for "
+              + "the span element, but content was found. %n");
+        }
+      }
+
+      // ----------------------------------------------------------- case
+      // 6
+      HtmlSpan span2 = (HtmlSpan) getElementOfTypeIncludingId(page, "span",
+          "link6");
+
+      if (span2 == null) {
+        formatter.format("Unable to find a span element with an ID"
+            + " containing 'link6' %n");
+      } else {
+        if (!"Disabled Link(Nested)".equals(span2.asNormalizedText())) {
+          formatter.format("Unexpected textual value for rendered "
+              + "span element when command link is disabled. "
+              + "Expected 'Disabled Link(Nested)', " + "but received '%s' %n",
+              span2.asNormalizedText());
+        }
+      }
+
+      // ----------------------------------------------------------- case
+      // 7
+      HtmlAnchor span7 = (HtmlAnchor) getElementOfTypeIncludingId(page, "a",
+          "link7");
+
+      if (span7 == null) {
+        formatter.format(
+            "Unable to find a span element with an ID" + " containing 'link7'");
+      } else {
+        if (!"sansserif".equals(span7.getAttribute("class"))) {
+          formatter.format("Unexpected value for class attribute " + "for "
+              + "the rendered anchor element when CommandLink is "
+              + "disabled. Expected 'sansserif'%n, " + "but received '%s'%n",
+              span7.getAttribute("class"));
+        }
+
+        if (!"rectangle".equals(span7.getShapeAttribute())) {
+          formatter.format("Unexpected value for shape attribute "
+              + "for the rendered anchor element when "
+              + "CommandLink is disabled. Expected 'gone'%n, "
+              + "but received '%s'%n", span7.getShapeAttribute());
+        }
+
+        if (!"gone".equals(span7.getAttribute("title"))) {
+          formatter.format("Unexpected value for title attribute "
+              + "for the rendered anchor element when "
+              + "CommandLink is disabled. Expected 'gone'%n, "
+              + "but received '%s'%n", span7.getAttribute("title"));
+        }
+      }
+
+      handleTestStatus(messages);
+    }
+  } // END clinkRenderEncodeTest
+
+  /**
+   * @testName: clinkRenderDecodeTest
+   * 
+   * @assertion_ids: PENDING
+   * 
+   * @test_Strategy:
+   * 
+   * @since 1.2
+   */
+  public void clinkRenderDecodeTest() throws Fault {
+    StringBuilder messages = new StringBuilder(64);
+    Formatter formatter = new Formatter(messages);
+
+    List<HtmlPage> pages = new ArrayList<HtmlPage>();
+    pages.add(getPage(CONTEXT_ROOT + "/faces/decodetest_facelet.xhtml"));
+
+    for (HtmlPage page : pages) {
+      HtmlAnchor link1 = (HtmlAnchor) getElementOfTypeIncludingId(page, "a",
+          "link1");
+      try {
+        HtmlPage postBack = (HtmlPage) link1.click();
+        // Check to see if an error header was returned
+        String msgHeader = postBack.getWebResponse()
+            .getResponseHeaderValue("actionEvent");
+        if (msgHeader != null) {
+          formatter.format(msgHeader + "%n");
+        } else {
+          // Check for non-error header
+          msgHeader = postBack.getWebResponse()
+              .getResponseHeaderValue("actionEventOK");
+          if (msgHeader == null) {
+            formatter.format("ActionListener was not invoked "
+                + "when CommandButton 'command1' was clicked.%n");
+          }
+
+        }
+      } catch (IOException e) {
+        throw new Fault(e);
+      }
+
+      handleTestStatus(messages);
+    }
+
+  } // END clinkRenderDecodeTest
+
+  /**
+   * @testName: clinkRenderPassthroughTest
+   * 
+   * @assertion_ids: PENDING
+   * 
+   * @test_Strategy: Ensure those attributes marked as passthrough are indeed
+   *                 visible in the rendered markup as specified in the JSP
+   *                 page.
+   * 
+   * @since 1.2
+   */
+  public void clinkRenderPassthroughTest() throws Fault {
+
+    TreeMap<String, String> control = new TreeMap<String, String>();
+    control.put("accesskey", "U");
+    control.put("charset", "ISO-8859-1");
+    control.put("coords", "31,45");
+    control.put("dir", "LTR");
+    control.put("hreflang", "en");
+    control.put("lang", "en");
+    control.put("onblur", "js1");
+    control.put("ondblclick", "js3");
+    control.put("onfocus", "js4");
+    control.put("onkeydown", "js5");
+    control.put("onkeypress", "js6");
+    control.put("onkeyup", "js7");
+    control.put("onmousedown", "js8");
+    control.put("onmousemove", "js9");
+    control.put("onmouseout", "js10");
+    control.put("onmouseover", "js11");
+    control.put("onmouseup", "js12");
+    control.put("rel", "somevalue");
+    control.put("rev", "revsomevalue");
+    control.put("shape", "rect");
+    control.put("style", "Color: red;");
+    control.put("tabindex", "0");
+    control.put("title", "sample");
+    control.put("type", "type");
+
+    TreeMap<String, String> controlSpan = new TreeMap<String, String>();
+    controlSpan.put("accesskey", "U");
+    controlSpan.put("dir", "LTR");
+    controlSpan.put("lang", "en");
+    controlSpan.put("onblur", "js1");
+    controlSpan.put("ondblclick", "js3");
+    controlSpan.put("onfocus", "js4");
+    controlSpan.put("onkeydown", "js5");
+    controlSpan.put("onkeypress", "js6");
+    controlSpan.put("onkeyup", "js7");
+    controlSpan.put("onmousedown", "js8");
+    controlSpan.put("onmousemove", "js9");
+    controlSpan.put("onmouseout", "js10");
+    controlSpan.put("onmouseover", "js11");
+    controlSpan.put("onmouseup", "js12");
+    controlSpan.put("style", "Color: red;");
+    controlSpan.put("tabindex", "0");
+    controlSpan.put("title", "sample");
+ 
+
+    StringBuilder messages = new StringBuilder(64);
+    Formatter formatter = new Formatter(messages);
+
+    List<HtmlPage> pages = new ArrayList<HtmlPage>();
+    pages.add(getPage(CONTEXT_ROOT + "/faces/passthroughtest.xhtml"));
+    pages.add(getPage(CONTEXT_ROOT + "/faces/passthroughtest_facelet.xhtml"));
+
+    for (HtmlPage page : pages) {
+
+      // Facelet Specific PassThrough options
+      if (page.getTitleText().contains("facelet")) {
+        control.put("foo", "bar");
+        control.put("singleatt", "singleAtt");
+        control.put("manyattone", "manyOne");
+        control.put("manyatttwo", "manyTwo");
+        control.put("manyattthree", "manyThree");
+        controlSpan.put("foo", "bar");
+        controlSpan.put("singleatt", "singleAtt");
+        controlSpan.put("manyattone", "manyOne");
+        controlSpan.put("manyatttwo", "manyTwo");
+        controlSpan.put("manyattthree", "manyThree");
+      }
+
+      HtmlAnchor anchor = (HtmlAnchor) getElementOfTypeIncludingId(page, "a",
+          "link1");
+      HtmlSpan span = (HtmlSpan) getElementOfTypeIncludingId(page, "span",
+          "link2");
+
+      if (anchor == null) {
+        formatter.format("Unable to find rendered anchor with ID "
+            + "containing 'link1' %n");
+      }
+
+      if (span == null) {
+        formatter.format(
+            "Unable to find rendered span with ID " + "containing 'link2' %n");
+      }
+
+      if (span == null || anchor == null) {
+        return;
+      }
+
+      validateAttributeSet(control, anchor,
+          new String[] { "name", "id", "value", "href", "onclick" }, formatter);
+
+      validateAttributeSet(controlSpan, span,
+          new String[] { "name", "id", "value", "href", "onclick" }, formatter);
+
+      handleTestStatus(messages);
+    }
+
+  } // END clinkRenderPassthroughTest
+
+  protected void validateAttributeSet(TreeMap<String, String> control,
+    HtmlElement underTest, String[] ignoredAttributes, Formatter formatter) {
+
+    Arrays.sort(ignoredAttributes);
+    TreeMap<String, String> fromPage = new TreeMap<String, String>();
+    for (Iterator i = underTest.getAttributesMap().values().iterator(); i
+        .hasNext();) {
+      DomAttr domEntry = (DomAttr) i.next();
+      String key = domEntry.getName();
+      if (Arrays.binarySearch(ignoredAttributes, key) > -1) {
+        continue;
+      }
+      // fromPage.put(key, entry.getValue());
+      fromPage.put(key, domEntry.getValue());
+    }
+
+    if (!control.equals(fromPage)) {
+      formatter.format("%n Unexpected result when validating "
+          + "passthrough attributes received for the rendered "
+          + "'%s' in the response.%n", underTest.getTagName());
+      formatter.format("%nExpected attribute key/value pairs:%n%s",
+          control.toString());
+      formatter.format(
+          "%nAttribute key/value pairs from the " + "response:%n%s",
+          fromPage.toString());
+    }
+
+  } // END validateAttributeSet
     
 }

--- a/tck/old-tck-selenium/commandLink/src/test/java/ee/jakarta/tck/faces/test/oldtck/commandlink/CommandLinkTestsIT.java
+++ b/tck/old-tck-selenium/commandLink/src/test/java/ee/jakarta/tck/faces/test/oldtck/commandlink/CommandLinkTestsIT.java
@@ -71,9 +71,6 @@ public class CommandLinkTestsIT {
         webClient.close();
     }
 
-     /*
-   * @class.setup_props: webServerHost; webServerPort; ts_home;
-   */
   /**
    * @testName: clinkRenderEncodeTest
    * 
@@ -112,181 +109,45 @@ public class CommandLinkTestsIT {
    * 
    * @since 1.2
    */
-  public void clinkRenderEncodeTest() throws Fault {
+  @Test
+  public void clinkRenderEncodeTest() throws Exception {
 
-    StringBuilder messages = new StringBuilder(64);
-    Formatter formatter = new Formatter(messages);
+    HtmlPage page = webClient.getPage(webUrl + "/faces/encodetest_facelet.xhtml");
 
-    List<HtmlPage> pages = new ArrayList<HtmlPage>();
-    pages.add(getPage(CONTEXT_ROOT + "/faces/encodetest_facelet.xhtml"));
+    HtmlAnchor link1 = (HtmlAnchor) page.getElementById("form:link1"); // form:link1? 
+    assertNotNull(link1);
+    assertEquals("#",link1.getHrefAttribute());
+    assertEquals("Click Me1",link1.asNormalizedText());
+    assertFalse(link1.getOnClickAttribute().length() < 0);
 
-    for (HtmlPage page : pages) {
+    HtmlAnchor link2 = (HtmlAnchor) page.getElementById("form:link2"); // form:link1? 
+    assertNotNull(link2);
+    assertEquals("#",link1.getHrefAttribute());
+    assertEquals("Click Me2",link2.asNormalizedText());
+    assertEquals("sansserif", link2.getAttribute("class"));
+    assertFalse(link2.getOnClickAttribute().length() < 0);
 
-      HtmlAnchor link1 = (HtmlAnchor) getElementOfTypeIncludingId(page, "a",
-          "link1");
+    HtmlAnchor link3 = (HtmlAnchor) page.getElementById("form:link3"); // form:link1? 
+    assertNotNull(link2);
+    assertEquals("#",link3.getHrefAttribute());
+    assertEquals("Click Me3",link3.asNormalizedText());
+    assertFalse(link3.getOnClickAttribute().length() < 0);
 
-      if (link1 == null) {
-        formatter.format("Unable to find achor with ID containing 'link1'. %n");
-      } else {
-        if (!"#".equals(link1.getHrefAttribute())) {
-          formatter.format(
-              "Unexpected value for attribute 'href'. "
-                  + "Expected '#', received: '%s' %n",
-              link1.getHrefAttribute());
-        }
+    HtmlSpan link5 = (HtmlSpan) page.getElementById("form:link5"); // form:link1? 
+    assertNotNull(link5);
+    assertEquals("sansserif", link5.getAttribute("class"));
+    assertEquals("Disabled Link",link5.asNormalizedText());
+    assertFalse(link5.getOnClickAttribute().length() < 0);
 
-        if (!"Click Me1".equals(link1.asNormalizedText())) {
-          formatter.format("Unexpected anchor text. %n" + "Expected: '%s' %n"
-              + "Received: '%s' %n", "Click Me1", link1.asNormalizedText());
-        }
+    HtmlSpan span2 = (HtmlSpan) page.getElementById("form:link6"); // form:link1? 
+    assertNotNull(span2);
+    assertEquals("Disabled Link(Nested)",span2.asNormalizedText());
 
-        if (link1.getOnClickAttribute().length() < 0) {
-          formatter.format("Expected some render specific content "
-              + "to be rendered in the 'onclick' attribute for "
-              + "the anchor, but no content was found. %n");
-        }
-      }
-
-      HtmlAnchor link2 = (HtmlAnchor) getElementOfTypeIncludingId(page, "a",
-          "link2");
-
-      if (link2 == null) {
-        formatter.format("Unable to find achor with ID containing 'link1'. %n");
-      } else {
-        if (!"#".equals(link2.getHrefAttribute())) {
-          formatter.format(
-              "Unexpected value for attribute 'href'. "
-                  + "Expected '#', received: '%s' %n",
-              link2.getHrefAttribute());
-        }
-
-        if (!"Click Me2".equals(link2.asNormalizedText())) {
-          formatter.format("Unexpected anchor text. %n" + "Expected '%s' %n"
-              + "Received: '%s' %n", "Click Me2", link2.asNormalizedText());
-        }
-
-        if (!"sansserif".equals(link2.getAttribute("class"))) {
-          formatter.format(
-              "Unexpected value for class attribute. "
-                  + "Expected 'sansserif' %n" + "Received: '%s'",
-              link2.getAttribute("style"));
-        }
-
-        if (link2.getOnClickAttribute().length() < 0) {
-          formatter.format("Expected some render specific content "
-              + "to be rendered in the 'onclick' attribute for "
-              + "the anchor, but no content was found. %n");
-        }
-      }
-
-      HtmlAnchor link3 = (HtmlAnchor) getElementOfTypeIncludingId(page, "a",
-          "link3");
-
-      if (link3 == null) {
-        formatter.format("Unable to find achor with ID containing 'link3'. %n");
-      } else {
-        if (!"#".equals(link3.getHrefAttribute())) {
-          formatter.format(
-              "Unexpected value for attribute 'href'. "
-                  + "Expected '#', received: '%s' %n",
-              link3.getHrefAttribute());
-        }
-
-        if (!"Click Me3".equals(link3.asNormalizedText())) {
-          formatter.format("Unexpected anchor text.  "
-              + "Expected 'Click M3'to be the anchor text "
-              + "when specified as a nested child (HtmlOutput), "
-              + "but received: '%s' %n", link3.asNormalizedText());
-        }
-
-        if (link3.getOnClickAttribute().length() < 0) {
-          formatter.format("Expected some render specific content "
-              + "to be rendered in the 'onclick' attribute for "
-              + "the anchor, but no content was found. %n");
-        }
-      }
-
-      // ----------------------------------------------------------- case
-      // 5
-      HtmlSpan span = (HtmlSpan) getElementOfTypeIncludingId(page, "span",
-          "link5");
-
-      if (span == null) {
-        formatter.format("Unable to find a span element with an ID"
-            + " containing 'link5' %n");
-      } else {
-        if (!"sansserif".equals(span.getAttribute("class"))) {
-          formatter.format("Unexpected value for class attribute "
-              + "for the rendered span element when CommandLink "
-              + "is disabled. Expected 'sansserif'%n, " + "but received '%s'%n",
-              span.getAttribute("class"));
-        }
-
-        if (!"Disabled Link".equals(span.asNormalizedText())) {
-          formatter.format(
-              "Unexpected textual value for rendered "
-                  + "span element when command link is disabled%n.  "
-                  + "Expected 'Disabled Link'%n, but received '%s'%n",
-              span.asNormalizedText());
-        }
-
-        if (span.getOnClickAttribute().length() > 0) {
-          formatter.format("Expected no render specific content "
-              + "to be rendered in the 'onclick' attribute for "
-              + "the span element, but content was found. %n");
-        }
-      }
-
-      // ----------------------------------------------------------- case
-      // 6
-      HtmlSpan span2 = (HtmlSpan) getElementOfTypeIncludingId(page, "span",
-          "link6");
-
-      if (span2 == null) {
-        formatter.format("Unable to find a span element with an ID"
-            + " containing 'link6' %n");
-      } else {
-        if (!"Disabled Link(Nested)".equals(span2.asNormalizedText())) {
-          formatter.format("Unexpected textual value for rendered "
-              + "span element when command link is disabled. "
-              + "Expected 'Disabled Link(Nested)', " + "but received '%s' %n",
-              span2.asNormalizedText());
-        }
-      }
-
-      // ----------------------------------------------------------- case
-      // 7
-      HtmlAnchor span7 = (HtmlAnchor) getElementOfTypeIncludingId(page, "a",
-          "link7");
-
-      if (span7 == null) {
-        formatter.format(
-            "Unable to find a span element with an ID" + " containing 'link7'");
-      } else {
-        if (!"sansserif".equals(span7.getAttribute("class"))) {
-          formatter.format("Unexpected value for class attribute " + "for "
-              + "the rendered anchor element when CommandLink is "
-              + "disabled. Expected 'sansserif'%n, " + "but received '%s'%n",
-              span7.getAttribute("class"));
-        }
-
-        if (!"rectangle".equals(span7.getShapeAttribute())) {
-          formatter.format("Unexpected value for shape attribute "
-              + "for the rendered anchor element when "
-              + "CommandLink is disabled. Expected 'gone'%n, "
-              + "but received '%s'%n", span7.getShapeAttribute());
-        }
-
-        if (!"gone".equals(span7.getAttribute("title"))) {
-          formatter.format("Unexpected value for title attribute "
-              + "for the rendered anchor element when "
-              + "CommandLink is disabled. Expected 'gone'%n, "
-              + "but received '%s'%n", span7.getAttribute("title"));
-        }
-      }
-
-      handleTestStatus(messages);
-    }
+    HtmlAnchor span7 = (HtmlAnchor) page.getElementById("form:link7"); // form:link1? 
+    assertNotNull(span7);
+    assertEquals("sansserif",span7.getAttribute("class"));
+    assertEquals("rectangle",span7.getShapeAttribute());
+    assertEquals("gone",span7.getAttribute("title"));
   } // END clinkRenderEncodeTest
 
   /**
@@ -298,40 +159,22 @@ public class CommandLinkTestsIT {
    * 
    * @since 1.2
    */
-  public void clinkRenderDecodeTest() throws Fault {
-    StringBuilder messages = new StringBuilder(64);
-    Formatter formatter = new Formatter(messages);
+  @Test
+  public void clinkRenderDecodeTest() throws Exception {
+    webClient.getOptions().setThrowExceptionOnFailingStatusCode(false);
+    HtmlPage page = webClient.getPage(webUrl + "/faces/decodetest_facelet.xhtml");
 
-    List<HtmlPage> pages = new ArrayList<HtmlPage>();
-    pages.add(getPage(CONTEXT_ROOT + "/faces/decodetest_facelet.xhtml"));
+    HtmlAnchor link1 = (HtmlAnchor) page.getElementById("form:link1");
+    assertNotNull(link1);
+    HtmlPage postBack = (HtmlPage) link1.click();  // FAILs 
 
-    for (HtmlPage page : pages) {
-      HtmlAnchor link1 = (HtmlAnchor) getElementOfTypeIncludingId(page, "a",
-          "link1");
-      try {
-        HtmlPage postBack = (HtmlPage) link1.click();
-        // Check to see if an error header was returned
-        String msgHeader = postBack.getWebResponse()
-            .getResponseHeaderValue("actionEvent");
-        if (msgHeader != null) {
-          formatter.format(msgHeader + "%n");
-        } else {
-          // Check for non-error header
-          msgHeader = postBack.getWebResponse()
-              .getResponseHeaderValue("actionEventOK");
-          if (msgHeader == null) {
-            formatter.format("ActionListener was not invoked "
-                + "when CommandButton 'command1' was clicked.%n");
-          }
-
-        }
-      } catch (IOException e) {
-        throw new Fault(e);
-      }
-
-      handleTestStatus(messages);
+    String msgHeader = postBack.getWebResponse().getResponseHeaderValue("actionEvent");
+    if(msgHeader != null) {
+      fail(msgHeader); // actionEvent is error header, see SimpleActionListener
+    } else {
+      msgHeader = postBack.getWebResponse().getResponseHeaderValue("actionEventOK");
+      assertNotNull("ActionListener was not invoked when CommandButton 'command1' was clicked.", msgHeader);
     }
-
   } // END clinkRenderDecodeTest
 
   /**
@@ -345,7 +188,8 @@ public class CommandLinkTestsIT {
    * 
    * @since 1.2
    */
-  public void clinkRenderPassthroughTest() throws Fault {
+  @Test
+  public void clinkRenderPassthroughTest() throws Exception {
 
     TreeMap<String, String> control = new TreeMap<String, String>();
     control.put("accesskey", "U");
@@ -391,14 +235,10 @@ public class CommandLinkTestsIT {
     controlSpan.put("style", "Color: red;");
     controlSpan.put("tabindex", "0");
     controlSpan.put("title", "sample");
- 
-
-    StringBuilder messages = new StringBuilder(64);
-    Formatter formatter = new Formatter(messages);
 
     List<HtmlPage> pages = new ArrayList<HtmlPage>();
-    pages.add(getPage(CONTEXT_ROOT + "/faces/passthroughtest.xhtml"));
-    pages.add(getPage(CONTEXT_ROOT + "/faces/passthroughtest_facelet.xhtml"));
+    pages.add(webClient.getPage(webUrl + "/faces/passthroughtest.xhtml"));
+    pages.add(webClient.getPage(webUrl + "/faces/passthroughtest_facelet.xhtml"));
 
     for (HtmlPage page : pages) {
 
@@ -416,38 +256,23 @@ public class CommandLinkTestsIT {
         controlSpan.put("manyattthree", "manyThree");
       }
 
-      HtmlAnchor anchor = (HtmlAnchor) getElementOfTypeIncludingId(page, "a",
-          "link1");
-      HtmlSpan span = (HtmlSpan) getElementOfTypeIncludingId(page, "span",
-          "link2");
-
-      if (anchor == null) {
-        formatter.format("Unable to find rendered anchor with ID "
-            + "containing 'link1' %n");
-      }
-
-      if (span == null) {
-        formatter.format(
-            "Unable to find rendered span with ID " + "containing 'link2' %n");
-      }
-
-      if (span == null || anchor == null) {
-        return;
-      }
+      HtmlAnchor anchor = (HtmlAnchor) page.getElementById("form:link1");
+      assertNotNull(anchor);
+      HtmlSpan span = (HtmlSpan) page.getElementById("form:link2");
+      assertNotNull(span);
 
       validateAttributeSet(control, anchor,
-          new String[] { "name", "id", "value", "href", "onclick" }, formatter);
+          new String[] { "name", "id", "value", "href", "onclick" });
 
       validateAttributeSet(controlSpan, span,
-          new String[] { "name", "id", "value", "href", "onclick" }, formatter);
+          new String[] { "name", "id", "value", "href", "onclick" });
 
-      handleTestStatus(messages);
     }
 
   } // END clinkRenderPassthroughTest
 
-  protected void validateAttributeSet(TreeMap<String, String> control,
-    HtmlElement underTest, String[] ignoredAttributes, Formatter formatter) {
+  private void validateAttributeSet(TreeMap<String, String> control,
+    HtmlElement underTest, String[] ignoredAttributes) {
 
     Arrays.sort(ignoredAttributes);
     TreeMap<String, String> fromPage = new TreeMap<String, String>();
@@ -458,20 +283,10 @@ public class CommandLinkTestsIT {
       if (Arrays.binarySearch(ignoredAttributes, key) > -1) {
         continue;
       }
-      // fromPage.put(key, entry.getValue());
       fromPage.put(key, domEntry.getValue());
     }
 
-    if (!control.equals(fromPage)) {
-      formatter.format("%n Unexpected result when validating "
-          + "passthrough attributes received for the rendered "
-          + "'%s' in the response.%n", underTest.getTagName());
-      formatter.format("%nExpected attribute key/value pairs:%n%s",
-          control.toString());
-      formatter.format(
-          "%nAttribute key/value pairs from the " + "response:%n%s",
-          fromPage.toString());
-    }
+    assertEquals(control, fromPage);
 
   } // END validateAttributeSet
     

--- a/tck/old-tck-selenium/commandLink/src/test/java/ee/jakarta/tck/faces/test/oldtck/commandlink/CommandLinkTestsIT.java
+++ b/tck/old-tck-selenium/commandLink/src/test/java/ee/jakarta/tck/faces/test/oldtck/commandlink/CommandLinkTestsIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Contributors to the Eclipse Foundation.
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -31,14 +31,12 @@ import java.util.List;
 import java.util.TreeMap;
 
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.shrinkwrap.api.importer.ZipImporter;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
 
 import com.gargoylesoftware.htmlunit.WebClient;
 import com.gargoylesoftware.htmlunit.html.DomAttr;
@@ -47,8 +45,9 @@ import com.gargoylesoftware.htmlunit.html.HtmlElement;
 import com.gargoylesoftware.htmlunit.html.HtmlPage;
 import com.gargoylesoftware.htmlunit.html.HtmlSpan;
 
-@RunWith(Arquillian.class)
-public class CommandLinkTestsIT {
+import ee.jakarta.tck.faces.test.util.arquillian.ITBase;
+
+public class CommandLinkTestsIT extends ITBase {
 
     @ArquillianResource
     private URL webUrl;
@@ -114,36 +113,36 @@ public class CommandLinkTestsIT {
 
     HtmlPage page = webClient.getPage(webUrl + "/faces/encodetest_facelet.xhtml");
 
-    HtmlAnchor link1 = (HtmlAnchor) page.getElementById("form:link1"); // form:link1? 
+    HtmlAnchor link1 = (HtmlAnchor) page.getElementById("form:link1");
     assertNotNull(link1);
     assertEquals("#",link1.getHrefAttribute());
     assertEquals("Click Me1",link1.asNormalizedText());
     assertFalse(link1.getOnClickAttribute().length() < 0);
 
-    HtmlAnchor link2 = (HtmlAnchor) page.getElementById("form:link2"); // form:link1? 
+    HtmlAnchor link2 = (HtmlAnchor) page.getElementById("form:link2");
     assertNotNull(link2);
     assertEquals("#",link1.getHrefAttribute());
     assertEquals("Click Me2",link2.asNormalizedText());
     assertEquals("sansserif", link2.getAttribute("class"));
     assertFalse(link2.getOnClickAttribute().length() < 0);
 
-    HtmlAnchor link3 = (HtmlAnchor) page.getElementById("form:link3"); // form:link1? 
+    HtmlAnchor link3 = (HtmlAnchor) page.getElementById("form:link3");
     assertNotNull(link2);
     assertEquals("#",link3.getHrefAttribute());
     assertEquals("Click Me3",link3.asNormalizedText());
     assertFalse(link3.getOnClickAttribute().length() < 0);
 
-    HtmlSpan link5 = (HtmlSpan) page.getElementById("form:link5"); // form:link1? 
+    HtmlSpan link5 = (HtmlSpan) page.getElementById("form:link5");
     assertNotNull(link5);
     assertEquals("sansserif", link5.getAttribute("class"));
     assertEquals("Disabled Link",link5.asNormalizedText());
     assertFalse(link5.getOnClickAttribute().length() < 0);
 
-    HtmlSpan span2 = (HtmlSpan) page.getElementById("form:link6"); // form:link1? 
+    HtmlSpan span2 = (HtmlSpan) page.getElementById("form:link6");
     assertNotNull(span2);
     assertEquals("Disabled Link(Nested)",span2.asNormalizedText());
 
-    HtmlAnchor span7 = (HtmlAnchor) page.getElementById("form:link7"); // form:link1? 
+    HtmlAnchor span7 = (HtmlAnchor) page.getElementById("form:link7");
     assertNotNull(span7);
     assertEquals("sansserif",span7.getAttribute("class"));
     assertEquals("rectangle",span7.getShapeAttribute());

--- a/tck/old-tck-selenium/commandLink/src/test/java/ee/jakarta/tck/faces/test/oldtck/commandlink/CommandLinkTestsIT.java
+++ b/tck/old-tck-selenium/commandLink/src/test/java/ee/jakarta/tck/faces/test/oldtck/commandlink/CommandLinkTestsIT.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package ee.jakarta.tck.faces.test.oldtck.commandlink;
+
+import static java.lang.System.getProperty;
+import static org.jboss.shrinkwrap.api.ShrinkWrap.create;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
+
+import java.io.File;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+import java.util.TreeMap;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.importer.ZipImporter;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import com.gargoylesoftware.htmlunit.WebClient;
+import com.gargoylesoftware.htmlunit.html.DomAttr;
+import com.gargoylesoftware.htmlunit.html.HtmlAnchor;
+import com.gargoylesoftware.htmlunit.html.HtmlElement;
+import com.gargoylesoftware.htmlunit.html.HtmlPage;
+import com.gargoylesoftware.htmlunit.html.HtmlSpan;
+
+@RunWith(Arquillian.class)
+public class CommandLinkTestsIT {
+
+    @ArquillianResource
+    private URL webUrl;
+    private WebClient webClient;
+
+    @Deployment(testable = false)
+    public static WebArchive createDeployment() {
+        return create(ZipImporter.class, getProperty("finalName") + ".war")
+                .importFrom(new File("target/" + getProperty("finalName") + ".war"))
+                .as(WebArchive.class);
+    }
+
+    @Before
+    public void setUp() {
+        webClient = new WebClient();
+    }
+
+    @After
+    public void tearDown() {
+        webClient.close();
+    }
+
+    
+}

--- a/tck/old-tck-selenium/commandLink/src/test/java/ee/jakarta/tck/faces/test/oldtck/commandlink_selenium/CommandLinkTestsIT.java
+++ b/tck/old-tck-selenium/commandLink/src/test/java/ee/jakarta/tck/faces/test/oldtck/commandlink_selenium/CommandLinkTestsIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Contributors to the Eclipse Foundation.
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/tck/old-tck-selenium/commandLink/src/test/java/ee/jakarta/tck/faces/test/oldtck/commandlink_selenium/CommandLinkTestsIT.java
+++ b/tck/old-tck-selenium/commandLink/src/test/java/ee/jakarta/tck/faces/test/oldtck/commandlink_selenium/CommandLinkTestsIT.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.faces.test.oldtck.commandlink_selenium;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+
+import org.junit.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+
+import ee.jakarta.tck.faces.test.util.selenium.BaseITNG;
+import ee.jakarta.tck.faces.test.util.selenium.WebPage;
+
+public class CommandLinkTestsIT extends BaseITNG {
+
+
+}

--- a/tck/old-tck-selenium/commandLink/src/test/java/ee/jakarta/tck/faces/test/oldtck/commandlink_selenium/CommandLinkTestsIT.java
+++ b/tck/old-tck-selenium/commandLink/src/test/java/ee/jakarta/tck/faces/test/oldtck/commandlink_selenium/CommandLinkTestsIT.java
@@ -75,42 +75,36 @@ public class CommandLinkTestsIT extends BaseITNG {
   @Test
   public void clinkRenderEncodeTest() throws Exception {
 
-    HtmlPage page = webClient.getPage(webUrl + "/faces/encodetest_facelet.xhtml");
+    WebPage page = getPage("faces/encodetest_facelet.xhtml");
 
-    HtmlAnchor link1 = (HtmlAnchor) page.getElementById("form:link1"); // form:link1? 
-    assertNotNull(link1);
-    assertEquals("#",link1.getHrefAttribute());
-    assertEquals("Click Me1",link1.asNormalizedText());
-    assertFalse(link1.getOnClickAttribute().length() < 0);
+    WebElement link1 = page.findElement(By.id("form:link1"));
+    assertEquals("#",link1.getDomAttribute​("href"));
+    assertEquals("Click Me1",link1.getText());
+    assertFalse(link1.getDomAttribute​("onclick").length() < 0);
 
-    HtmlAnchor link2 = (HtmlAnchor) page.getElementById("form:link2"); // form:link1? 
-    assertNotNull(link2);
-    assertEquals("#",link1.getHrefAttribute());
-    assertEquals("Click Me2",link2.asNormalizedText());
-    assertEquals("sansserif", link2.getAttribute("class"));
-    assertFalse(link2.getOnClickAttribute().length() < 0);
+    WebElement link2 = page.findElement(By.id("form:link2"));
+    assertEquals("#",link1.getDomAttribute​("href"));
+    assertEquals("Click Me2",link2.getText());
+    assertEquals("sansserif", link2.getDomAttribute​("class"));
+    assertFalse(link2.getDomAttribute​("onclick").length() < 0);
 
-    HtmlAnchor link3 = (HtmlAnchor) page.getElementById("form:link3"); // form:link1? 
-    assertNotNull(link2);
-    assertEquals("#",link3.getHrefAttribute());
-    assertEquals("Click Me3",link3.asNormalizedText());
-    assertFalse(link3.getOnClickAttribute().length() < 0);
+    WebElement link3 = page.findElement(By.id("form:link3"));
+    assertEquals("#",link3.getDomAttribute​("href"));
+    assertEquals("Click Me3",link3.getText());
+    assertFalse(link3.getDomAttribute​("onclick").length() < 0);
 
-    HtmlSpan link5 = (HtmlSpan) page.getElementById("form:link5"); // form:link1? 
-    assertNotNull(link5);
-    assertEquals("sansserif", link5.getAttribute("class"));
-    assertEquals("Disabled Link",link5.asNormalizedText());
-    assertFalse(link5.getOnClickAttribute().length() < 0);
+    WebElement link5 = page.findElement(By.id("form:link5"));
+    assertEquals("sansserif", link5.getDomAttribute​("class"));
+    assertEquals("Disabled Link",link5.getText());
+    assertNull(link5.getDomAttribute​("onclick")); 
 
-    HtmlSpan span2 = (HtmlSpan) page.getElementById("form:link6"); // form:link1? 
-    assertNotNull(span2);
-    assertEquals("Disabled Link(Nested)",span2.asNormalizedText());
+    WebElement span2 = page.findElement(By.id("form:link6")); 
+    assertEquals("Disabled Link(Nested)",span2.getText());
 
-    HtmlAnchor span7 = (HtmlAnchor) page.getElementById("form:link7"); // form:link1? 
-    assertNotNull(span7);
-    assertEquals("sansserif",span7.getAttribute("class"));
-    assertEquals("rectangle",span7.getShapeAttribute());
-    assertEquals("gone",span7.getAttribute("title"));
+    WebElement span7 = page.findElement(By.id("form:link7"));
+    assertEquals("sansserif",span7.getDomAttribute​("class"));
+    assertEquals("rectangle",span7.getDomAttribute​("shape"));
+    assertEquals("gone",span7.getDomAttribute​("title"));
   } // END clinkRenderEncodeTest
 
   /**
@@ -124,20 +118,17 @@ public class CommandLinkTestsIT extends BaseITNG {
    */
   @Test
   public void clinkRenderDecodeTest() throws Exception {
-    webClient.getOptions().setThrowExceptionOnFailingStatusCode(false);
-    HtmlPage page = webClient.getPage(webUrl + "/faces/decodetest_facelet.xhtml");
+    WebPage page = getPage("faces/decodetest_facelet.xhtml");
 
-    HtmlAnchor link1 = (HtmlAnchor) page.getElementById("form:link1");
-    assertNotNull(link1);
-    HtmlPage postBack = (HtmlPage) link1.click();  // FAILs 
+    WebElement result = page.findElement(By.id("result"));
+    assertEquals("", result.getText());
 
-    String msgHeader = postBack.getWebResponse().getResponseHeaderValue("actionEvent");
-    if(msgHeader != null) {
-      fail(msgHeader); // actionEvent is error header, see SimpleActionListener
-    } else {
-      msgHeader = postBack.getWebResponse().getResponseHeaderValue("actionEventOK");
-      assertNotNull("ActionListener was not invoked when CommandButton 'command1' was clicked.", msgHeader);
-    }
+    WebElement link1 = page.findElement(By.id("form:link1"));
+    link1.click();
+
+    result = page.findElement(By.id("result"));
+    assertEquals("PASSED", result.getText());
+
   } // END clinkRenderDecodeTest
 
   /**
@@ -199,14 +190,14 @@ public class CommandLinkTestsIT extends BaseITNG {
     controlSpan.put("tabindex", "0");
     controlSpan.put("title", "sample");
 
-    List<HtmlPage> pages = new ArrayList<HtmlPage>();
-    pages.add(webClient.getPage(webUrl + "/faces/passthroughtest.xhtml"));
-    pages.add(webClient.getPage(webUrl + "/faces/passthroughtest_facelet.xhtml"));
+    List<String> urls = new ArrayList<String>();
+    urls.add("faces/passthroughtest.xhtml");
+    urls.add("faces/passthroughtest_facelet.xhtml");
 
-    for (HtmlPage page : pages) {
-
+    for (String url : urls) {
+      WebPage page = getPage(url);
       // Facelet Specific PassThrough options
-      if (page.getTitleText().contains("facelet")) {
+      if (page.getTitle().contains("facelet")) {
         control.put("foo", "bar");
         control.put("singleatt", "singleAtt");
         control.put("manyattone", "manyOne");
@@ -219,38 +210,20 @@ public class CommandLinkTestsIT extends BaseITNG {
         controlSpan.put("manyattthree", "manyThree");
       }
 
-      HtmlAnchor anchor = (HtmlAnchor) page.getElementById("form:link1");
-      assertNotNull(anchor);
-      HtmlSpan span = (HtmlSpan) page.getElementById("form:link2");
-      assertNotNull(span);
+      WebElement anchor = page.findElement(By.id("form:link1"));
 
-      validateAttributeSet(control, anchor,
-          new String[] { "name", "id", "value", "href", "onclick" });
+      for (Map.Entry<String, String> entry : control.entrySet()) {
+        assertEquals(anchor.getDomAttribute​(entry.getKey()), entry.getValue());
+      }
 
-      validateAttributeSet(controlSpan, span,
-          new String[] { "name", "id", "value", "href", "onclick" });
+
+      WebElement span = page.findElement(By.id("form:link2"));
+      for (Map.Entry<String, String> entry : controlSpan.entrySet()) {
+        assertEquals(span.getDomAttribute​(entry.getKey()), entry.getValue());
+      }
 
     }
 
   } // END clinkRenderPassthroughTest
 
-  private void validateAttributeSet(TreeMap<String, String> control,
-    HtmlElement underTest, String[] ignoredAttributes) {
-
-    Arrays.sort(ignoredAttributes);
-    TreeMap<String, String> fromPage = new TreeMap<String, String>();
-    for (Iterator i = underTest.getAttributesMap().values().iterator(); i
-        .hasNext();) {
-      DomAttr domEntry = (DomAttr) i.next();
-      String key = domEntry.getName();
-      if (Arrays.binarySearch(ignoredAttributes, key) > -1) {
-        continue;
-      }
-      fromPage.put(key, domEntry.getValue());
-    }
-
-    assertEquals(control, fromPage);
-
-  } // END validateAttributeSet
-  
 }

--- a/tck/old-tck-selenium/commandLink/src/test/java/ee/jakarta/tck/faces/test/oldtck/commandlink_selenium/CommandLinkTestsIT.java
+++ b/tck/old-tck-selenium/commandLink/src/test/java/ee/jakarta/tck/faces/test/oldtck/commandlink_selenium/CommandLinkTestsIT.java
@@ -34,5 +34,223 @@ import ee.jakarta.tck.faces.test.util.selenium.WebPage;
 
 public class CommandLinkTestsIT extends BaseITNG {
 
+  /**
+   * @testName: clinkRenderEncodeTest
+   * 
+   * @assertion_ids: PENDING
+   * 
+   * @test_Strategy: Ensure proper CommandLink rendering: - case 1: Anchor has
+   *                 href value of '#' Anchor display value is "Click Me1"
+   *                 Anchor onclick attribute value has a non-zero length
+   * 
+   *                 - case 2: Anchor has href value of '#' Anchor display value
+   *                 is "Click Me2" The styleClass tag attribute is rendered as
+   *                 the class attribute on the rendered anchor Anchor onclick
+   *                 attribute value has a non-zero length
+   * 
+   *                 - case 3: Anchor has href value of '#' Anchor has display
+   *                 value of "Click Me3" which is specified as a nested
+   *                 HtmlOutput tag. Anchor onclick attribute value has a
+   *                 non-zero length
+   * 
+   *                 - case 4: REMOVED CODE DUE TO BUG ID:6460959
+   * 
+   *                 - case 5: CommandLink has the disabled attribute set to
+   *                 true. Ensure that: A span element is rendered instead of an
+   *                 anchor The span has no onclick content The display value of
+   *                 the span is 'Disabled Link' The styleClass tag attribute is
+   *                 rendered as the class attribute on the rendered span
+   *                 element
+   * 
+   *                 - case 6: CommandLink has the disabled attribute set to
+   *                 true with a nested output component as the link's textual
+   *                 value.
+   * 
+   *                 - case 7: CommandLink is tied to a backend bean via the
+   *                 "binding" attribute. Test to make sure that the "title",
+   *                 "shape" & "styleclass" are set and rendered correctly.
+   * 
+   * @since 1.2
+   */
+  @Test
+  public void clinkRenderEncodeTest() throws Exception {
 
+    HtmlPage page = webClient.getPage(webUrl + "/faces/encodetest_facelet.xhtml");
+
+    HtmlAnchor link1 = (HtmlAnchor) page.getElementById("form:link1"); // form:link1? 
+    assertNotNull(link1);
+    assertEquals("#",link1.getHrefAttribute());
+    assertEquals("Click Me1",link1.asNormalizedText());
+    assertFalse(link1.getOnClickAttribute().length() < 0);
+
+    HtmlAnchor link2 = (HtmlAnchor) page.getElementById("form:link2"); // form:link1? 
+    assertNotNull(link2);
+    assertEquals("#",link1.getHrefAttribute());
+    assertEquals("Click Me2",link2.asNormalizedText());
+    assertEquals("sansserif", link2.getAttribute("class"));
+    assertFalse(link2.getOnClickAttribute().length() < 0);
+
+    HtmlAnchor link3 = (HtmlAnchor) page.getElementById("form:link3"); // form:link1? 
+    assertNotNull(link2);
+    assertEquals("#",link3.getHrefAttribute());
+    assertEquals("Click Me3",link3.asNormalizedText());
+    assertFalse(link3.getOnClickAttribute().length() < 0);
+
+    HtmlSpan link5 = (HtmlSpan) page.getElementById("form:link5"); // form:link1? 
+    assertNotNull(link5);
+    assertEquals("sansserif", link5.getAttribute("class"));
+    assertEquals("Disabled Link",link5.asNormalizedText());
+    assertFalse(link5.getOnClickAttribute().length() < 0);
+
+    HtmlSpan span2 = (HtmlSpan) page.getElementById("form:link6"); // form:link1? 
+    assertNotNull(span2);
+    assertEquals("Disabled Link(Nested)",span2.asNormalizedText());
+
+    HtmlAnchor span7 = (HtmlAnchor) page.getElementById("form:link7"); // form:link1? 
+    assertNotNull(span7);
+    assertEquals("sansserif",span7.getAttribute("class"));
+    assertEquals("rectangle",span7.getShapeAttribute());
+    assertEquals("gone",span7.getAttribute("title"));
+  } // END clinkRenderEncodeTest
+
+  /**
+   * @testName: clinkRenderDecodeTest
+   * 
+   * @assertion_ids: PENDING
+   * 
+   * @test_Strategy:
+   * 
+   * @since 1.2
+   */
+  @Test
+  public void clinkRenderDecodeTest() throws Exception {
+    webClient.getOptions().setThrowExceptionOnFailingStatusCode(false);
+    HtmlPage page = webClient.getPage(webUrl + "/faces/decodetest_facelet.xhtml");
+
+    HtmlAnchor link1 = (HtmlAnchor) page.getElementById("form:link1");
+    assertNotNull(link1);
+    HtmlPage postBack = (HtmlPage) link1.click();  // FAILs 
+
+    String msgHeader = postBack.getWebResponse().getResponseHeaderValue("actionEvent");
+    if(msgHeader != null) {
+      fail(msgHeader); // actionEvent is error header, see SimpleActionListener
+    } else {
+      msgHeader = postBack.getWebResponse().getResponseHeaderValue("actionEventOK");
+      assertNotNull("ActionListener was not invoked when CommandButton 'command1' was clicked.", msgHeader);
+    }
+  } // END clinkRenderDecodeTest
+
+  /**
+   * @testName: clinkRenderPassthroughTest
+   * 
+   * @assertion_ids: PENDING
+   * 
+   * @test_Strategy: Ensure those attributes marked as passthrough are indeed
+   *                 visible in the rendered markup as specified in the JSP
+   *                 page.
+   * 
+   * @since 1.2
+   */
+  @Test
+  public void clinkRenderPassthroughTest() throws Exception {
+
+    TreeMap<String, String> control = new TreeMap<String, String>();
+    control.put("accesskey", "U");
+    control.put("charset", "ISO-8859-1");
+    control.put("coords", "31,45");
+    control.put("dir", "LTR");
+    control.put("hreflang", "en");
+    control.put("lang", "en");
+    control.put("onblur", "js1");
+    control.put("ondblclick", "js3");
+    control.put("onfocus", "js4");
+    control.put("onkeydown", "js5");
+    control.put("onkeypress", "js6");
+    control.put("onkeyup", "js7");
+    control.put("onmousedown", "js8");
+    control.put("onmousemove", "js9");
+    control.put("onmouseout", "js10");
+    control.put("onmouseover", "js11");
+    control.put("onmouseup", "js12");
+    control.put("rel", "somevalue");
+    control.put("rev", "revsomevalue");
+    control.put("shape", "rect");
+    control.put("style", "Color: red;");
+    control.put("tabindex", "0");
+    control.put("title", "sample");
+    control.put("type", "type");
+
+    TreeMap<String, String> controlSpan = new TreeMap<String, String>();
+    controlSpan.put("accesskey", "U");
+    controlSpan.put("dir", "LTR");
+    controlSpan.put("lang", "en");
+    controlSpan.put("onblur", "js1");
+    controlSpan.put("ondblclick", "js3");
+    controlSpan.put("onfocus", "js4");
+    controlSpan.put("onkeydown", "js5");
+    controlSpan.put("onkeypress", "js6");
+    controlSpan.put("onkeyup", "js7");
+    controlSpan.put("onmousedown", "js8");
+    controlSpan.put("onmousemove", "js9");
+    controlSpan.put("onmouseout", "js10");
+    controlSpan.put("onmouseover", "js11");
+    controlSpan.put("onmouseup", "js12");
+    controlSpan.put("style", "Color: red;");
+    controlSpan.put("tabindex", "0");
+    controlSpan.put("title", "sample");
+
+    List<HtmlPage> pages = new ArrayList<HtmlPage>();
+    pages.add(webClient.getPage(webUrl + "/faces/passthroughtest.xhtml"));
+    pages.add(webClient.getPage(webUrl + "/faces/passthroughtest_facelet.xhtml"));
+
+    for (HtmlPage page : pages) {
+
+      // Facelet Specific PassThrough options
+      if (page.getTitleText().contains("facelet")) {
+        control.put("foo", "bar");
+        control.put("singleatt", "singleAtt");
+        control.put("manyattone", "manyOne");
+        control.put("manyatttwo", "manyTwo");
+        control.put("manyattthree", "manyThree");
+        controlSpan.put("foo", "bar");
+        controlSpan.put("singleatt", "singleAtt");
+        controlSpan.put("manyattone", "manyOne");
+        controlSpan.put("manyatttwo", "manyTwo");
+        controlSpan.put("manyattthree", "manyThree");
+      }
+
+      HtmlAnchor anchor = (HtmlAnchor) page.getElementById("form:link1");
+      assertNotNull(anchor);
+      HtmlSpan span = (HtmlSpan) page.getElementById("form:link2");
+      assertNotNull(span);
+
+      validateAttributeSet(control, anchor,
+          new String[] { "name", "id", "value", "href", "onclick" });
+
+      validateAttributeSet(controlSpan, span,
+          new String[] { "name", "id", "value", "href", "onclick" });
+
+    }
+
+  } // END clinkRenderPassthroughTest
+
+  private void validateAttributeSet(TreeMap<String, String> control,
+    HtmlElement underTest, String[] ignoredAttributes) {
+
+    Arrays.sort(ignoredAttributes);
+    TreeMap<String, String> fromPage = new TreeMap<String, String>();
+    for (Iterator i = underTest.getAttributesMap().values().iterator(); i
+        .hasNext();) {
+      DomAttr domEntry = (DomAttr) i.next();
+      String key = domEntry.getName();
+      if (Arrays.binarySearch(ignoredAttributes, key) > -1) {
+        continue;
+      }
+      fromPage.put(key, domEntry.getValue());
+    }
+
+    assertEquals(control, fromPage);
+
+  } // END validateAttributeSet
+  
 }

--- a/tck/old-tck-selenium/commandLink/src/test/java/ee/jakarta/tck/faces/test/oldtck/commandlink_selenium/Deployments.java
+++ b/tck/old-tck-selenium/commandLink/src/test/java/ee/jakarta/tck/faces/test/oldtck/commandlink_selenium/Deployments.java
@@ -1,0 +1,21 @@
+package ee.jakarta.tck.faces.test.oldtck.commandlink_selenium;
+
+import ee.jakarta.tck.faces.test.util.selenium.BaseITNG;
+import org.eu.ingwar.tools.arquillian.extension.suite.annotations.ArquillianSuiteDeployment;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+
+/**
+ * Given Arquilian has no single deployment testsuite
+ * mechanism we have to rely on a third party library.
+ * This improves the performance in a major area, namely
+ * we are only deploying once and then run all tests
+ * on the same deployment (cuts down by 95% the test time)
+ */
+@ArquillianSuiteDeployment
+public class Deployments {
+    @Deployment(testable = false)
+    public static WebArchive createDeployment() {
+        return BaseITNG.createDeployment();
+    }
+}

--- a/tck/old-tck-selenium/commandLink/src/test/java/ee/jakarta/tck/faces/test/oldtck/commandlink_selenium/Deployments.java
+++ b/tck/old-tck-selenium/commandLink/src/test/java/ee/jakarta/tck/faces/test/oldtck/commandlink_selenium/Deployments.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ * 
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GPL-2.0 with Classpath-exception-2.0 which 
+ * is available at https://openjdk.java.net/legal/gplv2+ce.html.
+ * 
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 or Apache-2.0
+ */
 package ee.jakarta.tck.faces.test.oldtck.commandlink_selenium;
 
 import ee.jakarta.tck.faces.test.util.selenium.BaseITNG;

--- a/tck/old-tck-selenium/pom.xml
+++ b/tck/old-tck-selenium/pom.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2021 Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.eclipse.ee4j.faces.tck</groupId>
+        <artifactId>jakarta-faces-tck</artifactId>
+        <version>4.0.0-SNAPSHOT</version>
+    </parent>
+
+    <groupId>org.eclipse.ee4j.tck.faces.old-tck-selenium</groupId>
+    <artifactId>pom</artifactId>
+    <packaging>pom</packaging>
+
+    <name>Jakarta Faces TCK ${project.version} - Test - Old TCK Selenium</name>
+
+    <modules>
+        <module>ajax</module>
+        <module>commandLink</module>
+        <module>protectedViews</module>
+    </modules>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.eclipse.ee4j.tck.faces.test</groupId>
+            <artifactId>util</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/tck/old-tck-selenium/pom.xml
+++ b/tck/old-tck-selenium/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2021 Contributors to Eclipse Foundation.
+    Copyright (c) 2023 Contributors to Eclipse Foundation.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/tck/old-tck-selenium/protectedViews/pom.xml
+++ b/tck/old-tck-selenium/protectedViews/pom.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2021 Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.eclipse.ee4j.tck.faces.old-tck-selenium</groupId>
+        <artifactId>pom</artifactId>
+        <version>4.0.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>protectedViews</artifactId>
+    <packaging>war</packaging>
+
+    <name>Jakarta Faces TCK ${project.version} - Test - Faces 2.2 - protectedViews</name>
+
+    <build>
+        <finalName>old-tck-protectedViews</finalName>
+    </build>
+</project>

--- a/tck/old-tck-selenium/protectedViews/pom.xml
+++ b/tck/old-tck-selenium/protectedViews/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2021 Contributors to Eclipse Foundation.
+    Copyright (c) 2023 Contributors to Eclipse Foundation.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/tck/old-tck-selenium/protectedViews/src/main/webapp/WEB-INF/beans.xml
+++ b/tck/old-tck-selenium/protectedViews/src/main/webapp/WEB-INF/beans.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2022 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+
+<beans xmlns="https://jakarta.ee/xml/ns/jakartaee" 
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_4_0.xsd" 
+        bean-discovery-mode="all">
+</beans>

--- a/tck/old-tck-selenium/protectedViews/src/main/webapp/WEB-INF/beans.xml
+++ b/tck/old-tck-selenium/protectedViews/src/main/webapp/WEB-INF/beans.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2022 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2022,2023 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/tck/old-tck-selenium/protectedViews/src/main/webapp/WEB-INF/faces-config.xml
+++ b/tck/old-tck-selenium/protectedViews/src/main/webapp/WEB-INF/faces-config.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2012, 2020 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<faces-config version="3.0" 
+			  xmlns="https://jakarta.ee/xml/ns/jakartaee"
+   			  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+   			  xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee
+        			https://jakarta.ee/xml/ns/jakartaee/web-facesconfig_3_0.xsd">
+
+		<protected-views>
+			<url-pattern>/views/protected.xhtml</url-pattern>
+		</protected-views>
+	
+</faces-config>

--- a/tck/old-tck-selenium/protectedViews/src/main/webapp/WEB-INF/faces-config.xml
+++ b/tck/old-tck-selenium/protectedViews/src/main/webapp/WEB-INF/faces-config.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2012, 2020 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2012, 2023 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -17,12 +17,11 @@
 
 -->
 
-<faces-config version="3.0" 
-			  xmlns="https://jakarta.ee/xml/ns/jakartaee"
-   			  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-   			  xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee
-        			https://jakarta.ee/xml/ns/jakartaee/web-facesconfig_3_0.xsd">
-
+<faces-config xmlns="https://jakarta.ee/xml/ns/jakartaee"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-facesconfig_4_0.xsd"
+    version="4.0">
+    
 		<protected-views>
 			<url-pattern>/views/protected.xhtml</url-pattern>
 		</protected-views>

--- a/tck/old-tck-selenium/protectedViews/src/main/webapp/WEB-INF/web.xml
+++ b/tck/old-tck-selenium/protectedViews/src/main/webapp/WEB-INF/web.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2012, 2020 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<!-- $Id: $ -->
+
+<web-app version="5.0" xmlns="https://jakarta.ee/xml/ns/jakartaee"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-app_5_0.xsd">
+	<display-name>jsf_view_protectedview</display-name>
+		
+	<servlet>
+		<servlet-name>Faces Servlet</servlet-name>
+		<servlet-class>jakarta.faces.webapp.FacesServlet</servlet-class>
+	</servlet>
+	<servlet-mapping>
+		<servlet-name>Faces Servlet</servlet-name>
+		<url-pattern>/faces/*</url-pattern>
+	</servlet-mapping>
+	
+	<context-param>
+		<param-name>com.sun.faces.validateXml</param-name>
+		<param-value>true</param-value>
+	</context-param>	
+	
+	<session-config>
+		<session-timeout>54</session-timeout>
+	</session-config>
+</web-app>

--- a/tck/old-tck-selenium/protectedViews/src/main/webapp/WEB-INF/web.xml
+++ b/tck/old-tck-selenium/protectedViews/src/main/webapp/WEB-INF/web.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2012, 2020 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2012, 2023 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -16,12 +16,12 @@
     SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
 
 -->
+<web-app
+    xmlns="https://jakarta.ee/xml/ns/jakartaee"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-app_6_0.xsd"
+    version="6.0">
 
-<!-- $Id: $ -->
-
-<web-app version="5.0" xmlns="https://jakarta.ee/xml/ns/jakartaee"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-app_5_0.xsd">
 	<display-name>jsf_view_protectedview</display-name>
 		
 	<servlet>

--- a/tck/old-tck-selenium/protectedViews/src/main/webapp/views/protected.xhtml
+++ b/tck/old-tck-selenium/protectedViews/src/main/webapp/views/protected.xhtml
@@ -1,0 +1,31 @@
+<!--
+
+    Copyright (c) 2012, 2022 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en"
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core"> 
+	
+	<h:head>
+		<title>Protected View</title>
+	</h:head> 
+	<h:body>
+		<h:outputText id="messOne" value="This is a Protected View!" />
+	</h:body> 
+	
+</html>

--- a/tck/old-tck-selenium/protectedViews/src/main/webapp/views/public.xhtml
+++ b/tck/old-tck-selenium/protectedViews/src/main/webapp/views/public.xhtml
@@ -1,0 +1,31 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<!--
+
+    Copyright (c) 2013, 2022 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<xhtml xmlns="http://www.w3.org/1999/xhtml"
+	xmlns:h="jakarta.faces.html"
+	xmlns:f="jakarta.faces.core"> <h:head>
+	<title>Public View</title>
+</h:head> <h:body>
+	<h:outputText value="This is a Public View!" />
+	<h:form id="form1">
+		<h:commandLink id="linkOne" value="linkOne" action="protected.xhtml">
+			<h:outputText value="To Protected View" />
+		</h:commandLink>
+	</h:form>
+</h:body> </xhtml>

--- a/tck/old-tck-selenium/protectedViews/src/test/java/ee/jakarta/tck/faces/test/oldtck/protectedviews/ProtectedViewsTestIT.java
+++ b/tck/old-tck-selenium/protectedViews/src/test/java/ee/jakarta/tck/faces/test/oldtck/protectedviews/ProtectedViewsTestIT.java
@@ -65,6 +65,7 @@ public class ProtectedViewsTestIT {
     }
 
 
+
   /**
    * @testName: viewProtectedViewNonAccessPointTest
    * 
@@ -75,29 +76,19 @@ public class ProtectedViewsTestIT {
    * 
    * @since 2.2
    */
-  public void viewProtectedViewNonAccessPointTest() throws Fault {
-    StringBuilder messages = new StringBuilder(64);
-    Formatter formatter = new Formatter(messages);
+  @Test
+  public void viewProtectedViewNonAccessPointTest() throws Exception {
+    webClient.getOptions().setThrowExceptionOnFailingStatusCode(false);
 
-    throwExceptionOnFailingStatusCode = false;
+    HtmlPage page = webClient.getPage(webUrl + "faces/views/protected.xhtml");
 
-    HtmlPage page = getPage(new WebClient(),
-        CONTEXT_ROOT + "/faces/views/protected.xhtml");
+    HtmlAnchor anchor = (HtmlAnchor) page.getElementById("messOne");
 
-    HtmlAnchor anchor = (HtmlAnchor) getElementOfTypeIncludingId(page, "a",
-        "linkOne");
+    assertNull("Illegal Access of a Protected View!", anchor);
 
-    if (validateExistence("linkOne", "a", anchor, formatter)) {
-      formatter.format("We should not be able to gain access to a "
-          + "Protected View from outside of the Protected View's " + "webapp!");
-      handleTestStatus(messages);
-      formatter.close();
-      return;
-    }
+    assertTrue("Expected a ProtectedViewException when accessing a protected view", page.asNormalizedText().contains("jakarta.faces.application.ProtectedViewException"));
 
-    formatter.close();
-
-  } // END viewProtectedViewNonAccessPointTest
+  } 
 
   /**
    * @testName: viewProtectedViewSameWebAppAccessTest
@@ -110,40 +101,19 @@ public class ProtectedViewsTestIT {
    * 
    * @since 2.2
    */
-  public void viewProtectedViewSameWebAppAccessTest() throws Fault {
-    StringBuilder messages = new StringBuilder(64);
-    Formatter formatter = new Formatter(messages);
-    String result;
+  @Test
+  public void viewProtectedViewSameWebAppAccessTest() throws Exception {
+
     String expected = "This is a Protected View!";
 
-    HtmlPage page = getPage(new WebClient(),
-        CONTEXT_ROOT + "/faces/views/public.xhtml");
+    HtmlPage page = webClient.getPage(webUrl + "faces/views/public.xhtml");
 
-    HtmlAnchor anchor = (HtmlAnchor) getElementOfTypeIncludingId(page, "a",
-        "linkOne");
+    HtmlAnchor anchor = (HtmlAnchor) page.getElementById("form1:linkOne");
+    assertNotNull("Anchor linkOne should not be null!", anchor);
 
-    if (!validateExistence("linkOne", "a", anchor, formatter)) {
-      handleTestStatus(messages);
-      return;
-    }
+    HtmlPage protectedPage = anchor.click();
+    assertEquals(expected, protectedPage.getElementById("messOne").asNormalizedText());
 
-    try {
-      result = anchor.click().getWebResponse().getContentAsString();
-
-      if (!result.contains(expected)) {
-        formatter.format("Error occured during clicking of Link!");
-        handleTestStatus(messages);
-      }
-
-    } catch (IOException e) {
-      formatter.format("Error occured during clicking of Link!");
-      e.printStackTrace();
-      handleTestStatus(messages);
-      formatter.close();
-    }
-
-    formatter.close();
-
-  } // END viewProtectedViewNonAccessPointTest
+  } 
 
 }

--- a/tck/old-tck-selenium/protectedViews/src/test/java/ee/jakarta/tck/faces/test/oldtck/protectedviews/ProtectedViewsTestIT.java
+++ b/tck/old-tck-selenium/protectedViews/src/test/java/ee/jakarta/tck/faces/test/oldtck/protectedviews/ProtectedViewsTestIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Contributors to the Eclipse Foundation.
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -40,8 +40,9 @@ import com.gargoylesoftware.htmlunit.WebClient;
 import com.gargoylesoftware.htmlunit.html.HtmlAnchor;
 import com.gargoylesoftware.htmlunit.html.HtmlPage;
 
-@RunWith(Arquillian.class)
-public class ProtectedViewsTestIT {
+import ee.jakarta.tck.faces.test.util.arquillian.ITBase;
+
+public class ProtectedViewsTestIT extends ITBase {
 
     @ArquillianResource
     private URL webUrl;

--- a/tck/old-tck-selenium/protectedViews/src/test/java/ee/jakarta/tck/faces/test/oldtck/protectedviews/ProtectedViewsTestIT.java
+++ b/tck/old-tck-selenium/protectedViews/src/test/java/ee/jakarta/tck/faces/test/oldtck/protectedviews/ProtectedViewsTestIT.java
@@ -64,4 +64,86 @@ public class ProtectedViewsTestIT {
         webClient.close();
     }
 
+
+  /**
+   * @testName: viewProtectedViewNonAccessPointTest
+   * 
+   * @assertion_ids: PENDING
+   * 
+   * @test_Strategy: Validate that a that we can not gain access to a Protected
+   *                 View from out side that views web-app.
+   * 
+   * @since 2.2
+   */
+  public void viewProtectedViewNonAccessPointTest() throws Fault {
+    StringBuilder messages = new StringBuilder(64);
+    Formatter formatter = new Formatter(messages);
+
+    throwExceptionOnFailingStatusCode = false;
+
+    HtmlPage page = getPage(new WebClient(),
+        CONTEXT_ROOT + "/faces/views/protected.xhtml");
+
+    HtmlAnchor anchor = (HtmlAnchor) getElementOfTypeIncludingId(page, "a",
+        "linkOne");
+
+    if (validateExistence("linkOne", "a", anchor, formatter)) {
+      formatter.format("We should not be able to gain access to a "
+          + "Protected View from outside of the Protected View's " + "webapp!");
+      handleTestStatus(messages);
+      formatter.close();
+      return;
+    }
+
+    formatter.close();
+
+  } // END viewProtectedViewNonAccessPointTest
+
+  /**
+   * @testName: viewProtectedViewSameWebAppAccessTest
+   * 
+   * @assertion_ids: PENDING
+   * 
+   * @test_Strategy: Validate that we are able to gain access to a protected
+   *                 view from inside the same web-app through a non-protected
+   *                 view.
+   * 
+   * @since 2.2
+   */
+  public void viewProtectedViewSameWebAppAccessTest() throws Fault {
+    StringBuilder messages = new StringBuilder(64);
+    Formatter formatter = new Formatter(messages);
+    String result;
+    String expected = "This is a Protected View!";
+
+    HtmlPage page = getPage(new WebClient(),
+        CONTEXT_ROOT + "/faces/views/public.xhtml");
+
+    HtmlAnchor anchor = (HtmlAnchor) getElementOfTypeIncludingId(page, "a",
+        "linkOne");
+
+    if (!validateExistence("linkOne", "a", anchor, formatter)) {
+      handleTestStatus(messages);
+      return;
+    }
+
+    try {
+      result = anchor.click().getWebResponse().getContentAsString();
+
+      if (!result.contains(expected)) {
+        formatter.format("Error occured during clicking of Link!");
+        handleTestStatus(messages);
+      }
+
+    } catch (IOException e) {
+      formatter.format("Error occured during clicking of Link!");
+      e.printStackTrace();
+      handleTestStatus(messages);
+      formatter.close();
+    }
+
+    formatter.close();
+
+  } // END viewProtectedViewNonAccessPointTest
+
 }

--- a/tck/old-tck-selenium/protectedViews/src/test/java/ee/jakarta/tck/faces/test/oldtck/protectedviews/ProtectedViewsTestIT.java
+++ b/tck/old-tck-selenium/protectedViews/src/test/java/ee/jakarta/tck/faces/test/oldtck/protectedviews/ProtectedViewsTestIT.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.faces.test.oldtck.protectedviews;
+
+import static java.lang.System.getProperty;
+import static org.jboss.shrinkwrap.api.ShrinkWrap.create;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.net.URL;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.importer.ZipImporter;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import com.gargoylesoftware.htmlunit.WebClient;
+import com.gargoylesoftware.htmlunit.html.HtmlAnchor;
+import com.gargoylesoftware.htmlunit.html.HtmlPage;
+
+@RunWith(Arquillian.class)
+public class ProtectedViewsTestIT {
+
+    @ArquillianResource
+    private URL webUrl;
+    private WebClient webClient;
+
+    @Deployment(testable = false)
+    public static WebArchive createDeployment() {
+        return create(ZipImporter.class, getProperty("finalName") + ".war")
+                .importFrom(new File("target/" + getProperty("finalName") + ".war"))
+                .as(WebArchive.class);
+    }
+
+    @Before
+    public void setUp() {
+        webClient = new WebClient();
+    }
+
+    @After
+    public void tearDown() {
+        webClient.close();
+    }
+
+}

--- a/tck/old-tck-selenium/protectedViews/src/test/java/ee/jakarta/tck/faces/test/oldtck/protectedviews_selenium/Deployments.java
+++ b/tck/old-tck-selenium/protectedViews/src/test/java/ee/jakarta/tck/faces/test/oldtck/protectedviews_selenium/Deployments.java
@@ -1,0 +1,21 @@
+package ee.jakarta.tck.faces.test.oldtck.protectedviews_selenium;
+
+import ee.jakarta.tck.faces.test.util.selenium.BaseITNG;
+import org.eu.ingwar.tools.arquillian.extension.suite.annotations.ArquillianSuiteDeployment;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+
+/**
+ * Given Arquilian has no single deployment testsuite
+ * mechanism we have to rely on a third party library.
+ * This improves the performance in a major area, namely
+ * we are only deploying once and then run all tests
+ * on the same deployment (cuts down by 95% the test time)
+ */
+@ArquillianSuiteDeployment
+public class Deployments {
+    @Deployment(testable = false)
+    public static WebArchive createDeployment() {
+        return BaseITNG.createDeployment();
+    }
+}

--- a/tck/old-tck-selenium/protectedViews/src/test/java/ee/jakarta/tck/faces/test/oldtck/protectedviews_selenium/Deployments.java
+++ b/tck/old-tck-selenium/protectedViews/src/test/java/ee/jakarta/tck/faces/test/oldtck/protectedviews_selenium/Deployments.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ * 
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GPL-2.0 with Classpath-exception-2.0 which 
+ * is available at https://openjdk.java.net/legal/gplv2+ce.html.
+ * 
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 or Apache-2.0
+ */
 package ee.jakarta.tck.faces.test.oldtck.protectedviews_selenium;
 
 import ee.jakarta.tck.faces.test.util.selenium.BaseITNG;

--- a/tck/old-tck-selenium/protectedViews/src/test/java/ee/jakarta/tck/faces/test/oldtck/protectedviews_selenium/ProtectedViewsTestIT.java
+++ b/tck/old-tck-selenium/protectedViews/src/test/java/ee/jakarta/tck/faces/test/oldtck/protectedviews_selenium/ProtectedViewsTestIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Contributors to the Eclipse Foundation.
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/tck/old-tck-selenium/protectedViews/src/test/java/ee/jakarta/tck/faces/test/oldtck/protectedviews_selenium/ProtectedViewsTestIT.java
+++ b/tck/old-tck-selenium/protectedViews/src/test/java/ee/jakarta/tck/faces/test/oldtck/protectedviews_selenium/ProtectedViewsTestIT.java
@@ -28,7 +28,7 @@ import ee.jakarta.tck.faces.test.util.selenium.WebPage;
 
 public class ProtectedViewsTestIT extends BaseITNG {
 
-      /**
+ /**
    * @testName: viewProtectedViewNonAccessPointTest
    * 
    * @assertion_ids: PENDING
@@ -40,15 +40,12 @@ public class ProtectedViewsTestIT extends BaseITNG {
    */
   @Test
   public void viewProtectedViewNonAccessPointTest() throws Exception {
-    webClient.getOptions().setThrowExceptionOnFailingStatusCode(false);
 
-    HtmlPage page = webClient.getPage(webUrl + "faces/views/protected.xhtml");
+    WebPage page = getPage("faces/views/protected.xhtml");
 
-    HtmlAnchor anchor = (HtmlAnchor) page.getElementById("messOne");
+    assertTrue("Illegal Access of a Protected View!", page.findElements​(By.id("messOne")).size() == 0);
 
-    assertNull("Illegal Access of a Protected View!", anchor);
-
-    assertTrue("Expected a ProtectedViewException when accessing a protected view", page.asNormalizedText().contains("jakarta.faces.application.ProtectedViewException"));
+    assertTrue("Expected a ProtectedViewException when accessing a protected view", page.isInPageText("jakarta.faces.application.ProtectedViewException"));
 
   } 
 
@@ -68,13 +65,13 @@ public class ProtectedViewsTestIT extends BaseITNG {
 
     String expected = "This is a Protected View!";
 
-    HtmlPage page = webClient.getPage(webUrl + "faces/views/public.xhtml");
+    WebPage page = getPage("faces/views/public.xhtml");
 
-    HtmlAnchor anchor = (HtmlAnchor) page.getElementById("form1:linkOne");
-    assertNotNull("Anchor linkOne should not be null!", anchor);
+    WebElement anchor = page.findElement(By.id("form1:linkOne"));
 
-    HtmlPage protectedPage = anchor.click();
-    assertEquals(expected, protectedPage.getElementById("messOne").asNormalizedText());
+    anchor.click();
+    page.waitReqJs();
+    assertEquals(expected, page.findElement(By.id("messOne")).getText());
 
   } 
 

--- a/tck/old-tck-selenium/protectedViews/src/test/java/ee/jakarta/tck/faces/test/oldtck/protectedviews_selenium/ProtectedViewsTestIT.java
+++ b/tck/old-tck-selenium/protectedViews/src/test/java/ee/jakarta/tck/faces/test/oldtck/protectedviews_selenium/ProtectedViewsTestIT.java
@@ -28,4 +28,54 @@ import ee.jakarta.tck.faces.test.util.selenium.WebPage;
 
 public class ProtectedViewsTestIT extends BaseITNG {
 
+      /**
+   * @testName: viewProtectedViewNonAccessPointTest
+   * 
+   * @assertion_ids: PENDING
+   * 
+   * @test_Strategy: Validate that a that we can not gain access to a Protected
+   *                 View from out side that views web-app.
+   * 
+   * @since 2.2
+   */
+  @Test
+  public void viewProtectedViewNonAccessPointTest() throws Exception {
+    webClient.getOptions().setThrowExceptionOnFailingStatusCode(false);
+
+    HtmlPage page = webClient.getPage(webUrl + "faces/views/protected.xhtml");
+
+    HtmlAnchor anchor = (HtmlAnchor) page.getElementById("messOne");
+
+    assertNull("Illegal Access of a Protected View!", anchor);
+
+    assertTrue("Expected a ProtectedViewException when accessing a protected view", page.asNormalizedText().contains("jakarta.faces.application.ProtectedViewException"));
+
+  } 
+
+  /**
+   * @testName: viewProtectedViewSameWebAppAccessTest
+   * 
+   * @assertion_ids: PENDING
+   * 
+   * @test_Strategy: Validate that we are able to gain access to a protected
+   *                 view from inside the same web-app through a non-protected
+   *                 view.
+   * 
+   * @since 2.2
+   */
+  @Test
+  public void viewProtectedViewSameWebAppAccessTest() throws Exception {
+
+    String expected = "This is a Protected View!";
+
+    HtmlPage page = webClient.getPage(webUrl + "faces/views/public.xhtml");
+
+    HtmlAnchor anchor = (HtmlAnchor) page.getElementById("form1:linkOne");
+    assertNotNull("Anchor linkOne should not be null!", anchor);
+
+    HtmlPage protectedPage = anchor.click();
+    assertEquals(expected, protectedPage.getElementById("messOne").asNormalizedText());
+
+  } 
+
 }

--- a/tck/old-tck-selenium/protectedViews/src/test/java/ee/jakarta/tck/faces/test/oldtck/protectedviews_selenium/ProtectedViewsTestIT.java
+++ b/tck/old-tck-selenium/protectedViews/src/test/java/ee/jakarta/tck/faces/test/oldtck/protectedviews_selenium/ProtectedViewsTestIT.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.faces.test.oldtck.protectedviews_selenium;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+
+import ee.jakarta.tck.faces.test.util.selenium.BaseITNG;
+import ee.jakarta.tck.faces.test.util.selenium.WebPage;
+
+public class ProtectedViewsTestIT extends BaseITNG {
+
+}

--- a/tck/old-tck/source/install/jsf/bin/ts.jtx
+++ b/tck/old-tck/source/install/jsf/bin/ts.jtx
@@ -41,3 +41,15 @@ com/sun/ts/tests/jsf/spec/render/onelistbox/URLClient.java#oneListboxRenderDecod
 com/sun/ts/tests/jsf/spec/render/outputlink/URLClient.java#outputLinkRenderPassthroughTest
 com/sun/ts/tests/jsf/spec/resource/packaging/classpath/URLClient.java#jsfJsDoesExistTest
 com/sun/ts/tests/jsf/spec/webapp/tldsig/URLClient.java#jsfTldSignatureTest
+
+#skipped due to htmlunit's rhino engine /javascript syntax incompabilitities, ported to old-tck-selenium
+com/sun/ts/tests/jsf/spec/ajax/tagwrapper/URLClient.java#ajaxTagWrappingTest
+com/sun/ts/tests/jsf/spec/ajax/keyword/URLClient.java#ajaxAllKeywordTest
+com/sun/ts/tests/jsf/spec/ajax/keyword/URLClient.java#ajaxThisKeywordTest
+com/sun/ts/tests/jsf/spec/ajax/keyword/URLClient.java#ajaxFormKeywordTest
+com/sun/ts/tests/jsf/spec/ajax/keyword/URLClient.java#ajaxNoneKeywordTest
+com/sun/ts/tests/jsf/spec/render/commandlink/URLClient.java#clinkRenderEncodeTest
+com/sun/ts/tests/jsf/spec/render/commandlink/URLClient.java#clinkRenderDecodeTest
+com/sun/ts/tests/jsf/spec/render/commandlink/URLClient.java#clinkRenderPassthroughTest
+com/sun/ts/tests/jsf/spec/view/protectedview/URLClient.java#viewProtectedViewNonAccessPointTest
+com/sun/ts/tests/jsf/spec/view/protectedview/URLClient.java#viewProtectedViewSameWebAppAccessTest

--- a/tck/old-tck/source/install/jsf/bin/ts.jtx.platform
+++ b/tck/old-tck/source/install/jsf/bin/ts.jtx.platform
@@ -44,3 +44,15 @@ com/sun/ts/tests/jsf/spec/render/onelistbox/URLClient.java#oneListboxRenderDecod
 com/sun/ts/tests/jsf/spec/render/outputlink/URLClient.java#outputLinkRenderPassthroughTest
 com/sun/ts/tests/jsf/spec/resource/packaging/classpath/URLClient.java#jsfJsDoesExistTest
 com/sun/ts/tests/jsf/spec/webapp/tldsig/URLClient.java#jsfTldSignatureTest
+
+#skipped due to htmlunit's rhino engine /javascript syntax incompabilitities, ported to old-tck-selenium
+com/sun/ts/tests/jsf/spec/ajax/tagwrapper/URLClient.java#ajaxTagWrappingTest
+com/sun/ts/tests/jsf/spec/ajax/keyword/URLClient.java#ajaxAllKeywordTest
+com/sun/ts/tests/jsf/spec/ajax/keyword/URLClient.java#ajaxThisKeywordTest
+com/sun/ts/tests/jsf/spec/ajax/keyword/URLClient.java#ajaxFormKeywordTest
+com/sun/ts/tests/jsf/spec/ajax/keyword/URLClient.java#ajaxNoneKeywordTest
+com/sun/ts/tests/jsf/spec/render/commandlink/URLClient.java#clinkRenderEncodeTest
+com/sun/ts/tests/jsf/spec/render/commandlink/URLClient.java#clinkRenderDecodeTest
+com/sun/ts/tests/jsf/spec/render/commandlink/URLClient.java#clinkRenderPassthroughTest
+com/sun/ts/tests/jsf/spec/view/protectedview/URLClient.java#viewProtectedViewNonAccessPointTest
+com/sun/ts/tests/jsf/spec/view/protectedview/URLClient.java#viewProtectedViewSameWebAppAccessTest

--- a/tck/pom.xml
+++ b/tck/pom.xml
@@ -38,6 +38,7 @@
         <module>faces22</module>
         <module>faces23</module>
         <module>faces40</module>
+        <module>old-tck-selenium</module>
         <module>old-tck</module>
         <module>faces-signaturetest</module>
     </modules>


### PR DESCRIPTION
for #1722

Testing still required for MyFaces, but things look to pass on Mojarra. 

Tried to keep as true to the original tests as possible. 

**Ajax**
https://github.com/jakartaee/faces/blob/3fae98234692ec16545a6d27cf36fabaeb883f9b/tck/old-tck/source/src/com/sun/ts/tests/jsf/spec/ajax/tagwrapper/URLClient.java

**CommandLink**
https://github.com/jakartaee/faces/blob/18876c6a72cadc43aecbab9ca8bcebce470c99e3/tck/old-tck/source/src/com/sun/ts/tests/jsf/spec/render/commandlink/URLClient.java

**Protected View**
https://github.com/jakartaee/faces/blob/3fae98234692ec16545a6d27cf36fabaeb883f9b/tck/old-tck/source/src/com/sun/ts/tests/jsf/spec/view/protectedview/URLClient.java

Notable mentions:
- ajaxTagWrappingTest - needed `intext.sendKeys(TAB);` to trigger change event
- viewProtectedViewNonAccessPointTest Checks for ProtectedViewException in the output" 
- clinkRenderDecodeTest - Can't access header info in selenium so I created a result field 
- ajaxTagWrappingTest - Original test doesn't check for "true" in the checkedvalue element (neither does the new HTMLUnit test. Chnage was never registered, so the test kept failing), but I added a check to the selenium run.  

Lastly, let me know if I should add better error messages? 