### PR TITLE
Selenium Webdriver fix for Chromium engine 111.++

### DIFF
--- a/tck/util/src/main/java/ee/jakarta/tck/faces/test/util/selenium/ChromeDevtoolsDriver.java
+++ b/tck/util/src/main/java/ee/jakarta/tck/faces/test/util/selenium/ChromeDevtoolsDriver.java
@@ -514,6 +514,7 @@ public class ChromeDevtoolsDriver implements ExtendedWebDriver {
         options.addArguments("--no-sandbox");
         options.addArguments("--disable-web-security");
         options.addArguments("--allow-insecure-localhost");
+        options.addArguments("--remote-allow-origins=*");
         options.addArguments("--ignore-urlfetcher-cert-requests");
         options.addArguments("--auto-open-devtools-for-tabs");
         options.addArguments("--disable-gpu");


### PR DESCRIPTION
See also:

https://groups.google.com/g/chromedriver-users/c/xL5-13_qGaA

The lastest Chrome enforces a higher security hence disabling the websocket connection between the webdriver
and the browser engine.
By adding --remote-allow-origins=* it is reenabled again and the webdriver works again!
I ran into this issue on my local M1 mac based development machine (other architectures might not have this problem)
The parameter fixed it for me!
