### PR TITLE
Selenium Fix for Bean validation

### DIFF
--- a/tck/faces40/beanValidation/src/test/java/ee/jakarta/tck/faces/test/servlet50/beanValidation/Issue5171IT.java
+++ b/tck/faces40/beanValidation/src/test/java/ee/jakarta/tck/faces/test/servlet50/beanValidation/Issue5171IT.java
@@ -18,13 +18,16 @@ package ee.jakarta.tck.faces.test.servlet50.beanValidation;
 
 import static org.junit.Assert.assertEquals;
 
+import org.jboss.arquillian.junit.Arquillian;
 import org.junit.Test;
 
 import com.gargoylesoftware.htmlunit.html.HtmlPage;
 import com.gargoylesoftware.htmlunit.html.HtmlTextInput;
 
 import ee.jakarta.tck.faces.test.util.arquillian.ITBase;
+import org.junit.runner.RunWith;
 
+@RunWith(Arquillian.class)
 public class Issue5171IT extends ITBase {
 
     /**


### PR DESCRIPTION
As per request in https://github.com/jakartaee/faces/pull/1795 the bean validation fix has to go into its separate pull request, as this test very likely will not be part of 4.0.1!
Both PRs sync with master and now are independent of each other!
