### PR TITLE
Add directives to fail the build when something in old TCK fails

### DIFF
--- a/tck/old-tck-selenium/ajax/pom.xml
+++ b/tck/old-tck-selenium/ajax/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.eclipse.ee4j.tck.faces.old-tck-selenium</groupId>
         <artifactId>pom</artifactId>
-        <version>4.0.2-SNAPSHOT</version>
+        <version>4.0.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>ajax</artifactId>

--- a/tck/old-tck-selenium/commandLink/pom.xml
+++ b/tck/old-tck-selenium/commandLink/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.eclipse.ee4j.tck.faces.old-tck-selenium</groupId>
         <artifactId>pom</artifactId>
-        <version>4.0.2-SNAPSHOT</version>
+        <version>4.0.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>commandLink</artifactId>

--- a/tck/old-tck-selenium/pom.xml
+++ b/tck/old-tck-selenium/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.eclipse.ee4j.faces.tck</groupId>
         <artifactId>jakarta-faces-tck</artifactId>
-        <version>4.0.2-SNAPSHOT</version>
+        <version>4.0.3-SNAPSHOT</version>
     </parent>
 
     <groupId>org.eclipse.ee4j.tck.faces.old-tck-selenium</groupId>

--- a/tck/old-tck-selenium/protectedViews/pom.xml
+++ b/tck/old-tck-selenium/protectedViews/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.eclipse.ee4j.tck.faces.old-tck-selenium</groupId>
         <artifactId>pom</artifactId>
-        <version>4.0.2-SNAPSHOT</version>
+        <version>4.0.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>protectedViews</artifactId>

--- a/tck/old-tck/build/pom.xml
+++ b/tck/old-tck/build/pom.xml
@@ -27,8 +27,8 @@
     </parent>
 
     <groupId>org.eclipse.ee4j.faces.tck</groupId>
-    <artifactId>old-faces-tck</artifactId>
-    <version>4.0.2-SNAPSHOT</version>
+    <artifactId>old-tck-build</artifactId>
+    <version>4.0.3-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Old Jakarta Faces TCK - build</name>

--- a/tck/old-tck/pom.xml
+++ b/tck/old-tck/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.eclipse.ee4j.faces.tck</groupId>
         <artifactId>jakarta-faces-tck</artifactId>
-        <version>4.0.2-SNAPSHOT</version>
+        <version>4.0.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>old-faces-tck-parent</artifactId>

--- a/tck/old-tck/run/pom.xml
+++ b/tck/old-tck/run/pom.xml
@@ -23,10 +23,10 @@
     <parent>
         <groupId>org.eclipse.ee4j.faces.tck</groupId>
         <artifactId>old-faces-tck-parent</artifactId>
-        <version>4.0.2-SNAPSHOT</version>
+        <version>4.0.3-SNAPSHOT</version>
     </parent>
 
-    <artifactId>glassfish-external-tck-faces</artifactId>
+    <artifactId>old-tck-run</artifactId>
     <packaging>pom</packaging>
 
     <name>Old Jakarta Faces TCK - run</name>
@@ -67,7 +67,7 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.ee4j.faces.tck</groupId>
-            <artifactId>old-faces-tck</artifactId>
+            <artifactId>old-tck-build</artifactId>
             <version>${project.version}</version>
             <type>zip</type>
         </dependency>
@@ -98,7 +98,6 @@
 
             <plugin>
                 <artifactId>maven-dependency-plugin</artifactId>
-                <version>3.3.0</version>
                 <configuration>
                     <skip>${tck.old.skip}</skip>
                 </configuration>
@@ -110,7 +109,7 @@
                             <goal>unpack-dependencies</goal>
                         </goals>
                         <configuration>
-                            <includeArtifactIds>old-faces-tck</includeArtifactIds>
+                            <includeArtifactIds>old-tck-build</includeArtifactIds>
                             <outputDirectory>${project.build.directory}</outputDirectory>
                         </configuration>
                     </execution>
@@ -198,18 +197,18 @@
                                 <tck-setting key="jsf.classes" value="${webServerHome}/modules/cdi-api.jar;${webServerHome}/modules/jakarta.servlet.jsp.jstl-api.jar;${webServerHome}/modules/jakarta.inject.jar;${webServerHome}/modules/jakarta.faces.jar;${webServerHome}/modules/jakarta.servlet.jsp-api.jar;${webServerHome}/modules/jakarta.servlet-api.jar;${webServerHome}/modules/expressly.jar"/>
 
                                 <limit maxwait="60">
-                                    <exec executable="${glassfish.asadmin}" dir="${glassfish.home}/glassfish/bin">
+                                    <exec executable="${glassfish.asadmin}" dir="${glassfish.home}/glassfish/bin" failonerror="true">
                                         <arg value="delete-domain"/>
                                         <arg value="domain1" />
                                     </exec>
-                                    <exec executable="${glassfish.asadmin}" dir="${glassfish.home}/glassfish/bin">
+                                    <exec executable="${glassfish.asadmin}" dir="${glassfish.home}/glassfish/bin" failonerror="true">
                                         <arg value="create-domain"/>
                                         <arg value="--domainproperties=domain.adminPort=${port.admin}:domain.instancePort=${port.http}:http.ssl.port=${port.https}:jms.port=${port.jms}:domain.jmxPort=${port.jmx}:orb.listener.port=${port.orb}:orb.ssl.port=${port.orb.ssl}:orb.mutualauth.port=${port.orb.mutual}" />
                                         <arg value="--user=admin" />
                                         <arg value="--nopassword" />
                                         <arg value="domain1" />
                                     </exec>
-                                    <exec executable="${glassfish.asadmin}" dir="${glassfish.home}/glassfish/bin">
+                                    <exec executable="${glassfish.asadmin}" dir="${glassfish.home}/glassfish/bin" failonerror="true">
                                         <arg value="start-domain"/>
                                     </exec>
 
@@ -223,7 +222,7 @@
                                             </exec>
                                         </then>
                                     </if>
-                                    <exec executable="${glassfish.asadmin}" dir="${glassfish.home}/glassfish/bin">
+                                    <exec executable="${glassfish.asadmin}" dir="${glassfish.home}/glassfish/bin" failonerror="true">
                                         <arg value="stop-domain"/>
                                         <arg value="domain1"/>
                                     </exec>
@@ -257,7 +256,7 @@
                                 <taskdef resource="net/sf/antcontrib/antcontrib.properties" classpathref="maven.plugin.classpath" />
                                 
                                 <limit maxwait="300">
-                                    <exec executable="${glassfish.asadmin}" dir="${glassfish.home}/glassfish/bin">
+                                    <exec executable="${glassfish.asadmin}" dir="${glassfish.home}/glassfish/bin" failonerror="true">
                                         <arg value="start-domain"/>
                                         <arg value="--suspend" if:set="glassfish.suspend"/>
                                     </exec>
@@ -268,7 +267,7 @@
                                     <dirname property="test.dir" file="${tck.home}/src/${run.test}"/>
                                     <echo>Deploying from ${test.dir}</echo>
                                     
-                                    <exec executable="${ant.home}/bin/ant" dir="${test.dir}">
+                                    <exec executable="${ant.home}/bin/ant" dir="${test.dir}" failonerror="true">
                                         <arg value="deploy"  />
                                     </exec>
                                 </sequential>
@@ -276,7 +275,7 @@
                                 <!-- Deploy all tests -->
                                 <sequential unless:set="run.test" >
                                     <echo>Deploying all archives</echo>
-                                    <exec executable="${ant.home}/bin/ant" dir="${tck.tests.home}">
+                                    <exec executable="${ant.home}/bin/ant" dir="${tck.tests.home}" failonerror="true">
                                         <arg value="-Dutil.dir=${tck.home}"  />
                                         <arg value="deploy.all"  />
                                     </exec>
@@ -318,6 +317,15 @@
                                 <exec executable="${glassfish.asadmin}" dir="${glassfish.home}/glassfish/bin">
                                     <arg value="stop-domain" />
                                 </exec>
+                                
+                                <if>
+                                    <not>
+                                        <equals arg1="${testResult}" arg2="0" />
+                                    </not>
+                                    <then>
+                                        <fail/>
+                                    </then>
+                                </if>
                             </target>
                         </configuration>
                     </execution>

--- a/tck/old-tck/source/pom.xml
+++ b/tck/old-tck/source/pom.xml
@@ -22,7 +22,7 @@
 
     <groupId>org.glassfish.main.tests.tck</groupId>
     <version>4.0.0</version>
-    <artifactId>glassfish-tck-faces</artifactId>
+    <artifactId>old-tck-source</artifactId>
     <packaging>pom</packaging>
 
     <name>TCK: Faces</name>


### PR DESCRIPTION
Additionally, give modules better names and also set version to 4.0.3-SNAPSHOT.