### PR TITLE
Exclude generated methods from lambdas in the interface

### DIFF
--- a/tck/old-tck/source/src/com/sun/ts/tests/jsf/api/jakarta_faces/context/facescontext/TestServlet.java
+++ b/tck/old-tck/source/src/com/sun/ts/tests/jsf/api/jakarta_faces/context/facescontext/TestServlet.java
@@ -1,4 +1,5 @@
 /*
+ * * Copyright (c) 2024 Contributors to Eclipse Foundation.
  * Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -849,7 +850,7 @@ public final class TestServlet extends HttpTCKServlet {
       Method method = methods[i];
       String name = method.getName();
 
-      if (!isExcluded(name, exMethods)) {
+      if (!isExcluded(name, exMethods) && !name.startsWith("lambda$")) {
         Class<?>[] types = method.getParameterTypes();
         Object[] params = new Object[types.length];
 

--- a/tck/old-tck/source/src/com/sun/ts/tests/jsf/api/jakarta_faces/context/facescontext/TestServlet.java
+++ b/tck/old-tck/source/src/com/sun/ts/tests/jsf/api/jakarta_faces/context/facescontext/TestServlet.java
@@ -1,5 +1,4 @@
 /*
- * Copyright (c) 2024 Contributors to Eclipse Foundation.
  * Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -62,1102 +61,1263 @@ import jakarta.servlet.http.HttpServletResponse;
 
 public final class TestServlet extends HttpTCKServlet {
 
-    public void init(ServletConfig config) throws ServletException {
-        super.init(config);
-    }
-    
-    // ------------------------------------------------ Test Methods -------
-    // FacesContext.getClientIdsWithMessages()
+  public void init(ServletConfig config) throws ServletException {
+    super.init(config);
+  }
+  // ------------------------------------------------ Test Methods -------
+  // FacesContext.getClientIdsWithMessages()
 
-    public void facesCtxGetClientIdsWithMessagesTest(HttpServletRequest request, HttpServletResponse response) throws IOException {
-        PrintWriter out = response.getWriter();
-        FacesContext context = getFacesContext();
-        context.setViewRoot(createViewRoot());
+  public void facesCtxGetClientIdsWithMessagesTest(HttpServletRequest request,
+      HttpServletResponse response) throws IOException {
+    PrintWriter out = response.getWriter();
+    FacesContext context = getFacesContext();
+    context.setViewRoot(createViewRoot());
 
-        UIComponent component1 = getApplication().createComponent(UIInput.COMPONENT_TYPE);
-        component1.setId("component1");
-        UIComponent component2 = getApplication().createComponent(UIOutput.COMPONENT_TYPE);
-        component2.setId("component2");
-        FacesMessage message1 = new TCKMessage(FacesMessage.SEVERITY_INFO, "message1 summary", "message1 detail", "message1");
+    UIComponent component1 = getApplication()
+        .createComponent(UIInput.COMPONENT_TYPE);
+    component1.setId("component1");
+    UIComponent component2 = getApplication()
+        .createComponent(UIOutput.COMPONENT_TYPE);
+    component2.setId("component2");
+    FacesMessage message1 = new TCKMessage(FacesMessage.SEVERITY_INFO,
+        "message1 summary", "message1 detail", "message1");
 
-        context.addMessage(component1.getClientId(context), message1);
-        context.addMessage(component2.getClientId(context), message1);
+    context.addMessage(component1.getClientId(context), message1);
+    context.addMessage(component2.getClientId(context), message1);
 
-        String[] controlClientIds = { component1.getClientId(context), component2.getClientId(context) };
-        String[] testClientIds = JSFTestUtil.getAsStringArray(context.getClientIdsWithMessages());
+    String[] controlClientIds = { component1.getClientId(context),
+        component2.getClientId(context) };
+    String[] testClientIds = JSFTestUtil
+        .getAsStringArray(context.getClientIdsWithMessages());
 
-        if (controlClientIds.length != testClientIds.length) {
-            out.println(JSFTestUtil.FAIL + " Unexpected number of client IDs returned by " + "FacesContext.getComponentIdsWithMessages().");
-            out.println("Exected the number of IDs returned to be 2.  Actual number returned: " + testClientIds.length);
-            return;
-        }
-
-        List list = Arrays.asList(testClientIds);
-        for (int i = 0; i < controlClientIds.length; i++) {
-            if (!list.contains(controlClientIds[i])) {
-                out.println(JSFTestUtil.FAIL + " Unable to find '" + controlClientIds[i] + "' in the client IDs returned"
-                        + " by FacesContext.getClientIdsWithMessages().");
-                for (int j = 0; j < testClientIds.length; j++) {
-                    out.println("Client ID received: " + testClientIds[j]);
-                }
-                return;
-            }
-        }
-
-        out.println(JSFTestUtil.PASS);
-    }
-    // FacesContext.getClientIdsWithMessages() returning an empty Iterator when no
-    // components are found.
-
-    public void facesCtxGetClientIdsWithMessagesEmptyTest(HttpServletRequest request, HttpServletResponse response) throws IOException {
-        PrintWriter out = response.getWriter();
-        FacesContext context = getFacesContext();
-
-        Iterator i = context.getClientIdsWithMessages();
-
-        if (i == null) {
-            out.println(
-                    JSFTestUtil.FAIL + " FacesContext.getClientIdsWithMessages() returned null" + " when instead of an empty Iterator.");
-            return;
-        }
-
-        if (i.hasNext()) {
-            out.println(JSFTestUtil.FAIL + " FacesContext.getClientIdsWithMessages() returned a"
-                    + " non-empty Iterator even though no messages have been added.");
-            while (i.hasNext()) {
-                UIComponent comp = (UIComponent) i.next();
-                out.println("Component: " + ((comp == null) ? null : comp.getId()));
-            }
-            return;
-        }
-
-        context.addMessage(null, new FacesMessage());
-        context.addMessage(null, new FacesMessage());
-        i = context.getClientIdsWithMessages();
-
-        if (i == null) {
-            out.println(
-                    "Test FAILED[2]. FacesContext.getClientIds" + "WithMessages() returned null when instead of an empty " + "Iterator.");
-            return;
-        }
-
-        if (i.hasNext()) {
-            UIComponent comp = (UIComponent) i.next();
-            if (comp != null) {
-                out.println(JSFTestUtil.FAIL + " Non-null value returned from iterator.");
-                return;
-            }
-
-            if (i.hasNext()) {
-                out.println(JSFTestUtil.FAIL + " Iterator contained more than 1" + " value after when getClientIdWithMessages() was "
-                        + "called where a Message existed with no client id.");
-                return;
-            }
-        }
-
-        out.println(JSFTestUtil.PASS);
-    }
-    // FacesContext.addMessage(UIComponent, FacesMessage)
-    // FacesContext.getMessages()
-    // FacesContext.getMessages(UIComponent)
-    // 7/18/05 updated test to ensure message order is retained by returned
-    // iterators.
-
-    public void facesCtxAddGetMessagesTest(HttpServletRequest request, HttpServletResponse response) throws IOException {
-        PrintWriter out = response.getWriter();
-
-        UIComponent component = getApplication().createComponent(UIInput.COMPONENT_TYPE);
-        component.setId("input1");
-        FacesMessage message1 = new TCKMessage(FacesMessage.SEVERITY_INFO, "message1 summary", "message1 detail", "message1");
-        FacesMessage message2 = new TCKMessage(FacesMessage.SEVERITY_INFO, "message2 summary", "message2 detail", "message2");
-        FacesMessage message3 = new TCKMessage(FacesMessage.SEVERITY_INFO, "message3 summary", "message3 detail", "message3");
-        FacesMessage message4 = new TCKMessage(FacesMessage.SEVERITY_INFO, "message4 summary", "message4 detail", "message4");
-
-        FacesContext context = getFacesContext();
-        context.setViewRoot(createViewRoot());
-
-        context.addMessage(component.getClientId(context), message1);
-        context.addMessage(component.getClientId(context), message3);
-        context.addMessage(null, message2);
-        context.addMessage(null, message4);
-
-        FacesMessage[] controlMessagesComp = { message1, message3 };
-        FacesMessage[] controlMessagesNoComp = { message1, message3, message2, message4 };
-        FacesMessage[] controlMessagesNullComp = { message2, message4 };
-
-        FacesMessage[] testMessagesComp = getMessagesAsArray(context.getMessages(component.getClientId(context)));
-
-        // the next two should be equivalent
-        FacesMessage[] testMessagesNullComp = getMessagesAsArray(context.getMessages(null));
-        FacesMessage[] testMessages = getMessagesAsArray(context.getMessages());
-
-        // check the messages associated with a component
-        if (controlMessagesComp.length != testMessagesComp.length) {
-            out.println(JSFTestUtil.FAIL + " An unexpected number of messages" + " returned when FacesContext. getMessages(UIComponent)"
-                    + " was called.");
-            out.println("Expected 2 messages to be returned. Actual message " + "count: " + testMessagesComp.length);
-            return;
-        }
-
-        List messages = Arrays.asList(testMessagesComp);
-        for (int i = 0; i < controlMessagesComp.length; i++) {
-            if (!messages.get(i).equals(controlMessagesComp[i])) {
-                out.println(JSFTestUtil.FAIL + " Unable to find '" + controlMessagesComp[i] + "' in the return value of FacesContext."
-                        + "getMessages(UIComponent) when the appropriate" + " component was provided.");
-                out.println("Messages returned: " + JSFTestUtil.getAsString(testMessagesComp));
-                return;
-            }
-        }
-
-        // check the messages returned when a null value is provided
-        // to FacesContext.getMessages(null)
-        if (controlMessagesNullComp.length != testMessagesNullComp.length) {
-            out.println(JSFTestUtil.FAIL + " An unexpected number of messages " + "returned when FacesContext. getMessages(null) was "
-                    + "called.");
-            out.println("Expected 2 messages to be returned. Actual message " + "count: " + testMessagesNullComp.length);
-            return;
-        }
-
-        messages = Arrays.asList(testMessagesNullComp);
-        for (int i = 0; i < controlMessagesNullComp.length; i++) {
-            if (!messages.get(i).equals(controlMessagesNullComp[i])) {
-                out.println(JSFTestUtil.FAIL + " Unable to find '" + controlMessagesNullComp[i] + "' in the return value of FacesContext."
-                        + "getMessages(UIComponent) when null was passed to the" + " method.");
-                out.println("Messages returned: " + JSFTestUtil.getAsString(testMessagesNullComp));
-                return;
-            }
-        }
-
-        // check the messages returned by FacesContext.getMessages()
-        if (controlMessagesNoComp.length != testMessages.length) {
-            out.println(
-                    JSFTestUtil.FAIL + " An unexpected number of messages " + "returned when FacesContext." + "getMessages() was called.");
-            out.println("Expected 4 messages to be returned. Actual message" + " count: " + testMessages.length);
-            return;
-        }
-
-        messages = Arrays.asList(testMessages);
-        for (int i = 0; i < controlMessagesNoComp.length; i++) {
-            if (!messages.get(i).equals(controlMessagesNoComp[i])) {
-                out.println(JSFTestUtil.FAIL + " Unable to find '" + controlMessagesNoComp[i] + "' in the return value of FacesContext."
-                        + "getMessages()");
-                out.println("Messages returned: " + JSFTestUtil.getAsString(testMessages));
-                return;
-            }
-        }
-        out.println(JSFTestUtil.PASS);
-    }
-    // FacesContext.getMessages(UIComponent)
-    // FacesContext.getMessages()
-    // - both return an empty Iterator if no messages were added.
-
-    public void facesCtxGetMessagesEmptyTest(HttpServletRequest request, HttpServletResponse response) throws IOException {
-        PrintWriter out = response.getWriter();
-        FacesContext context = getFacesContext();
-        context.setViewRoot(createViewRoot());
-
-        Iterator i = context.getMessages();
-        if (i != null) {
-            if (i.hasNext()) {
-                out.println(JSFTestUtil.FAIL + " FacesContext.getMessages() " + "returned a non-empty Iterator when no FacesMessage "
-                        + "instances were added.");
-                return;
-            }
-        } else {
-            out.println(JSFTestUtil.FAIL + " FacesContext.getMessages() returned " + "null as opposed to an empty Iterator.");
-            return;
-        }
-
-        i = context.getMessages(getApplication().createComponent(UIInput.COMPONENT_TYPE).getClientId(context));
-        if (i != null) {
-            if (i.hasNext()) {
-                out.println(JSFTestUtil.FAIL + " FacesContext.getMessages(" + "UIComponent) returned a non-empty Iterator when no "
-                        + "FacesMessage instances were added.");
-                return;
-            }
-        } else {
-            out.println(JSFTestUtil.FAIL + " FacesContext.getMessages(UIComponent)" + " returned null as opposed to an empty Iterator.");
-            return;
-        }
-
-        i = context.getMessages(null);
-        if (i != null) {
-            if (i.hasNext()) {
-                out.println(JSFTestUtil.FAIL + " FacesContext.getMessages(null) " + "returned a non-empty Iterator when no FacesMessage"
-                        + " instances were added.");
-                return;
-            }
-        } else {
-            out.println(JSFTestUtil.FAIL + " FacesContext.getMessages(null) " + "returned null as opposed to an empty Iterator.");
-            return;
-        }
-
-        out.println(JSFTestUtil.PASS);
+    if (controlClientIds.length != testClientIds.length) {
+      out.println(
+          JSFTestUtil.FAIL + " Unexpected number of client IDs returned by "
+              + "FacesContext.getComponentIdsWithMessages().");
+      out.println(
+          "Exected the number of IDs returned to be 2.  Actual number returned: "
+              + testClientIds.length);
+      return;
     }
 
-    public void facesCtxGetMessageListTest(HttpServletRequest request, HttpServletResponse response) throws IOException {
-
-        PrintWriter out = response.getWriter();
-        FacesContext context = getFacesContext();
-        this.addTestMessagesToContext(context, null);
-
-        try {
-            List allMessages = context.getMessageList();
-            if (allMessages.size() != 4) {
-                out.print("Test FAILED." + JSFTestUtil.NL + "Call to " + "FacesContext.getMessageList unexepected size! " + JSFTestUtil.NL
-                        + "Expected: 4" + JSFTestUtil.NL + "Received: " + allMessages.size());
-                return;
-            }
-        } catch (Exception e) {
-            out.print("Test FAILED." + JSFTestUtil.NL + e.toString());
+    List list = Arrays.asList(testClientIds);
+    for (int i = 0; i < controlClientIds.length; i++) {
+      if (!list.contains(controlClientIds[i])) {
+        out.println(JSFTestUtil.FAIL + " Unable to find '" + controlClientIds[i]
+            + "' in the client IDs returned"
+            + " by FacesContext.getClientIdsWithMessages().");
+        for (int j = 0; j < testClientIds.length; j++) {
+          out.println("Client ID received: " + testClientIds[j]);
         }
-
-        out.println(JSFTestUtil.PASS);
-
-    } // END facesCtxgetMessageListTest
-
-    public void facesCtxGetMessageListByIdTest(HttpServletRequest request, HttpServletResponse response) throws IOException {
-
-        PrintWriter out = response.getWriter();
-        FacesContext context = getFacesContext();
-        this.addTestMessagesToContext(context, "test_one");
-
-        try {
-            List allMessages = context.getMessageList("test_one");
-            if (allMessages.size() != 2) {
-                out.print("Test FAILED." + JSFTestUtil.NL + "Call to " + "FacesContext.getMessageList unexepected size! " + JSFTestUtil.NL
-                        + "Expected: 2" + JSFTestUtil.NL + "Received: " + allMessages.size());
-                return;
-            }
-        } catch (Exception e) {
-            out.print("Test FAILED." + JSFTestUtil.NL + e.toString());
-        }
-
-        out.println(JSFTestUtil.PASS);
-
-    } // END facesCtxgetMessageListByIdTest
-
-    public void facesCtxisValidationFailedTest(HttpServletRequest request, HttpServletResponse response) throws IOException {
-
-        PrintWriter out = response.getWriter();
-        FacesContext context = getFacesContext();
-        Boolean isFailed;
-        try {
-            isFailed = context.isValidationFailed();
-            if (isFailed) {
-                out.print("Test FAILED." + JSFTestUtil.NL + "Unexpected result from " + "FacesContext.isValadationFailed()" + JSFTestUtil.NL
-                        + "Expected: false" + JSFTestUtil.NL + "Received: " + isFailed);
-                return;
-            }
-
-            context.validationFailed();
-            isFailed = context.isValidationFailed();
-            if (!isFailed) {
-                out.print("Test FAILED." + JSFTestUtil.NL + "Unexpected result from " + "FacesContext.isValadationFailed() after calling "
-                        + "FacesContext.validationFailed." + JSFTestUtil.NL + "Expected: true" + JSFTestUtil.NL + "Received: " + isFailed);
-                return;
-            }
-        } catch (Exception e) {
-            out.print("Test FAILED." + JSFTestUtil.NL + e.toString());
-        }
-
-        out.println(JSFTestUtil.PASS);
-
-    } // END facesCtxisValidationFailedTest
-
-    public void facesCtxisPostbackTest(HttpServletRequest request, HttpServletResponse response) throws IOException {
-
-        PrintWriter out = response.getWriter();
-        FacesContext context = getFacesContext();
-        context.getApplication();
-        Boolean isPB;
-
-        try {
-            isPB = context.isPostback();
-            if (isPB) {
-                out.print("Test FAILED." + JSFTestUtil.NL + "Unexpected result from " + "FacesContext.isPostback() before calling "
-                        + "StateManger.writeState()." + JSFTestUtil.NL + "Expected: false" + JSFTestUtil.NL + "Received: " + isPB);
-                return;
-            }
-
-        } catch (Exception e) {
-            out.print("Test FAILED." + JSFTestUtil.NL + e.toString());
-        }
-
-        out.println(JSFTestUtil.PASS);
-
-    } // END facesCtxisPostbackTest
-
-    // FacesContext.getApplication()
-    public void facesCtxGetApplicationTest(HttpServletRequest request, HttpServletResponse response) throws IOException {
-        PrintWriter out = response.getWriter();
-        Application controlApplication = getApplication();
-        Application testApplication = getFacesContext().getApplication();
-
-        if (controlApplication == null) {
-            out.println(JSFTestUtil.FAIL + " Application.getCurrentInstance() " + "unexpectedly returned null.");
-            return;
-        }
-
-        if (controlApplication != testApplication) {
-            out.println(JSFTestUtil.FAIL + " The Application instance returned by " + "Application. getCurrentInstance() differs from the "
-                    + "Application returned by FacesContext.getApplication().");
-            out.println("Application.getCurrentInstance(): " + controlApplication);
-            out.println("FacesContext.getApplication():" + testApplication);
-            return;
-        }
-
-        out.println(JSFTestUtil.PASS);
-    }
-    // FacesContext.addMessage(UIComponent, FacesMessage) throws NPE if
-    // FacesMessage is null
-
-    public void facesCtxAddMessageNPETest(HttpServletRequest request, HttpServletResponse response) throws IOException {
-        PrintWriter out = response.getWriter();
-
-        JSFTestUtil.checkForNPE(getFacesContext(), "addMessage", new Class<?>[] { String.class, FacesMessage.class },
-                new Object[] { "id", null }, out);
+        return;
+      }
     }
 
-    // FacesContext.isProjectStage(ProjectStage stage) throws NPE if stage is null
-    public void facesCtxIsProjectStageNPETest(HttpServletRequest request, HttpServletResponse response) throws IOException {
-        PrintWriter out = response.getWriter();
+    out.println(JSFTestUtil.PASS);
+  }
+  // FacesContext.getClientIdsWithMessages() returning an empty Iterator when no
+  // components are found.
 
-        JSFTestUtil.checkForNPE(getFacesContext(), "isProjectStage", new Class<?>[] { ProjectStage.class }, new Object[] { null }, out);
+  public void facesCtxGetClientIdsWithMessagesEmptyTest(
+      HttpServletRequest request, HttpServletResponse response)
+      throws IOException {
+    PrintWriter out = response.getWriter();
+    FacesContext context = getFacesContext();
+
+    Iterator i = context.getClientIdsWithMessages();
+
+    if (i == null) {
+      out.println(JSFTestUtil.FAIL
+          + " FacesContext.getClientIdsWithMessages() returned null"
+          + " when instead of an empty Iterator.");
+      return;
     }
 
-    // FacesContext.getCurrentInstance()
-    public void facesCtxSetGetCurrentInstanceTest(HttpServletRequest request, HttpServletResponse response) throws IOException {
-        PrintWriter out = response.getWriter();
-        FacesContext controlContext = getFacesContext();
-        FacesContext testContext = FacesContext.getCurrentInstance();
-
-        if (controlContext != testContext) {
-            out.println(JSFTestUtil.FAIL + " FacesContext.getCurrentInstance() " + "returned a FacesContext instance that differs from the "
-                    + "one that is currently services this request.");
-            out.println("Current FacesContext: " + controlContext);
-            out.println("FacesContext.getCurrentInstance(): " + testContext);
-            return;
-        }
-
-        out.println(JSFTestUtil.PASS);
+    if (i.hasNext()) {
+      out.println(JSFTestUtil.FAIL
+          + " FacesContext.getClientIdsWithMessages() returned a"
+          + " non-empty Iterator even though no messages have been added.");
+      while (i.hasNext()) {
+        UIComponent comp = (UIComponent) i.next();
+        out.println("Component: " + ((comp == null) ? null : comp.getId()));
+      }
+      return;
     }
 
-    // FacesContext.getMaximumSeverity()
-    public void facesCtxGetMaximumSeverityTest(HttpServletRequest request, HttpServletResponse response) throws IOException {
-        PrintWriter out = response.getWriter();
-        FacesContext context = getFacesContext();
-        context.setViewRoot(new UIViewRoot());
-        FacesMessage message1 = new TCKMessage(FacesMessage.SEVERITY_INFO, "message1 summary", "message1 detail", "message1");
-        FacesMessage message2 = new TCKMessage(FacesMessage.SEVERITY_WARN, "message2 summary", "message2 detail", "message2");
-        FacesMessage message3 = new TCKMessage(FacesMessage.SEVERITY_ERROR, "message3 summary", "message3 detail", "message3");
-        FacesMessage message4 = new TCKMessage(FacesMessage.SEVERITY_FATAL, "message4 summary", "message4 detail", "message4");
+    context.addMessage(null, new FacesMessage());
+    context.addMessage(null, new FacesMessage());
+    i = context.getClientIdsWithMessages();
 
-        /*
-         * if no messages have been queued, then FacesContext.getMaximumSeverity should return null
-         */
-        if (context.getMaximumSeverity() != null) {
-            out.println(JSFTestUtil.FAIL + " FacesContext.getMaximumSeverity returned a"
-                    + "non null value when no messages have been added to the" + " FacesContext.");
-            out.println("Severity received: " + context.getMaximumSeverity().getOrdinal());
-            return;
-        }
-
-        context.addMessage(null, message1);
-        int severity = context.getMaximumSeverity().getOrdinal();
-        if (severity != FacesMessage.SEVERITY_INFO.getOrdinal()) {
-            out.println(JSFTestUtil.FAIL + " Expected FacesContext." + "getMaximumSeverity() to return FacesMessage."
-                    + "SEVERITY_INFO when only a SEVERITY_INFO message exists" + " in the FacesContext.");
-            out.println("Severity Recieved: " + severity);
-            out.println("Integer value of FacesMessage.SEVERITY_INFO: " + FacesMessage.SEVERITY_INFO);
-            return;
-        }
-
-        context.addMessage(null, message2);
-        severity = context.getMaximumSeverity().getOrdinal();
-        if (severity != FacesMessage.SEVERITY_WARN.getOrdinal()) {
-            out.println(JSFTestUtil.FAIL + " Expected FacesContext." + "getMaximumSeverity() to return FacesMessage."
-                    + "SEVERITY_WARN when both a SEVERITY_INFO and " + "SEVERITY_WARN message exist in the FacesContext.");
-            out.println("Severity Recieved: " + severity);
-            out.println("Integer value of FacesMessage.SEVERITY_WARN: " + FacesMessage.SEVERITY_WARN);
-            return;
-        }
-
-        context.addMessage(null, message3);
-        severity = context.getMaximumSeverity().getOrdinal();
-        if (severity != FacesMessage.SEVERITY_ERROR.getOrdinal()) {
-            out.println(JSFTestUtil.FAIL + " Expected FacesContext." + "getMaximumSeverity() to return FacesMessage."
-                    + "SEVERITY_ERROR when messages with SEVERITY_INFO, " + "SEVERITY_WARN, and SEVERITY_ERROR exist in the"
-                    + " FacesContext.");
-            out.println("Severity Recieved: " + severity);
-            out.println("Integer value of FacesMessage.SEVERITY_ERROR: " + FacesMessage.SEVERITY_ERROR);
-            return;
-        }
-
-        context.addMessage(null, message4);
-        severity = context.getMaximumSeverity().getOrdinal();
-        if (severity != FacesMessage.SEVERITY_FATAL.getOrdinal()) {
-            out.println(JSFTestUtil.FAIL + " Expected FacesContext." + "getMaximumSeverity() to return FacesMessage."
-                    + "SEVERITY_ERROR when messages with SEVERITY_INFO, " + "SEVERITY_WARN, SEVERITY_ERROR, SEVERITY_FATAL exist"
-                    + " in the FacesContext.");
-            out.println("Severity Recieved: " + severity);
-            out.println("Integer value of FacesMessage.SEVERITY_FATAL: " + FacesMessage.SEVERITY_FATAL);
-            return;
-        }
-
-        out.println(JSFTestUtil.PASS);
-    }
-    // FacesContext.getResponseComplete()
-    // FacesContext.responseComplete()
-
-    public void facesCtxResponseCompleteTest(HttpServletRequest request, HttpServletResponse response) throws IOException {
-        PrintWriter out = response.getWriter();
-        FacesContext context = getFacesContext();
-        context.setViewRoot(new UIViewRoot());
-
-        if (context.getResponseComplete()) {
-            out.println(JSFTestUtil.FAIL + " Expected FacesContext." + "getResponseComplete() to return false if FacesContext."
-                    + "responseComplete() hasn't been called.");
-            return;
-        }
-
-        context.responseComplete();
-
-        if (!context.getResponseComplete()) {
-            out.println(JSFTestUtil.FAIL + " Expected FacesContext." + "getResponseComplete() to return true if"
-                    + " FacesContext.responseComplete() has been called.");
-            return;
-        }
-
-        out.println(JSFTestUtil.PASS);
-    }
-    // FacesContext.getRenderResponse()
-    // FacesContext.renderResponse()
-
-    public void facexCtxRenderResponseTest(HttpServletRequest request, HttpServletResponse response) throws IOException {
-        PrintWriter out = response.getWriter();
-        FacesContext context = getFacesContext();
-        context.setViewRoot(new UIViewRoot());
-
-        if (context.getRenderResponse()) {
-            out.println(JSFTestUtil.FAIL + " Expected FacesContext." + "getRenderResponse() to return false if"
-                    + " FacesContext.renderResponse() hasn't been called.");
-            return;
-        }
-
-        context.renderResponse();
-
-        if (!context.getRenderResponse()) {
-            out.println(JSFTestUtil.FAIL + " Expected FacesContext." + "getRenderResponse() to return true if"
-                    + " FacesContext.renderResponse() has been called.");
-            return;
-        }
-
-        out.println(JSFTestUtil.PASS);
-    }
-    // FacesContext.setResponseWriter()
-    // FacesContext.getResponseWriter()
-
-    public void facesCtxSetGetResponseWriterTest(HttpServletRequest request, HttpServletResponse response) throws IOException {
-        PrintWriter out = response.getWriter();
-        FacesContext context = getFacesContext();
-        context.setViewRoot(new UIViewRoot());
-
-        ResponseWriter writer = new TCKResponseWriter();
-
-        context.setResponseWriter(writer);
-        ResponseWriter test = context.getResponseWriter();
-
-        if (test == null) {
-            out.println(JSFTestUtil.FAIL + " FacesContext.getResponseWriter() " + "returned null after FacesContext.setResponseWriter("
-                    + "ResponseWriter) was called.");
-            return;
-        }
-
-        if (test != writer) {
-            out.println(
-                    JSFTestUtil.FAIL + " FacesContext.getResponseWriter()" + " did not return the expected" + " ResponseWriter instance.");
-            out.println("Expected: " + writer);
-            out.println("Received: " + test);
-            return;
-        }
-
-        out.println(JSFTestUtil.PASS);
+    if (i == null) {
+      out.println("Test FAILED[2]. FacesContext.getClientIds"
+          + "WithMessages() returned null when instead of an empty "
+          + "Iterator.");
+      return;
     }
 
-    // FacesContext.[get, set]ResponseStream()
-    public void facesCtxSetGetResponseStreamTest(HttpServletRequest request, HttpServletResponse response) throws IOException {
-        PrintWriter out = response.getWriter();
-        FacesContext context = getFacesContext();
-        context.setViewRoot(new UIViewRoot());
+    if (i.hasNext()) {
+      UIComponent comp = (UIComponent) i.next();
+      if (comp != null) {
+        out.println(
+            JSFTestUtil.FAIL + " Non-null value returned from iterator.");
+        return;
+      }
 
-        ResponseStream stream = new TCKResponseStream();
-
-        context.setResponseStream(stream);
-        ResponseStream test = context.getResponseStream();
-
-        if (test == null) {
-            out.println(JSFTestUtil.FAIL + " FacesContext.getResponseStream()" + " returned null after FacesContext.setResponseStream("
-                    + "ResponseStream) was called.");
-            return;
-        }
-
-        if (test != stream) {
-            out.println(JSFTestUtil.FAIL + " FacesContext.getResponseStream() " + "did not return the expected ResponseStream instance.");
-            out.println("Expected: " + stream);
-            out.println("Received: " + test);
-            return;
-        }
-
-        out.println(JSFTestUtil.PASS);
-
-    }// End facesCtxSetGetResponseStreamTest
-
-    public void facesCtxSetResponseStreamNPETest(HttpServletRequest request, HttpServletResponse response) throws IOException {
-        PrintWriter out = response.getWriter();
-
-        JSFTestUtil.checkForNPE(getFacesContext(), "setResponseStream", new Class<?>[] { ResponseStream.class }, new Object[] { null },
-                out);
-
-    }// End facesCtxSetResponseStreamNPETest
-
-    public void facesCtxSetResponseWriterNPETest(HttpServletRequest request, HttpServletResponse response) throws IOException {
-        PrintWriter out = response.getWriter();
-
-        JSFTestUtil.checkForNPE(getFacesContext(), "setResponseWriter", new Class<?>[] { ResponseWriter.class }, new Object[] { null },
-                out);
-
-    }// End facesCtxSetResponseWriterNPETest
-
-    // FacesContext.[get, set]ViewRoot()
-    public void facesCtxSetGetViewRootTest(HttpServletRequest request, HttpServletResponse response) throws IOException {
-        PrintWriter out = response.getWriter();
-        FacesContext context = getFacesContext();
-        UIViewRoot root = (UIViewRoot) getApplication().createComponent(UIViewRoot.COMPONENT_TYPE);
-
-        context.setViewRoot(root);
-        UIViewRoot test = context.getViewRoot();
-
-        if (test == null) {
-            out.println(JSFTestUtil.FAIL + " FacesContext.getViewRoot() returned " + "null after FacesContext.setViewRoot(UIViewRoot) "
-                    + "was called.");
-            return;
-        }
-
-        if (test != root) {
-            out.println(JSFTestUtil.FAIL + " FacesContext.getViewRoot() did not " + "return the expected UIViewRoot instance.");
-            out.println("Expected: " + root);
-            out.println("Received: " + test);
-            return;
-        }
-
-        out.println(JSFTestUtil.PASS);
-
-    } // End facesCtxSetGetViewRootTest
-
-    // FacesContext.[is, set]ProcessingEvents()
-    public void facesCtxIsGetProcessingEventTest(HttpServletRequest request, HttpServletResponse response) throws IOException {
-        PrintWriter out = response.getWriter();
-        FacesContext context = getFacesContext();
-
-        context.setProcessingEvents(true);
-        if (!context.isProcessingEvents()) {
-            out.println(JSFTestUtil.FAIL + JSFTestUtil.NL + "Unexpected value returned from FacesContext.isProcessingEvents()"
-                    + JSFTestUtil.NL + "Expected: true" + JSFTestUtil.NL + "Received: " + context.isProcessingEvents());
-
-        } else {
-            context.setProcessingEvents(false);
-            if (context.isProcessingEvents()) {
-                out.println(JSFTestUtil.FAIL + JSFTestUtil.NL + "Unexpected value returned from FacesContext.isProcessingEvents()"
-                        + JSFTestUtil.NL + "Expected: false" + JSFTestUtil.NL + "Received: " + context.isProcessingEvents());
-
-            } else {
-                out.println(JSFTestUtil.PASS);
-            }
-        }
-
-    } // End facesCtxIsGetProcessingEventTest
-
-    // FacesContext.[get, set]CurrentPhaseId()
-    public void facesCtxSetGetCurrentPhaseIdTest(HttpServletRequest request, HttpServletResponse response) throws IOException {
-        PrintWriter out = response.getWriter();
-        FacesContext context = getFacesContext();
-
-        context.setCurrentPhaseId(PhaseId.ANY_PHASE);
-        PhaseId result = context.getCurrentPhaseId();
-        if (PhaseId.ANY_PHASE.equals(result)) {
-            out.println(JSFTestUtil.PASS);
-
-        } else {
-            out.println(JSFTestUtil.FAIL + " FacesContext.getCurrentPhaseId() did not " + "return the expected PhaseId.");
-            out.println("Expected: " + PhaseId.ANY_PHASE);
-            out.println("Received: " + result);
-        }
-
-    } // End facesCtxSetGetCurrentPhaseIdTest
-
-    // Ensure NPE is thrown if a null argument is passed to
-    // FacesContext.setViewRoot().
-    public void facesCtxSetViewRootNPETest(HttpServletRequest request, HttpServletResponse response) throws IOException {
-        PrintWriter out = response.getWriter();
-
-        JSFTestUtil.checkForNPE(getFacesContext(), "setViewRoot", new Class<?>[] { UIViewRoot.class }, new Object[] { null }, out);
+      if (i.hasNext()) {
+        out.println(JSFTestUtil.FAIL + " Iterator contained more than 1"
+            + " value after when getClientIdWithMessages() was "
+            + "called where a Message existed with no client id.");
+        return;
+      }
     }
 
-    // All methods of FacesContext must throw an IllegalStateException
-    // if called after FacesContext.release() has been called with the
-    // Exception of those referenced in the exMethods List.
-    public void facesCtxISEAfterReleaseTest(HttpServletRequest request, HttpServletResponse response) throws IOException {
-        PrintWriter out = response.getWriter();
-        FacesContext context = getFacesContext();
+    out.println(JSFTestUtil.PASS);
+  }
+  // FacesContext.addMessage(UIComponent, FacesMessage)
+  // FacesContext.getMessages()
+  // FacesContext.getMessages(UIComponent)
+  // 7/18/05 updated test to ensure message order is retained by returned
+  // iterators.
 
-        // Excluded methods that do not throw IllegalStateException.
-        List<String> exMethods = new ArrayList<String>();
-        exMethods.add("release");
-        exMethods.add("isReleased");
-        exMethods.add("getComponentModificationManager");
-        exMethods.add("setCurrentInstance");
-        exMethods.add("getCurrentInstance");
-        exMethods.add("getCurrentPhaseId");
-        exMethods.add("setExceptionHandler");
-        exMethods.add("getExceptionHandler");
-        exMethods.add("setProcessingEvents");
-        exMethods.add("isProcessingEvents");
+  public void facesCtxAddGetMessagesTest(HttpServletRequest request,
+      HttpServletResponse response) throws IOException {
+    PrintWriter out = response.getWriter();
 
-        Method[] methods = FacesContext.class.getDeclaredMethods();
-        
-        // Loop through the remaining methods an ensure they all
-        // throw an IllegalStateException
-        context.release();
+    UIComponent component = getApplication()
+        .createComponent(UIInput.COMPONENT_TYPE);
+    component.setId("input1");
+    FacesMessage message1 = new TCKMessage(FacesMessage.SEVERITY_INFO,
+        "message1 summary", "message1 detail", "message1");
+    FacesMessage message2 = new TCKMessage(FacesMessage.SEVERITY_INFO,
+        "message2 summary", "message2 detail", "message2");
+    FacesMessage message3 = new TCKMessage(FacesMessage.SEVERITY_INFO,
+        "message3 summary", "message3 detail", "message3");
+    FacesMessage message4 = new TCKMessage(FacesMessage.SEVERITY_INFO,
+        "message4 summary", "message4 detail", "message4");
 
-        for (int i = 0; i < methods.length; i++) {
-            Method method = methods[i];
-            String name = method.getName();
+    FacesContext context = getFacesContext();
+    context.setViewRoot(createViewRoot());
 
-            if (!isExcluded(name, exMethods) && !name.startsWith("lambda$")) {
-                Class<?>[] types = method.getParameterTypes();
-                Object[] params = new Object[types.length];
+    context.addMessage(component.getClientId(context), message1);
+    context.addMessage(component.getClientId(context), message3);
+    context.addMessage(null, message2);
+    context.addMessage(null, message4);
 
-                if (name.equals("isProjectStage")) {
-                    params[0] = ProjectStage.Development;
-                }
+    FacesMessage[] controlMessagesComp = { message1, message3 };
+    FacesMessage[] controlMessagesNoComp = { message1, message3, message2,
+        message4 };
+    FacesMessage[] controlMessagesNullComp = { message2, message4 };
 
-                JSFTestUtil.checkForISE(context, name, types, params, out);
-            }
-        }
+    FacesMessage[] testMessagesComp = getMessagesAsArray(
+        context.getMessages(component.getClientId(context)));
+
+    // the next two should be equivalent
+    FacesMessage[] testMessagesNullComp = getMessagesAsArray(
+        context.getMessages(null));
+    FacesMessage[] testMessages = getMessagesAsArray(context.getMessages());
+
+    // check the messages associated with a component
+    if (controlMessagesComp.length != testMessagesComp.length) {
+      out.println(JSFTestUtil.FAIL + " An unexpected number of messages"
+          + " returned when FacesContext. getMessages(UIComponent)"
+          + " was called.");
+      out.println("Expected 2 messages to be returned. Actual message "
+          + "count: " + testMessagesComp.length);
+      return;
     }
 
-    public void facesCtxGetELContextTest(HttpServletRequest request, HttpServletResponse response) throws IOException {
-        PrintWriter out = response.getWriter();
-        FacesContext context = getFacesContext();
-
-        ELContext elContext = context.getELContext();
-
-        if (elContext == null) {
-            out.println(JSFTestUtil.FAIL + " FacesContext.getELContext() returned" + " null.");
-            return;
-        }
-
-        out.println(JSFTestUtil.PASS);
-
-    } // END facesCtxGetELContextTest
-
-    public void facesCtxGetAttributesTest(HttpServletRequest request, HttpServletResponse response) throws IOException {
-
-        PrintWriter out = response.getWriter();
-        FacesContext context = getFacesContext();
-
-        if (!(context.getAttributes() instanceof Map)) {
-            out.println("Test FAILED. Unexpected class type returned from" + "FacesContext.getAttributes() method." + JSFTestUtil.NL
-                    + "Expected: java.util.Map" + JSFTestUtil.NL + "Received: " + context.getAttributes().getClass().getName());
-            return;
-        } else {
-            try {
-                context.getAttributes().put("test_key", "test_value");
-
-            } catch (UnsupportedOperationException usoe) {
-                out.print("Test FAILED. Map Not Mutable!");
-                out.print(usoe.toString());
-            } catch (Exception e) {
-                /*
-                 * Swallow any other exception since we only care if the Map is mutable.
-                 */
-            }
-        }
-
-        out.println(JSFTestUtil.PASS);
-
-    } // END facesCtxgetAttributesTest
-
-    public void facesCtxGetAttributesEmptyTest(HttpServletRequest request, HttpServletResponse response) throws IOException {
-
-        PrintWriter out = response.getWriter();
-        FacesContext context = getFacesContext();
-
-        try {
-            context.getAttributes().put("test_key", "test_value");
-            // validate that the attribute was put in.
-            HashMap<?, ?> hm = (HashMap<?, ?>) context.getAttributes();
-            if (!hm.containsKey("test_key")) {
-                out.println("Test FAILED. Attribute not added to context" + "attribute Map!");
-                return;
-            } else {
-                // map should be empty after this call.
-                context.release();
-                if (!hm.isEmpty()) {
-                    out.println(
-                            "Test FAILED. Attributes still found in " + "context attribute Map, After 'context.release()" + "was called!");
-                    return;
-                }
-
-            }
-        } catch (Exception e) {
-            out.print("Test FAILED." + JSFTestUtil.NL + e.toString());
-        }
-
-        out.println(JSFTestUtil.PASS);
-
-    } // END facesCtxgetAttributesEmptyTest
-
-    public void facesCtxGetPartialViewContextTest(HttpServletRequest request, HttpServletResponse response) throws IOException {
-
-        PrintWriter out = response.getWriter();
-        FacesContext context = getFacesContext();
-
-        try {
-            PartialViewContext pvc = context.getPartialViewContext();
-            if (!(pvc instanceof PartialViewContext)) {
-                out.print("Test FAILED." + JSFTestUtil.NL + "Call to " + "FacesContext.getPartialViewContext() should have "
-                        + "returned a PartialViewContext." + JSFTestUtil.NL + "Instead Received: " + pvc.getClass().getSimpleName());
-                return;
-            }
-        } catch (Exception e) {
-            out.print("Test FAILED." + JSFTestUtil.NL + e.toString());
-        }
-
-        out.println(JSFTestUtil.PASS);
-
-    } // END facesCtxgetPartialViewContextTest
-
-    public void facesCtxSetGetExceptionHandlerTest(HttpServletRequest request, HttpServletResponse response) throws IOException {
-
-        PrintWriter out = response.getWriter();
-        FacesContext context = getFacesContext();
-        ExceptionHandler eh = new TCKExceptionHandler();
-        context.setExceptionHandler(eh);
-
-        String golden = "TCKExceptionHandler";
-        String result = context.getExceptionHandler().getClass().getSimpleName();
-
-        if (golden.equals(result)) {
-            out.println(JSFTestUtil.PASS);
-
-        } else {
-            out.print("Test FAILED." + JSFTestUtil.NL + " Unexpected value returned from" + "FacesContext.getExceptionHandler()!"
-                    + JSFTestUtil.NL + "Expected: " + golden + JSFTestUtil.NL + "Received: " + result);
-        }
-
-    } // END facesCtxSetGetExceptionHandlerTest
-
-    public void facesCtxsetExceptionHandlerTest(HttpServletRequest request, HttpServletResponse response) throws IOException {
-
-        PrintWriter out = response.getWriter();
-        FacesContext context = getFacesContext();
-
-        try {
-            context.setExceptionHandler(new TCKExceptionHandler());
-            ExceptionHandler eh = context.getExceptionHandler();
-            if (!("TCKExceptionHandler".equals(eh.getClass().getSimpleName()))) {
-                out.print("Test FAILED." + JSFTestUtil.NL + "Call to " + "FacesContext.setExceptionHandler() did not set " + "Handler!"
-                        + JSFTestUtil.NL + "Expected: TCKExceptionHandler" + JSFTestUtil.NL + "Received: " + eh.getClass().getSimpleName());
-                return;
-            }
-        } catch (Exception e) {
-            out.print("Test FAILED." + JSFTestUtil.NL + e.toString());
-        }
-
-        out.println(JSFTestUtil.PASS);
-
-    } // END facesCtxgetExceptionHandlerTest
-
-    public void facesCtxGetExternalContextTest(HttpServletRequest request, HttpServletResponse response) throws IOException {
-
-        PrintWriter out = response.getWriter();
-        FacesContext context = getFacesContext();
-
-        try {
-            ExternalContext ec = context.getExternalContext();
-            if (!(ec instanceof ExternalContext)) {
-                out.print("Test FAILED." + JSFTestUtil.NL + "Call to " + "FacesContext.getExternalContext did not return"
-                        + "correct instance type." + JSFTestUtil.NL + "Expected: ExternalContext" + JSFTestUtil.NL + "Received: "
-                        + ec.getClass().getSimpleName());
-                return;
-            }
-        } catch (Exception e) {
-            out.print("Test FAILED." + JSFTestUtil.NL + e.toString());
-        }
-
-        out.println(JSFTestUtil.PASS);
-
-    } // END facesCtxgetExternalContextTest
-
-    public void facesCtxisReleasedTest(HttpServletRequest request, HttpServletResponse response) throws IOException {
-        PrintWriter out = response.getWriter();
-        FacesContext context = getFacesContext();
-
-        // Test before release.
-        if (context.isReleased()) {
-            out.println("Test FAILED");
-            out.println("Unexpected value returned from FacesContext.isReleased() " + "before FacesContext.release() was callled."
-                    + JSFTestUtil.NL + "Expected: FALSE " + JSFTestUtil.NL + "Received: TRUE" + JSFTestUtil.NL);
-            return;
-        }
-
-        // Test After release
-        context.release();
-        if (!context.isReleased()) {
-            out.println("Test FAILED");
-            out.println("Unexpected value returned from FacesContext.isReleased() " + "after FacesContext.release() was called. "
-                    + JSFTestUtil.NL + "Expected: TRUE " + JSFTestUtil.NL + "Received: FALSE" + JSFTestUtil.NL);
-            return;
-        }
-
-        out.println(JSFTestUtil.PASS);
-
-    } // END facesCtxisReleasedTest
-
-    public void facesCtxGetRenderKitTest(HttpServletRequest request, HttpServletResponse response) throws IOException {
-
-        PrintWriter out = response.getWriter();
-        FacesContext context = getFacesContext();
-        UIViewRoot root = context.getViewRoot();
-        String rkn = "TCKRenderKit";
-
-        // Setup renderKit
-        RenderKit renderKit = new TCKRenderKit();
-        RenderKitFactory factory = (RenderKitFactory) FactoryFinder.getFactory(FactoryFinder.RENDER_KIT_FACTORY);
-        factory.addRenderKit(rkn, renderKit);
-
-        root.setRenderKitId(rkn);
-        RenderKit result = context.getRenderKit();
-
-        if (rkn.equals(result.getClass().getSimpleName())) {
-            out.println(JSFTestUtil.PASS);
-
-        } else {
-            out.println(JSFTestUtil.FAIL + JSFTestUtil.NL + "Unexpected RenderKit returned from FacesContext.getRenderKit()"
-                    + JSFTestUtil.NL + "Expected: " + rkn + JSFTestUtil.NL + "Received: " + result);
-        }
-    } // END facesCtxGetRenderKitTest
-
-    // ------------------------------------------- Private Methods -----------
-    private String validateIllegalStateException(Method methodToInvoke, Object target, Object[] params) {
-        String result = null;
-
-        try {
-            methodToInvoke.invoke(target, params);
-            result = JSFTestUtil.FAIL + " No Exception thrown when calling '" + methodToInvoke.getName() + "'"
-                    + " after FacesContext.release() was called.";
-
-        } catch (Throwable throwable) {
-            Throwable t = throwable;
-            if (throwable instanceof InvocationTargetException) {
-                t = ((InvocationTargetException) throwable).getTargetException();
-            }
-
-            if (!(t instanceof IllegalStateException)) {
-                StringBuffer sb = new StringBuffer(100);
-                sb.append(JSFTestUtil.FAIL + " Exception thrown when '").append(methodToInvoke.getName());
-                sb.append("' was called after FacesContext.release(), but it " + "wasn't an instance of");
-                sb.append(" IllegalStateException.\nException received: ").append(t.getClass().getName());
-                result = sb.toString();
-            }
-        }
-        return result;
+    List messages = Arrays.asList(testMessagesComp);
+    for (int i = 0; i < controlMessagesComp.length; i++) {
+      if (!messages.get(i).equals(controlMessagesComp[i])) {
+        out.println(JSFTestUtil.FAIL + " Unable to find '"
+            + controlMessagesComp[i] + "' in the return value of FacesContext."
+            + "getMessages(UIComponent) when the appropriate"
+            + " component was provided.");
+        out.println(
+            "Messages returned: " + JSFTestUtil.getAsString(testMessagesComp));
+        return;
+      }
     }
 
-    private boolean isExcluded(String methodName, List<String> excludeList) {
-        boolean result = false;
-
-        for (String excluded : excludeList) {
-            if (excluded.equals(methodName) || methodName.charAt(0) == '$') {
-                result = true;
-            }
-        }
-
-        return result;
+    // check the messages returned when a null value is provided
+    // to FacesContext.getMessages(null)
+    if (controlMessagesNullComp.length != testMessagesNullComp.length) {
+      out.println(JSFTestUtil.FAIL + " An unexpected number of messages "
+          + "returned when FacesContext. getMessages(null) was " + "called.");
+      out.println("Expected 2 messages to be returned. Actual message "
+          + "count: " + testMessagesNullComp.length);
+      return;
     }
 
-    private FacesMessage[] getMessagesAsArray(Iterator iterator) {
-        List list = new ArrayList();
-        while (iterator.hasNext()) {
-            list.add(iterator.next());
-        }
-        return (FacesMessage[]) list.toArray(new FacesMessage[list.size()]);
+    messages = Arrays.asList(testMessagesNullComp);
+    for (int i = 0; i < controlMessagesNullComp.length; i++) {
+      if (!messages.get(i).equals(controlMessagesNullComp[i])) {
+        out.println(
+            JSFTestUtil.FAIL + " Unable to find '" + controlMessagesNullComp[i]
+                + "' in the return value of FacesContext."
+                + "getMessages(UIComponent) when null was passed to the"
+                + " method.");
+        out.println("Messages returned: "
+            + JSFTestUtil.getAsString(testMessagesNullComp));
+        return;
+      }
     }
+
+    // check the messages returned by FacesContext.getMessages()
+    if (controlMessagesNoComp.length != testMessages.length) {
+      out.println(JSFTestUtil.FAIL + " An unexpected number of messages "
+          + "returned when FacesContext." + "getMessages() was called.");
+      out.println("Expected 4 messages to be returned. Actual message"
+          + " count: " + testMessages.length);
+      return;
+    }
+
+    messages = Arrays.asList(testMessages);
+    for (int i = 0; i < controlMessagesNoComp.length; i++) {
+      if (!messages.get(i).equals(controlMessagesNoComp[i])) {
+        out.println(
+            JSFTestUtil.FAIL + " Unable to find '" + controlMessagesNoComp[i]
+                + "' in the return value of FacesContext." + "getMessages()");
+        out.println(
+            "Messages returned: " + JSFTestUtil.getAsString(testMessages));
+        return;
+      }
+    }
+    out.println(JSFTestUtil.PASS);
+  }
+  // FacesContext.getMessages(UIComponent)
+  // FacesContext.getMessages()
+  // - both return an empty Iterator if no messages were added.
+
+  public void facesCtxGetMessagesEmptyTest(HttpServletRequest request,
+      HttpServletResponse response) throws IOException {
+    PrintWriter out = response.getWriter();
+    FacesContext context = getFacesContext();
+    context.setViewRoot(createViewRoot());
+
+    Iterator i = context.getMessages();
+    if (i != null) {
+      if (i.hasNext()) {
+        out.println(JSFTestUtil.FAIL + " FacesContext.getMessages() "
+            + "returned a non-empty Iterator when no FacesMessage "
+            + "instances were added.");
+        return;
+      }
+    } else {
+      out.println(JSFTestUtil.FAIL + " FacesContext.getMessages() returned "
+          + "null as opposed to an empty Iterator.");
+      return;
+    }
+
+    i = context.getMessages(getApplication()
+        .createComponent(UIInput.COMPONENT_TYPE).getClientId(context));
+    if (i != null) {
+      if (i.hasNext()) {
+        out.println(JSFTestUtil.FAIL + " FacesContext.getMessages("
+            + "UIComponent) returned a non-empty Iterator when no "
+            + "FacesMessage instances were added.");
+        return;
+      }
+    } else {
+      out.println(JSFTestUtil.FAIL + " FacesContext.getMessages(UIComponent)"
+          + " returned null as opposed to an empty Iterator.");
+      return;
+    }
+
+    i = context.getMessages(null);
+    if (i != null) {
+      if (i.hasNext()) {
+        out.println(JSFTestUtil.FAIL + " FacesContext.getMessages(null) "
+            + "returned a non-empty Iterator when no FacesMessage"
+            + " instances were added.");
+        return;
+      }
+    } else {
+      out.println(JSFTestUtil.FAIL + " FacesContext.getMessages(null) "
+          + "returned null as opposed to an empty Iterator.");
+      return;
+    }
+
+    out.println(JSFTestUtil.PASS);
+  }
+
+  public void facesCtxGetMessageListTest(HttpServletRequest request,
+      HttpServletResponse response) throws IOException {
+
+    PrintWriter out = response.getWriter();
+    FacesContext context = getFacesContext();
+    this.addTestMessagesToContext(context, null);
+
+    try {
+      List allMessages = context.getMessageList();
+      if (allMessages.size() != 4) {
+        out.print("Test FAILED." + JSFTestUtil.NL + "Call to "
+            + "FacesContext.getMessageList unexepected size! " + JSFTestUtil.NL
+            + "Expected: 4" + JSFTestUtil.NL + "Received: "
+            + allMessages.size());
+        return;
+      }
+    } catch (Exception e) {
+      out.print("Test FAILED." + JSFTestUtil.NL + e.toString());
+    }
+
+    out.println(JSFTestUtil.PASS);
+
+  } // END facesCtxgetMessageListTest
+
+  public void facesCtxGetMessageListByIdTest(HttpServletRequest request,
+      HttpServletResponse response) throws IOException {
+
+    PrintWriter out = response.getWriter();
+    FacesContext context = getFacesContext();
+    this.addTestMessagesToContext(context, "test_one");
+
+    try {
+      List allMessages = context.getMessageList("test_one");
+      if (allMessages.size() != 2) {
+        out.print("Test FAILED." + JSFTestUtil.NL + "Call to "
+            + "FacesContext.getMessageList unexepected size! " + JSFTestUtil.NL
+            + "Expected: 2" + JSFTestUtil.NL + "Received: "
+            + allMessages.size());
+        return;
+      }
+    } catch (Exception e) {
+      out.print("Test FAILED." + JSFTestUtil.NL + e.toString());
+    }
+
+    out.println(JSFTestUtil.PASS);
+
+  } // END facesCtxgetMessageListByIdTest
+
+  public void facesCtxisValidationFailedTest(HttpServletRequest request,
+      HttpServletResponse response) throws IOException {
+
+    PrintWriter out = response.getWriter();
+    FacesContext context = getFacesContext();
+    Boolean isFailed;
+    try {
+      isFailed = context.isValidationFailed();
+      if (isFailed) {
+        out.print("Test FAILED." + JSFTestUtil.NL + "Unexpected result from "
+            + "FacesContext.isValadationFailed()" + JSFTestUtil.NL
+            + "Expected: false" + JSFTestUtil.NL + "Received: " + isFailed);
+        return;
+      }
+
+      context.validationFailed();
+      isFailed = context.isValidationFailed();
+      if (!isFailed) {
+        out.print("Test FAILED." + JSFTestUtil.NL + "Unexpected result from "
+            + "FacesContext.isValadationFailed() after calling "
+            + "FacesContext.validationFailed." + JSFTestUtil.NL
+            + "Expected: true" + JSFTestUtil.NL + "Received: " + isFailed);
+        return;
+      }
+    } catch (Exception e) {
+      out.print("Test FAILED." + JSFTestUtil.NL + e.toString());
+    }
+
+    out.println(JSFTestUtil.PASS);
+
+  } // END facesCtxisValidationFailedTest
+
+  public void facesCtxisPostbackTest(HttpServletRequest request,
+      HttpServletResponse response) throws IOException {
+
+    PrintWriter out = response.getWriter();
+    FacesContext context = getFacesContext();
+    context.getApplication();
+    Boolean isPB;
+
+    try {
+      isPB = context.isPostback();
+      if (isPB) {
+        out.print("Test FAILED." + JSFTestUtil.NL + "Unexpected result from "
+            + "FacesContext.isPostback() before calling "
+            + "StateManger.writeState()." + JSFTestUtil.NL + "Expected: false"
+            + JSFTestUtil.NL + "Received: " + isPB);
+        return;
+      }
+
+    } catch (Exception e) {
+      out.print("Test FAILED." + JSFTestUtil.NL + e.toString());
+    }
+
+    out.println(JSFTestUtil.PASS);
+
+  } // END facesCtxisPostbackTest
+
+  // FacesContext.getApplication()
+  public void facesCtxGetApplicationTest(HttpServletRequest request,
+      HttpServletResponse response) throws IOException {
+    PrintWriter out = response.getWriter();
+    Application controlApplication = getApplication();
+    Application testApplication = getFacesContext().getApplication();
+
+    if (controlApplication == null) {
+      out.println(JSFTestUtil.FAIL + " Application.getCurrentInstance() "
+          + "unexpectedly returned null.");
+      return;
+    }
+
+    if (controlApplication != testApplication) {
+      out.println(JSFTestUtil.FAIL + " The Application instance returned by "
+          + "Application. getCurrentInstance() differs from the "
+          + "Application returned by FacesContext.getApplication().");
+      out.println("Application.getCurrentInstance(): " + controlApplication);
+      out.println("FacesContext.getApplication():" + testApplication);
+      return;
+    }
+
+    out.println(JSFTestUtil.PASS);
+  }
+  // FacesContext.addMessage(UIComponent, FacesMessage) throws NPE if
+  // FacesMessage is null
+
+  public void facesCtxAddMessageNPETest(HttpServletRequest request,
+      HttpServletResponse response) throws IOException {
+    PrintWriter out = response.getWriter();
+
+    JSFTestUtil.checkForNPE(getFacesContext(), "addMessage",
+        new Class<?>[] { String.class, FacesMessage.class },
+        new Object[] { "id", null }, out);
+  }
+
+  // FacesContext.isProjectStage(ProjectStage stage) throws NPE if stage is null
+  public void facesCtxIsProjectStageNPETest(HttpServletRequest request,
+      HttpServletResponse response) throws IOException {
+    PrintWriter out = response.getWriter();
+
+    JSFTestUtil.checkForNPE(getFacesContext(), "isProjectStage",
+        new Class<?>[] { ProjectStage.class }, new Object[] { null }, out);
+  }
+
+  // FacesContext.getCurrentInstance()
+  public void facesCtxSetGetCurrentInstanceTest(HttpServletRequest request,
+      HttpServletResponse response) throws IOException {
+    PrintWriter out = response.getWriter();
+    FacesContext controlContext = getFacesContext();
+    FacesContext testContext = FacesContext.getCurrentInstance();
+
+    if (controlContext != testContext) {
+      out.println(JSFTestUtil.FAIL + " FacesContext.getCurrentInstance() "
+          + "returned a FacesContext instance that differs from the "
+          + "one that is currently services this request.");
+      out.println("Current FacesContext: " + controlContext);
+      out.println("FacesContext.getCurrentInstance(): " + testContext);
+      return;
+    }
+
+    out.println(JSFTestUtil.PASS);
+  }
+
+  // FacesContext.getMaximumSeverity()
+  public void facesCtxGetMaximumSeverityTest(HttpServletRequest request,
+      HttpServletResponse response) throws IOException {
+    PrintWriter out = response.getWriter();
+    FacesContext context = getFacesContext();
+    context.setViewRoot(new UIViewRoot());
+    FacesMessage message1 = new TCKMessage(FacesMessage.SEVERITY_INFO,
+        "message1 summary", "message1 detail", "message1");
+    FacesMessage message2 = new TCKMessage(FacesMessage.SEVERITY_WARN,
+        "message2 summary", "message2 detail", "message2");
+    FacesMessage message3 = new TCKMessage(FacesMessage.SEVERITY_ERROR,
+        "message3 summary", "message3 detail", "message3");
+    FacesMessage message4 = new TCKMessage(FacesMessage.SEVERITY_FATAL,
+        "message4 summary", "message4 detail", "message4");
 
     /*
-     * Add test messages to the given FacesContext.
+     * if no messages have been queued, then FacesContext.getMaximumSeverity
+     * should return null
      */
-    private void addTestMessagesToContext(FacesContext context, String compId) {
-
-        UIComponent component = getApplication().createComponent(UIInput.COMPONENT_TYPE);
-        if (compId == null) {
-            component.setId("nothing");
-        } else {
-            component.setId(compId);
-        }
-
-        FacesMessage message1 = new TCKMessage(FacesMessage.SEVERITY_INFO, "message1 summary", "message1 detail", "message1");
-        FacesMessage message2 = new TCKMessage(FacesMessage.SEVERITY_INFO, "message2 summary", "message2 detail", "message2");
-        FacesMessage message3 = new TCKMessage(FacesMessage.SEVERITY_INFO, "message3 summary", "message3 detail", "message3");
-        FacesMessage message4 = new TCKMessage(FacesMessage.SEVERITY_INFO, "message4 summary", "message4 detail", "message4");
-
-        context.setViewRoot(createViewRoot());
-
-        context.addMessage(component.getClientId(context), message1);
-        context.addMessage(component.getClientId(context), message3);
-        context.addMessage(null, message2);
-        context.addMessage(null, message4);
+    if (context.getMaximumSeverity() != null) {
+      out.println(
+          JSFTestUtil.FAIL + " FacesContext.getMaximumSeverity returned a"
+              + "non null value when no messages have been added to the"
+              + " FacesContext.");
+      out.println(
+          "Severity received: " + context.getMaximumSeverity().getOrdinal());
+      return;
     }
 
-    // ------------------------------------------- Inner Classes -----------
-    
-    // Skeletal implementation of ResponseStream
-    private static final class TCKResponseStream extends ResponseStream {
-
-        @Override
-        public void write(int b) throws IOException {
-        }
+    context.addMessage(null, message1);
+    int severity = context.getMaximumSeverity().getOrdinal();
+    if (severity != FacesMessage.SEVERITY_INFO.getOrdinal()) {
+      out.println(JSFTestUtil.FAIL + " Expected FacesContext."
+          + "getMaximumSeverity() to return FacesMessage."
+          + "SEVERITY_INFO when only a SEVERITY_INFO message exists"
+          + " in the FacesContext.");
+      out.println("Severity Recieved: " + severity);
+      out.println("Integer value of FacesMessage.SEVERITY_INFO: "
+          + FacesMessage.SEVERITY_INFO);
+      return;
     }
 
-    // Skeletal implementation of ResponseWriter
-    private static final class TCKResponseWriter extends ResponseWriter {
-
-        public void closeStartTag(UIComponent component) throws IOException {
-        }
-
-        @Override
-        public String getContentType() {
-            return null;
-        }
-
-        @Override
-        public String getCharacterEncoding() {
-            return null;
-        }
-
-        @Override
-        public void write(char cbuf[], int off, int len) throws IOException {
-        }
-
-        @Override
-        public void flush() throws IOException {
-        }
-
-        @Override
-        public void close() throws IOException {
-        }
-
-        @Override
-        public void startDocument() throws IOException {
-        }
-
-        @Override
-        public void endDocument() throws IOException {
-        }
-
-        @Override
-        public void startElement(String name, UIComponent component) throws IOException {
-        }
-
-        @Override
-        public void endElement(String name) throws IOException {
-        }
-
-        @Override
-        public void writeAttribute(String name, Object value, String property) throws IOException {
-        }
-
-        @Override
-        public void writeURIAttribute(String name, Object value, String property) throws IOException {
-        }
-
-        @Override
-        public void writeComment(Object comment) throws IOException {
-        }
-
-        @Override
-        public void writeText(Object text, String property) throws IOException {
-        }
-
-        @Override
-        public void writeText(char text[], int off, int len) throws IOException {
-        }
-
-        @Override
-        public ResponseWriter cloneWithWriter(Writer writer) {
-            return null;
-        }
+    context.addMessage(null, message2);
+    severity = context.getMaximumSeverity().getOrdinal();
+    if (severity != FacesMessage.SEVERITY_WARN.getOrdinal()) {
+      out.println(JSFTestUtil.FAIL + " Expected FacesContext."
+          + "getMaximumSeverity() to return FacesMessage."
+          + "SEVERITY_WARN when both a SEVERITY_INFO and "
+          + "SEVERITY_WARN message exist in the FacesContext.");
+      out.println("Severity Recieved: " + severity);
+      out.println("Integer value of FacesMessage.SEVERITY_WARN: "
+          + FacesMessage.SEVERITY_WARN);
+      return;
     }
 
-    // Simple implementation of FacesMessage
-    private static final class TCKMessage extends FacesMessage {
-
-        private FacesMessage.Severity messageSeverity;
-
-        private String messageSummary;
-
-        private String messageDetail;
-
-        String name;
-
-        TCKMessage(FacesMessage.Severity severity, String messageSummary, String messageDetail, String name) {
-            this.messageSeverity = severity;
-            this.messageSummary = messageSummary;
-            this.messageDetail = messageDetail;
-            this.name = name;
-        }
-
-        @Override
-        public String getDetail() {
-            return messageDetail;
-        }
-
-        @Override
-        public FacesMessage.Severity getSeverity() {
-            return messageSeverity;
-        }
-
-        @Override
-        public String getSummary() {
-            return messageSummary;
-        }
-
-        @Override
-        public String toString() {
-            return name;
-        }
+    context.addMessage(null, message3);
+    severity = context.getMaximumSeverity().getOrdinal();
+    if (severity != FacesMessage.SEVERITY_ERROR.getOrdinal()) {
+      out.println(JSFTestUtil.FAIL + " Expected FacesContext."
+          + "getMaximumSeverity() to return FacesMessage."
+          + "SEVERITY_ERROR when messages with SEVERITY_INFO, "
+          + "SEVERITY_WARN, and SEVERITY_ERROR exist in the"
+          + " FacesContext.");
+      out.println("Severity Recieved: " + severity);
+      out.println("Integer value of FacesMessage.SEVERITY_ERROR: "
+          + FacesMessage.SEVERITY_ERROR);
+      return;
     }
 
-    // Simple implementation of ExceptionHandler
-    private static final class TCKExceptionHandler extends ExceptionHandlerWrapper {
+    context.addMessage(null, message4);
+    severity = context.getMaximumSeverity().getOrdinal();
+    if (severity != FacesMessage.SEVERITY_FATAL.getOrdinal()) {
+      out.println(JSFTestUtil.FAIL + " Expected FacesContext."
+          + "getMaximumSeverity() to return FacesMessage."
+          + "SEVERITY_ERROR when messages with SEVERITY_INFO, "
+          + "SEVERITY_WARN, SEVERITY_ERROR, SEVERITY_FATAL exist"
+          + " in the FacesContext.");
+      out.println("Severity Recieved: " + severity);
+      out.println("Integer value of FacesMessage.SEVERITY_FATAL: "
+          + FacesMessage.SEVERITY_FATAL);
+      return;
+    }
 
-        @Override
-        public ExceptionHandler getWrapped() {
-            // TODO Auto-generated method stub
-            return null;
+    out.println(JSFTestUtil.PASS);
+  }
+  // FacesContext.getResponseComplete()
+  // FacesContext.responseComplete()
+
+  public void facesCtxResponseCompleteTest(HttpServletRequest request,
+      HttpServletResponse response) throws IOException {
+    PrintWriter out = response.getWriter();
+    FacesContext context = getFacesContext();
+    context.setViewRoot(new UIViewRoot());
+
+    if (context.getResponseComplete()) {
+      out.println(JSFTestUtil.FAIL + " Expected FacesContext."
+          + "getResponseComplete() to return false if FacesContext."
+          + "responseComplete() hasn't been called.");
+      return;
+    }
+
+    context.responseComplete();
+
+    if (!context.getResponseComplete()) {
+      out.println(JSFTestUtil.FAIL + " Expected FacesContext."
+          + "getResponseComplete() to return true if"
+          + " FacesContext.responseComplete() has been called.");
+      return;
+    }
+
+    out.println(JSFTestUtil.PASS);
+  }
+  // FacesContext.getRenderResponse()
+  // FacesContext.renderResponse()
+
+  public void facexCtxRenderResponseTest(HttpServletRequest request,
+      HttpServletResponse response) throws IOException {
+    PrintWriter out = response.getWriter();
+    FacesContext context = getFacesContext();
+    context.setViewRoot(new UIViewRoot());
+
+    if (context.getRenderResponse()) {
+      out.println(JSFTestUtil.FAIL + " Expected FacesContext."
+          + "getRenderResponse() to return false if"
+          + " FacesContext.renderResponse() hasn't been called.");
+      return;
+    }
+
+    context.renderResponse();
+
+    if (!context.getRenderResponse()) {
+      out.println(JSFTestUtil.FAIL + " Expected FacesContext."
+          + "getRenderResponse() to return true if"
+          + " FacesContext.renderResponse() has been called.");
+      return;
+    }
+
+    out.println(JSFTestUtil.PASS);
+  }
+  // FacesContext.setResponseWriter()
+  // FacesContext.getResponseWriter()
+
+  public void facesCtxSetGetResponseWriterTest(HttpServletRequest request,
+      HttpServletResponse response) throws IOException {
+    PrintWriter out = response.getWriter();
+    FacesContext context = getFacesContext();
+    context.setViewRoot(new UIViewRoot());
+
+    ResponseWriter writer = new TCKResponseWriter();
+
+    context.setResponseWriter(writer);
+    ResponseWriter test = context.getResponseWriter();
+
+    if (test == null) {
+      out.println(JSFTestUtil.FAIL + " FacesContext.getResponseWriter() "
+          + "returned null after FacesContext.setResponseWriter("
+          + "ResponseWriter) was called.");
+      return;
+    }
+
+    if (test != writer) {
+      out.println(JSFTestUtil.FAIL + " FacesContext.getResponseWriter()"
+          + " did not return the expected" + " ResponseWriter instance.");
+      out.println("Expected: " + writer);
+      out.println("Received: " + test);
+      return;
+    }
+
+    out.println(JSFTestUtil.PASS);
+  }
+
+  // FacesContext.[get, set]ResponseStream()
+  public void facesCtxSetGetResponseStreamTest(HttpServletRequest request,
+      HttpServletResponse response) throws IOException {
+    PrintWriter out = response.getWriter();
+    FacesContext context = getFacesContext();
+    context.setViewRoot(new UIViewRoot());
+
+    ResponseStream stream = new TCKResponseStream();
+
+    context.setResponseStream(stream);
+    ResponseStream test = context.getResponseStream();
+
+    if (test == null) {
+      out.println(JSFTestUtil.FAIL + " FacesContext.getResponseStream()"
+          + " returned null after FacesContext.setResponseStream("
+          + "ResponseStream) was called.");
+      return;
+    }
+
+    if (test != stream) {
+      out.println(JSFTestUtil.FAIL + " FacesContext.getResponseStream() "
+          + "did not return the expected ResponseStream instance.");
+      out.println("Expected: " + stream);
+      out.println("Received: " + test);
+      return;
+    }
+
+    out.println(JSFTestUtil.PASS);
+
+  }// End facesCtxSetGetResponseStreamTest
+
+  public void facesCtxSetResponseStreamNPETest(HttpServletRequest request,
+      HttpServletResponse response) throws IOException {
+    PrintWriter out = response.getWriter();
+
+    JSFTestUtil.checkForNPE(getFacesContext(), "setResponseStream",
+        new Class<?>[] { ResponseStream.class }, new Object[] { null }, out);
+
+  }// End facesCtxSetResponseStreamNPETest
+
+  public void facesCtxSetResponseWriterNPETest(HttpServletRequest request,
+      HttpServletResponse response) throws IOException {
+    PrintWriter out = response.getWriter();
+
+    JSFTestUtil.checkForNPE(getFacesContext(), "setResponseWriter",
+        new Class<?>[] { ResponseWriter.class }, new Object[] { null }, out);
+
+  }// End facesCtxSetResponseWriterNPETest
+
+  // FacesContext.[get, set]ViewRoot()
+  public void facesCtxSetGetViewRootTest(HttpServletRequest request,
+      HttpServletResponse response) throws IOException {
+    PrintWriter out = response.getWriter();
+    FacesContext context = getFacesContext();
+    UIViewRoot root = (UIViewRoot) getApplication()
+        .createComponent(UIViewRoot.COMPONENT_TYPE);
+
+    context.setViewRoot(root);
+    UIViewRoot test = context.getViewRoot();
+
+    if (test == null) {
+      out.println(JSFTestUtil.FAIL + " FacesContext.getViewRoot() returned "
+          + "null after FacesContext.setViewRoot(UIViewRoot) " + "was called.");
+      return;
+    }
+
+    if (test != root) {
+      out.println(JSFTestUtil.FAIL + " FacesContext.getViewRoot() did not "
+          + "return the expected UIViewRoot instance.");
+      out.println("Expected: " + root);
+      out.println("Received: " + test);
+      return;
+    }
+
+    out.println(JSFTestUtil.PASS);
+
+  } // End facesCtxSetGetViewRootTest
+
+  // FacesContext.[is, set]ProcessingEvents()
+  public void facesCtxIsGetProcessingEventTest(HttpServletRequest request,
+      HttpServletResponse response) throws IOException {
+    PrintWriter out = response.getWriter();
+    FacesContext context = getFacesContext();
+
+    context.setProcessingEvents(true);
+    if (!context.isProcessingEvents()) {
+      out.println(JSFTestUtil.FAIL + JSFTestUtil.NL
+          + "Unexpected value returned from FacesContext.isProcessingEvents()"
+          + JSFTestUtil.NL + "Expected: true" + JSFTestUtil.NL + "Received: "
+          + context.isProcessingEvents());
+
+    } else {
+      context.setProcessingEvents(false);
+      if (context.isProcessingEvents()) {
+        out.println(JSFTestUtil.FAIL + JSFTestUtil.NL
+            + "Unexpected value returned from FacesContext.isProcessingEvents()"
+            + JSFTestUtil.NL + "Expected: false" + JSFTestUtil.NL + "Received: "
+            + context.isProcessingEvents());
+
+      } else {
+        out.println(JSFTestUtil.PASS);
+      }
+    }
+
+  } // End facesCtxIsGetProcessingEventTest
+
+  // FacesContext.[get, set]CurrentPhaseId()
+  public void facesCtxSetGetCurrentPhaseIdTest(HttpServletRequest request,
+      HttpServletResponse response) throws IOException {
+    PrintWriter out = response.getWriter();
+    FacesContext context = getFacesContext();
+
+    context.setCurrentPhaseId(PhaseId.ANY_PHASE);
+    PhaseId result = context.getCurrentPhaseId();
+    if (PhaseId.ANY_PHASE.equals(result)) {
+      out.println(JSFTestUtil.PASS);
+
+    } else {
+      out.println(
+          JSFTestUtil.FAIL + " FacesContext.getCurrentPhaseId() did not "
+              + "return the expected PhaseId.");
+      out.println("Expected: " + PhaseId.ANY_PHASE);
+      out.println("Received: " + result);
+    }
+
+  } // End facesCtxSetGetCurrentPhaseIdTest
+
+  // Ensure NPE is thrown if a null argument is passed to
+  // FacesContext.setViewRoot().
+  public void facesCtxSetViewRootNPETest(HttpServletRequest request,
+      HttpServletResponse response) throws IOException {
+    PrintWriter out = response.getWriter();
+
+    JSFTestUtil.checkForNPE(getFacesContext(), "setViewRoot",
+        new Class<?>[] { UIViewRoot.class }, new Object[] { null }, out);
+  }
+
+  // All methods of FacesContext must throw an IllegalStateException
+  // if called after FacesContext.release() has been called with the
+  // Exception of those referenced in the exMethods List.
+  public void facesCtxISEAfterReleaseTest(HttpServletRequest request,
+      HttpServletResponse response) throws IOException {
+    PrintWriter out = response.getWriter();
+    FacesContext context = getFacesContext();
+
+    // Excluded methods that do not throw IllegalStateException.
+    List<String> exMethods = new ArrayList<String>();
+    exMethods.add("release");
+    exMethods.add("isReleased");
+    exMethods.add("getComponentModificationManager");
+    exMethods.add("setCurrentInstance");
+    exMethods.add("getCurrentInstance");
+    exMethods.add("getCurrentPhaseId");
+    exMethods.add("setExceptionHandler");
+    exMethods.add("getExceptionHandler");
+    exMethods.add("setProcessingEvents");
+    exMethods.add("isProcessingEvents");
+
+    Method[] methods = FacesContext.class.getDeclaredMethods();
+    // loop through the remaining methods an ensure they all
+    // throw an IllegalStateException
+    context.release();
+
+    for (int i = 0; i < methods.length; i++) {
+      Method method = methods[i];
+      String name = method.getName();
+
+      if (!isExcluded(name, exMethods)) {
+        Class<?>[] types = method.getParameterTypes();
+        Object[] params = new Object[types.length];
+
+        if (name.equals("isProjectStage")) {
+          params[0] = ProjectStage.Development;
         }
 
-    } // End TCKExceptionHandler
+        JSFTestUtil.checkForISE(context, name, types, params, out);
 
-    private static class TCKRenderKit extends RenderKitWrapper {
+      }
+    }
+  }
 
-        @Override
-        public RenderKit getWrapped() {
-            return FacesContext.getCurrentInstance().getRenderKit();
+  public void facesCtxGetELContextTest(HttpServletRequest request,
+      HttpServletResponse response) throws IOException {
+
+    PrintWriter out = response.getWriter();
+    FacesContext context = getFacesContext();
+
+    ELContext elContext = context.getELContext();
+
+    if (elContext == null) {
+      out.println(JSFTestUtil.FAIL + " FacesContext.getELContext() returned"
+          + " null.");
+      return;
+    }
+
+    out.println(JSFTestUtil.PASS);
+
+  } // END facesCtxGetELContextTest
+
+  public void facesCtxGetAttributesTest(HttpServletRequest request,
+      HttpServletResponse response) throws IOException {
+
+    PrintWriter out = response.getWriter();
+    FacesContext context = getFacesContext();
+
+    if (!(context.getAttributes() instanceof Map)) {
+      out.println("Test FAILED. Unexpected class type returned from"
+          + "FacesContext.getAttributes() method." + JSFTestUtil.NL
+          + "Expected: java.util.Map" + JSFTestUtil.NL + "Received: "
+          + context.getAttributes().getClass().getName());
+      return;
+    } else {
+      try {
+        context.getAttributes().put("test_key", "test_value");
+
+      } catch (UnsupportedOperationException usoe) {
+        out.print("Test FAILED. Map Not Mutable!");
+        out.print(usoe.toString());
+      } catch (Exception e) {
+        /*
+         * Swallow any other exception since we only care if the Map is mutable.
+         */
+      }
+    }
+
+    out.println(JSFTestUtil.PASS);
+
+  } // END facesCtxgetAttributesTest
+
+  public void facesCtxGetAttributesEmptyTest(HttpServletRequest request,
+      HttpServletResponse response) throws IOException {
+
+    PrintWriter out = response.getWriter();
+    FacesContext context = getFacesContext();
+
+    try {
+      context.getAttributes().put("test_key", "test_value");
+      // validate that the attribute was put in.
+      HashMap<?, ?> hm = (HashMap<?, ?>) context.getAttributes();
+      if (!hm.containsKey("test_key")) {
+        out.println(
+            "Test FAILED. Attribute not added to context" + "attribute Map!");
+        return;
+      } else {
+        // map should be empty after this call.
+        context.release();
+        if (!hm.isEmpty()) {
+          out.println("Test FAILED. Attributes still found in "
+              + "context attribute Map, After 'context.release()"
+              + "was called!");
+          return;
         }
 
-    } // End TCKRenderKit
+      }
+    } catch (Exception e) {
+      out.print("Test FAILED." + JSFTestUtil.NL + e.toString());
+    }
+
+    out.println(JSFTestUtil.PASS);
+
+  } // END facesCtxgetAttributesEmptyTest
+
+  public void facesCtxGetPartialViewContextTest(HttpServletRequest request,
+      HttpServletResponse response) throws IOException {
+
+    PrintWriter out = response.getWriter();
+    FacesContext context = getFacesContext();
+
+    try {
+      PartialViewContext pvc = context.getPartialViewContext();
+      if (!(pvc instanceof PartialViewContext)) {
+        out.print("Test FAILED." + JSFTestUtil.NL + "Call to "
+            + "FacesContext.getPartialViewContext() should have "
+            + "returned a PartialViewContext." + JSFTestUtil.NL
+            + "Instead Received: " + pvc.getClass().getSimpleName());
+        return;
+      }
+    } catch (Exception e) {
+      out.print("Test FAILED." + JSFTestUtil.NL + e.toString());
+    }
+
+    out.println(JSFTestUtil.PASS);
+
+  } // END facesCtxgetPartialViewContextTest
+
+  public void facesCtxSetGetExceptionHandlerTest(HttpServletRequest request,
+      HttpServletResponse response) throws IOException {
+
+    PrintWriter out = response.getWriter();
+    FacesContext context = getFacesContext();
+    ExceptionHandler eh = new TCKExceptionHandler();
+    context.setExceptionHandler(eh);
+
+    String golden = "TCKExceptionHandler";
+    String result = context.getExceptionHandler().getClass().getSimpleName();
+
+    if (golden.equals(result)) {
+      out.println(JSFTestUtil.PASS);
+
+    } else {
+      out.print(
+          "Test FAILED." + JSFTestUtil.NL + " Unexpected value returned from"
+              + "FacesContext.getExceptionHandler()!" + JSFTestUtil.NL
+              + "Expected: " + golden + JSFTestUtil.NL + "Received: " + result);
+    }
+
+  } // END facesCtxSetGetExceptionHandlerTest
+
+  public void facesCtxsetExceptionHandlerTest(HttpServletRequest request,
+      HttpServletResponse response) throws IOException {
+
+    PrintWriter out = response.getWriter();
+    FacesContext context = getFacesContext();
+
+    try {
+      context.setExceptionHandler(new TCKExceptionHandler());
+      ExceptionHandler eh = context.getExceptionHandler();
+      if (!("TCKExceptionHandler".equals(eh.getClass().getSimpleName()))) {
+        out.print("Test FAILED." + JSFTestUtil.NL + "Call to "
+            + "FacesContext.setExceptionHandler() did not set " + "Handler!"
+            + JSFTestUtil.NL + "Expected: TCKExceptionHandler" + JSFTestUtil.NL
+            + "Received: " + eh.getClass().getSimpleName());
+        return;
+      }
+    } catch (Exception e) {
+      out.print("Test FAILED." + JSFTestUtil.NL + e.toString());
+    }
+
+    out.println(JSFTestUtil.PASS);
+
+  } // END facesCtxgetExceptionHandlerTest
+
+  public void facesCtxGetExternalContextTest(HttpServletRequest request,
+      HttpServletResponse response) throws IOException {
+
+    PrintWriter out = response.getWriter();
+    FacesContext context = getFacesContext();
+
+    try {
+      ExternalContext ec = context.getExternalContext();
+      if (!(ec instanceof ExternalContext)) {
+        out.print("Test FAILED." + JSFTestUtil.NL + "Call to "
+            + "FacesContext.getExternalContext did not return"
+            + "correct instance type." + JSFTestUtil.NL
+            + "Expected: ExternalContext" + JSFTestUtil.NL + "Received: "
+            + ec.getClass().getSimpleName());
+        return;
+      }
+    } catch (Exception e) {
+      out.print("Test FAILED." + JSFTestUtil.NL + e.toString());
+    }
+
+    out.println(JSFTestUtil.PASS);
+
+  } // END facesCtxgetExternalContextTest
+
+  public void facesCtxisReleasedTest(HttpServletRequest request,
+      HttpServletResponse response) throws IOException {
+    PrintWriter out = response.getWriter();
+    FacesContext context = getFacesContext();
+
+    // Test before release.
+    if (context.isReleased()) {
+      out.println("Test FAILED");
+      out.println("Unexpected value returned from FacesContext.isReleased() "
+          + "before FacesContext.release() was callled." + JSFTestUtil.NL
+          + "Expected: FALSE " + JSFTestUtil.NL + "Received: TRUE"
+          + JSFTestUtil.NL);
+      return;
+    }
+
+    // Test After release
+    context.release();
+    if (!context.isReleased()) {
+      out.println("Test FAILED");
+      out.println("Unexpected value returned from FacesContext.isReleased() "
+          + "after FacesContext.release() was called. " + JSFTestUtil.NL
+          + "Expected: TRUE " + JSFTestUtil.NL + "Received: FALSE"
+          + JSFTestUtil.NL);
+      return;
+    }
+
+    out.println(JSFTestUtil.PASS);
+
+  } // END facesCtxisReleasedTest
+
+  public void facesCtxGetRenderKitTest(HttpServletRequest request,
+      HttpServletResponse response) throws IOException {
+
+    PrintWriter out = response.getWriter();
+    FacesContext context = getFacesContext();
+    UIViewRoot root = context.getViewRoot();
+    String rkn = "TCKRenderKit";
+
+    // Setup renderKit
+    RenderKit renderKit = new TCKRenderKit();
+    RenderKitFactory factory = (RenderKitFactory) FactoryFinder
+        .getFactory(FactoryFinder.RENDER_KIT_FACTORY);
+    factory.addRenderKit(rkn, renderKit);
+
+    root.setRenderKitId(rkn);
+    RenderKit result = context.getRenderKit();
+
+    if (rkn.equals(result.getClass().getSimpleName())) {
+      out.println(JSFTestUtil.PASS);
+
+    } else {
+      out.println(JSFTestUtil.FAIL + JSFTestUtil.NL
+          + "Unexpected RenderKit returned from FacesContext.getRenderKit()"
+          + JSFTestUtil.NL + "Expected: " + rkn + JSFTestUtil.NL + "Received: "
+          + result);
+    }
+  } // END facesCtxGetRenderKitTest
+
+  // ------------------------------------------- Private Methods -----------
+  private String validateIllegalStateException(Method methodToInvoke,
+      Object target, Object[] params) {
+    String result = null;
+
+    try {
+      methodToInvoke.invoke(target, params);
+      result = JSFTestUtil.FAIL + " No Exception thrown when calling '"
+          + methodToInvoke.getName() + "'"
+          + " after FacesContext.release() was called.";
+
+    } catch (Throwable throwable) {
+      Throwable t = throwable;
+      if (throwable instanceof InvocationTargetException) {
+        t = ((InvocationTargetException) throwable).getTargetException();
+      }
+
+      if (!(t instanceof IllegalStateException)) {
+        StringBuffer sb = new StringBuffer(100);
+        sb.append(JSFTestUtil.FAIL + " Exception thrown when '")
+            .append(methodToInvoke.getName());
+        sb.append("' was called after FacesContext.release(), but it "
+            + "wasn't an instance of");
+        sb.append(" IllegalStateException.\nException received: ")
+            .append(t.getClass().getName());
+        result = sb.toString();
+      }
+    }
+    return result;
+  }
+
+  private boolean isExcluded(String methodName, List<String> excludeList) {
+    boolean result = false;
+
+    for (String excluded : excludeList) {
+      if (excluded.equals(methodName) || methodName.charAt(0) == '$') {
+        result = true;
+      }
+    }
+
+    return result;
+  }
+
+  private FacesMessage[] getMessagesAsArray(Iterator iterator) {
+    List list = new ArrayList();
+    while (iterator.hasNext()) {
+      list.add(iterator.next());
+    }
+    return (FacesMessage[]) list.toArray(new FacesMessage[list.size()]);
+  }
+
+  /*
+   * Add test messages to the given FacesContext.
+   */
+  private void addTestMessagesToContext(FacesContext context, String compId) {
+
+    UIComponent component = getApplication()
+        .createComponent(UIInput.COMPONENT_TYPE);
+    if (compId == null) {
+      component.setId("nothing");
+    } else {
+      component.setId(compId);
+    }
+
+    FacesMessage message1 = new TCKMessage(FacesMessage.SEVERITY_INFO,
+        "message1 summary", "message1 detail", "message1");
+    FacesMessage message2 = new TCKMessage(FacesMessage.SEVERITY_INFO,
+        "message2 summary", "message2 detail", "message2");
+    FacesMessage message3 = new TCKMessage(FacesMessage.SEVERITY_INFO,
+        "message3 summary", "message3 detail", "message3");
+    FacesMessage message4 = new TCKMessage(FacesMessage.SEVERITY_INFO,
+        "message4 summary", "message4 detail", "message4");
+
+    context.setViewRoot(createViewRoot());
+
+    context.addMessage(component.getClientId(context), message1);
+    context.addMessage(component.getClientId(context), message3);
+    context.addMessage(null, message2);
+    context.addMessage(null, message4);
+  }
+
+  // ------------------------------------------- Inner Classes -----------
+  // skeletal implementation of ResponseStream
+  private static final class TCKResponseStream extends ResponseStream {
+
+    @Override
+    public void write(int b) throws IOException {
+    }
+  }
+
+  // skeletal implementation of ResponseWriter
+  private static final class TCKResponseWriter extends ResponseWriter {
+
+    public void closeStartTag(UIComponent component) throws IOException {
+    }
+
+    @Override
+    public String getContentType() {
+      return null;
+    }
+
+    @Override
+    public String getCharacterEncoding() {
+      return null;
+    }
+
+    @Override
+    public void write(char cbuf[], int off, int len) throws IOException {
+    }
+
+    @Override
+    public void flush() throws IOException {
+    }
+
+    @Override
+    public void close() throws IOException {
+    }
+
+    @Override
+    public void startDocument() throws IOException {
+    }
+
+    @Override
+    public void endDocument() throws IOException {
+    }
+
+    @Override
+    public void startElement(String name, UIComponent component)
+        throws IOException {
+    }
+
+    @Override
+    public void endElement(String name) throws IOException {
+    }
+
+    @Override
+    public void writeAttribute(String name, Object value, String property)
+        throws IOException {
+    }
+
+    @Override
+    public void writeURIAttribute(String name, Object value, String property)
+        throws IOException {
+    }
+
+    @Override
+    public void writeComment(Object comment) throws IOException {
+    }
+
+    @Override
+    public void writeText(Object text, String property) throws IOException {
+    }
+
+    @Override
+    public void writeText(char text[], int off, int len) throws IOException {
+    }
+
+    @Override
+    public ResponseWriter cloneWithWriter(Writer writer) {
+      return null;
+    }
+  }
+
+  // simple implementation of FacesMessage
+  private static final class TCKMessage extends FacesMessage {
+
+    private FacesMessage.Severity messageSeverity;
+
+    private String messageSummary;
+
+    private String messageDetail;
+
+    String name;
+
+    TCKMessage(FacesMessage.Severity severity, String messageSummary,
+        String messageDetail, String name) {
+      this.messageSeverity = severity;
+      this.messageSummary = messageSummary;
+      this.messageDetail = messageDetail;
+      this.name = name;
+    }
+
+    @Override
+    public String getDetail() {
+      return messageDetail;
+    }
+
+    @Override
+    public FacesMessage.Severity getSeverity() {
+      return messageSeverity;
+    }
+
+    @Override
+    public String getSummary() {
+      return messageSummary;
+    }
+
+    @Override
+    public String toString() {
+      return name;
+    }
+  }
+
+  // simple implementation of ExceptionHandler
+  private static final class TCKExceptionHandler
+      extends ExceptionHandlerWrapper {
+
+    @Override
+    public ExceptionHandler getWrapped() {
+      // TODO Auto-generated method stub
+      return null;
+    }
+
+  } // End TCKExceptionHandler
+
+  private static class TCKRenderKit extends RenderKitWrapper {
+
+    @Override
+    public RenderKit getWrapped() {
+      return FacesContext.getCurrentInstance().getRenderKit();
+    }
+
+  } // End TCKRenderKit
 
 }

--- a/tck/old-tck/source/src/com/sun/ts/tests/jsf/api/jakarta_faces/context/facescontext/TestServlet.java
+++ b/tck/old-tck/source/src/com/sun/ts/tests/jsf/api/jakarta_faces/context/facescontext/TestServlet.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2024 Contributors to Eclipse Foundation.
  * Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -61,1263 +62,1102 @@ import jakarta.servlet.http.HttpServletResponse;
 
 public final class TestServlet extends HttpTCKServlet {
 
-  public void init(ServletConfig config) throws ServletException {
-    super.init(config);
-  }
-  // ------------------------------------------------ Test Methods -------
-  // FacesContext.getClientIdsWithMessages()
-
-  public void facesCtxGetClientIdsWithMessagesTest(HttpServletRequest request,
-      HttpServletResponse response) throws IOException {
-    PrintWriter out = response.getWriter();
-    FacesContext context = getFacesContext();
-    context.setViewRoot(createViewRoot());
-
-    UIComponent component1 = getApplication()
-        .createComponent(UIInput.COMPONENT_TYPE);
-    component1.setId("component1");
-    UIComponent component2 = getApplication()
-        .createComponent(UIOutput.COMPONENT_TYPE);
-    component2.setId("component2");
-    FacesMessage message1 = new TCKMessage(FacesMessage.SEVERITY_INFO,
-        "message1 summary", "message1 detail", "message1");
-
-    context.addMessage(component1.getClientId(context), message1);
-    context.addMessage(component2.getClientId(context), message1);
-
-    String[] controlClientIds = { component1.getClientId(context),
-        component2.getClientId(context) };
-    String[] testClientIds = JSFTestUtil
-        .getAsStringArray(context.getClientIdsWithMessages());
-
-    if (controlClientIds.length != testClientIds.length) {
-      out.println(
-          JSFTestUtil.FAIL + " Unexpected number of client IDs returned by "
-              + "FacesContext.getComponentIdsWithMessages().");
-      out.println(
-          "Exected the number of IDs returned to be 2.  Actual number returned: "
-              + testClientIds.length);
-      return;
+    public void init(ServletConfig config) throws ServletException {
+        super.init(config);
     }
+    
+    // ------------------------------------------------ Test Methods -------
+    // FacesContext.getClientIdsWithMessages()
 
-    List list = Arrays.asList(testClientIds);
-    for (int i = 0; i < controlClientIds.length; i++) {
-      if (!list.contains(controlClientIds[i])) {
-        out.println(JSFTestUtil.FAIL + " Unable to find '" + controlClientIds[i]
-            + "' in the client IDs returned"
-            + " by FacesContext.getClientIdsWithMessages().");
-        for (int j = 0; j < testClientIds.length; j++) {
-          out.println("Client ID received: " + testClientIds[j]);
+    public void facesCtxGetClientIdsWithMessagesTest(HttpServletRequest request, HttpServletResponse response) throws IOException {
+        PrintWriter out = response.getWriter();
+        FacesContext context = getFacesContext();
+        context.setViewRoot(createViewRoot());
+
+        UIComponent component1 = getApplication().createComponent(UIInput.COMPONENT_TYPE);
+        component1.setId("component1");
+        UIComponent component2 = getApplication().createComponent(UIOutput.COMPONENT_TYPE);
+        component2.setId("component2");
+        FacesMessage message1 = new TCKMessage(FacesMessage.SEVERITY_INFO, "message1 summary", "message1 detail", "message1");
+
+        context.addMessage(component1.getClientId(context), message1);
+        context.addMessage(component2.getClientId(context), message1);
+
+        String[] controlClientIds = { component1.getClientId(context), component2.getClientId(context) };
+        String[] testClientIds = JSFTestUtil.getAsStringArray(context.getClientIdsWithMessages());
+
+        if (controlClientIds.length != testClientIds.length) {
+            out.println(JSFTestUtil.FAIL + " Unexpected number of client IDs returned by " + "FacesContext.getComponentIdsWithMessages().");
+            out.println("Exected the number of IDs returned to be 2.  Actual number returned: " + testClientIds.length);
+            return;
         }
-        return;
-      }
+
+        List list = Arrays.asList(testClientIds);
+        for (int i = 0; i < controlClientIds.length; i++) {
+            if (!list.contains(controlClientIds[i])) {
+                out.println(JSFTestUtil.FAIL + " Unable to find '" + controlClientIds[i] + "' in the client IDs returned"
+                        + " by FacesContext.getClientIdsWithMessages().");
+                for (int j = 0; j < testClientIds.length; j++) {
+                    out.println("Client ID received: " + testClientIds[j]);
+                }
+                return;
+            }
+        }
+
+        out.println(JSFTestUtil.PASS);
+    }
+    // FacesContext.getClientIdsWithMessages() returning an empty Iterator when no
+    // components are found.
+
+    public void facesCtxGetClientIdsWithMessagesEmptyTest(HttpServletRequest request, HttpServletResponse response) throws IOException {
+        PrintWriter out = response.getWriter();
+        FacesContext context = getFacesContext();
+
+        Iterator i = context.getClientIdsWithMessages();
+
+        if (i == null) {
+            out.println(
+                    JSFTestUtil.FAIL + " FacesContext.getClientIdsWithMessages() returned null" + " when instead of an empty Iterator.");
+            return;
+        }
+
+        if (i.hasNext()) {
+            out.println(JSFTestUtil.FAIL + " FacesContext.getClientIdsWithMessages() returned a"
+                    + " non-empty Iterator even though no messages have been added.");
+            while (i.hasNext()) {
+                UIComponent comp = (UIComponent) i.next();
+                out.println("Component: " + ((comp == null) ? null : comp.getId()));
+            }
+            return;
+        }
+
+        context.addMessage(null, new FacesMessage());
+        context.addMessage(null, new FacesMessage());
+        i = context.getClientIdsWithMessages();
+
+        if (i == null) {
+            out.println(
+                    "Test FAILED[2]. FacesContext.getClientIds" + "WithMessages() returned null when instead of an empty " + "Iterator.");
+            return;
+        }
+
+        if (i.hasNext()) {
+            UIComponent comp = (UIComponent) i.next();
+            if (comp != null) {
+                out.println(JSFTestUtil.FAIL + " Non-null value returned from iterator.");
+                return;
+            }
+
+            if (i.hasNext()) {
+                out.println(JSFTestUtil.FAIL + " Iterator contained more than 1" + " value after when getClientIdWithMessages() was "
+                        + "called where a Message existed with no client id.");
+                return;
+            }
+        }
+
+        out.println(JSFTestUtil.PASS);
+    }
+    // FacesContext.addMessage(UIComponent, FacesMessage)
+    // FacesContext.getMessages()
+    // FacesContext.getMessages(UIComponent)
+    // 7/18/05 updated test to ensure message order is retained by returned
+    // iterators.
+
+    public void facesCtxAddGetMessagesTest(HttpServletRequest request, HttpServletResponse response) throws IOException {
+        PrintWriter out = response.getWriter();
+
+        UIComponent component = getApplication().createComponent(UIInput.COMPONENT_TYPE);
+        component.setId("input1");
+        FacesMessage message1 = new TCKMessage(FacesMessage.SEVERITY_INFO, "message1 summary", "message1 detail", "message1");
+        FacesMessage message2 = new TCKMessage(FacesMessage.SEVERITY_INFO, "message2 summary", "message2 detail", "message2");
+        FacesMessage message3 = new TCKMessage(FacesMessage.SEVERITY_INFO, "message3 summary", "message3 detail", "message3");
+        FacesMessage message4 = new TCKMessage(FacesMessage.SEVERITY_INFO, "message4 summary", "message4 detail", "message4");
+
+        FacesContext context = getFacesContext();
+        context.setViewRoot(createViewRoot());
+
+        context.addMessage(component.getClientId(context), message1);
+        context.addMessage(component.getClientId(context), message3);
+        context.addMessage(null, message2);
+        context.addMessage(null, message4);
+
+        FacesMessage[] controlMessagesComp = { message1, message3 };
+        FacesMessage[] controlMessagesNoComp = { message1, message3, message2, message4 };
+        FacesMessage[] controlMessagesNullComp = { message2, message4 };
+
+        FacesMessage[] testMessagesComp = getMessagesAsArray(context.getMessages(component.getClientId(context)));
+
+        // the next two should be equivalent
+        FacesMessage[] testMessagesNullComp = getMessagesAsArray(context.getMessages(null));
+        FacesMessage[] testMessages = getMessagesAsArray(context.getMessages());
+
+        // check the messages associated with a component
+        if (controlMessagesComp.length != testMessagesComp.length) {
+            out.println(JSFTestUtil.FAIL + " An unexpected number of messages" + " returned when FacesContext. getMessages(UIComponent)"
+                    + " was called.");
+            out.println("Expected 2 messages to be returned. Actual message " + "count: " + testMessagesComp.length);
+            return;
+        }
+
+        List messages = Arrays.asList(testMessagesComp);
+        for (int i = 0; i < controlMessagesComp.length; i++) {
+            if (!messages.get(i).equals(controlMessagesComp[i])) {
+                out.println(JSFTestUtil.FAIL + " Unable to find '" + controlMessagesComp[i] + "' in the return value of FacesContext."
+                        + "getMessages(UIComponent) when the appropriate" + " component was provided.");
+                out.println("Messages returned: " + JSFTestUtil.getAsString(testMessagesComp));
+                return;
+            }
+        }
+
+        // check the messages returned when a null value is provided
+        // to FacesContext.getMessages(null)
+        if (controlMessagesNullComp.length != testMessagesNullComp.length) {
+            out.println(JSFTestUtil.FAIL + " An unexpected number of messages " + "returned when FacesContext. getMessages(null) was "
+                    + "called.");
+            out.println("Expected 2 messages to be returned. Actual message " + "count: " + testMessagesNullComp.length);
+            return;
+        }
+
+        messages = Arrays.asList(testMessagesNullComp);
+        for (int i = 0; i < controlMessagesNullComp.length; i++) {
+            if (!messages.get(i).equals(controlMessagesNullComp[i])) {
+                out.println(JSFTestUtil.FAIL + " Unable to find '" + controlMessagesNullComp[i] + "' in the return value of FacesContext."
+                        + "getMessages(UIComponent) when null was passed to the" + " method.");
+                out.println("Messages returned: " + JSFTestUtil.getAsString(testMessagesNullComp));
+                return;
+            }
+        }
+
+        // check the messages returned by FacesContext.getMessages()
+        if (controlMessagesNoComp.length != testMessages.length) {
+            out.println(
+                    JSFTestUtil.FAIL + " An unexpected number of messages " + "returned when FacesContext." + "getMessages() was called.");
+            out.println("Expected 4 messages to be returned. Actual message" + " count: " + testMessages.length);
+            return;
+        }
+
+        messages = Arrays.asList(testMessages);
+        for (int i = 0; i < controlMessagesNoComp.length; i++) {
+            if (!messages.get(i).equals(controlMessagesNoComp[i])) {
+                out.println(JSFTestUtil.FAIL + " Unable to find '" + controlMessagesNoComp[i] + "' in the return value of FacesContext."
+                        + "getMessages()");
+                out.println("Messages returned: " + JSFTestUtil.getAsString(testMessages));
+                return;
+            }
+        }
+        out.println(JSFTestUtil.PASS);
+    }
+    // FacesContext.getMessages(UIComponent)
+    // FacesContext.getMessages()
+    // - both return an empty Iterator if no messages were added.
+
+    public void facesCtxGetMessagesEmptyTest(HttpServletRequest request, HttpServletResponse response) throws IOException {
+        PrintWriter out = response.getWriter();
+        FacesContext context = getFacesContext();
+        context.setViewRoot(createViewRoot());
+
+        Iterator i = context.getMessages();
+        if (i != null) {
+            if (i.hasNext()) {
+                out.println(JSFTestUtil.FAIL + " FacesContext.getMessages() " + "returned a non-empty Iterator when no FacesMessage "
+                        + "instances were added.");
+                return;
+            }
+        } else {
+            out.println(JSFTestUtil.FAIL + " FacesContext.getMessages() returned " + "null as opposed to an empty Iterator.");
+            return;
+        }
+
+        i = context.getMessages(getApplication().createComponent(UIInput.COMPONENT_TYPE).getClientId(context));
+        if (i != null) {
+            if (i.hasNext()) {
+                out.println(JSFTestUtil.FAIL + " FacesContext.getMessages(" + "UIComponent) returned a non-empty Iterator when no "
+                        + "FacesMessage instances were added.");
+                return;
+            }
+        } else {
+            out.println(JSFTestUtil.FAIL + " FacesContext.getMessages(UIComponent)" + " returned null as opposed to an empty Iterator.");
+            return;
+        }
+
+        i = context.getMessages(null);
+        if (i != null) {
+            if (i.hasNext()) {
+                out.println(JSFTestUtil.FAIL + " FacesContext.getMessages(null) " + "returned a non-empty Iterator when no FacesMessage"
+                        + " instances were added.");
+                return;
+            }
+        } else {
+            out.println(JSFTestUtil.FAIL + " FacesContext.getMessages(null) " + "returned null as opposed to an empty Iterator.");
+            return;
+        }
+
+        out.println(JSFTestUtil.PASS);
     }
 
-    out.println(JSFTestUtil.PASS);
-  }
-  // FacesContext.getClientIdsWithMessages() returning an empty Iterator when no
-  // components are found.
+    public void facesCtxGetMessageListTest(HttpServletRequest request, HttpServletResponse response) throws IOException {
 
-  public void facesCtxGetClientIdsWithMessagesEmptyTest(
-      HttpServletRequest request, HttpServletResponse response)
-      throws IOException {
-    PrintWriter out = response.getWriter();
-    FacesContext context = getFacesContext();
+        PrintWriter out = response.getWriter();
+        FacesContext context = getFacesContext();
+        this.addTestMessagesToContext(context, null);
 
-    Iterator i = context.getClientIdsWithMessages();
+        try {
+            List allMessages = context.getMessageList();
+            if (allMessages.size() != 4) {
+                out.print("Test FAILED." + JSFTestUtil.NL + "Call to " + "FacesContext.getMessageList unexepected size! " + JSFTestUtil.NL
+                        + "Expected: 4" + JSFTestUtil.NL + "Received: " + allMessages.size());
+                return;
+            }
+        } catch (Exception e) {
+            out.print("Test FAILED." + JSFTestUtil.NL + e.toString());
+        }
 
-    if (i == null) {
-      out.println(JSFTestUtil.FAIL
-          + " FacesContext.getClientIdsWithMessages() returned null"
-          + " when instead of an empty Iterator.");
-      return;
+        out.println(JSFTestUtil.PASS);
+
+    } // END facesCtxgetMessageListTest
+
+    public void facesCtxGetMessageListByIdTest(HttpServletRequest request, HttpServletResponse response) throws IOException {
+
+        PrintWriter out = response.getWriter();
+        FacesContext context = getFacesContext();
+        this.addTestMessagesToContext(context, "test_one");
+
+        try {
+            List allMessages = context.getMessageList("test_one");
+            if (allMessages.size() != 2) {
+                out.print("Test FAILED." + JSFTestUtil.NL + "Call to " + "FacesContext.getMessageList unexepected size! " + JSFTestUtil.NL
+                        + "Expected: 2" + JSFTestUtil.NL + "Received: " + allMessages.size());
+                return;
+            }
+        } catch (Exception e) {
+            out.print("Test FAILED." + JSFTestUtil.NL + e.toString());
+        }
+
+        out.println(JSFTestUtil.PASS);
+
+    } // END facesCtxgetMessageListByIdTest
+
+    public void facesCtxisValidationFailedTest(HttpServletRequest request, HttpServletResponse response) throws IOException {
+
+        PrintWriter out = response.getWriter();
+        FacesContext context = getFacesContext();
+        Boolean isFailed;
+        try {
+            isFailed = context.isValidationFailed();
+            if (isFailed) {
+                out.print("Test FAILED." + JSFTestUtil.NL + "Unexpected result from " + "FacesContext.isValadationFailed()" + JSFTestUtil.NL
+                        + "Expected: false" + JSFTestUtil.NL + "Received: " + isFailed);
+                return;
+            }
+
+            context.validationFailed();
+            isFailed = context.isValidationFailed();
+            if (!isFailed) {
+                out.print("Test FAILED." + JSFTestUtil.NL + "Unexpected result from " + "FacesContext.isValadationFailed() after calling "
+                        + "FacesContext.validationFailed." + JSFTestUtil.NL + "Expected: true" + JSFTestUtil.NL + "Received: " + isFailed);
+                return;
+            }
+        } catch (Exception e) {
+            out.print("Test FAILED." + JSFTestUtil.NL + e.toString());
+        }
+
+        out.println(JSFTestUtil.PASS);
+
+    } // END facesCtxisValidationFailedTest
+
+    public void facesCtxisPostbackTest(HttpServletRequest request, HttpServletResponse response) throws IOException {
+
+        PrintWriter out = response.getWriter();
+        FacesContext context = getFacesContext();
+        context.getApplication();
+        Boolean isPB;
+
+        try {
+            isPB = context.isPostback();
+            if (isPB) {
+                out.print("Test FAILED." + JSFTestUtil.NL + "Unexpected result from " + "FacesContext.isPostback() before calling "
+                        + "StateManger.writeState()." + JSFTestUtil.NL + "Expected: false" + JSFTestUtil.NL + "Received: " + isPB);
+                return;
+            }
+
+        } catch (Exception e) {
+            out.print("Test FAILED." + JSFTestUtil.NL + e.toString());
+        }
+
+        out.println(JSFTestUtil.PASS);
+
+    } // END facesCtxisPostbackTest
+
+    // FacesContext.getApplication()
+    public void facesCtxGetApplicationTest(HttpServletRequest request, HttpServletResponse response) throws IOException {
+        PrintWriter out = response.getWriter();
+        Application controlApplication = getApplication();
+        Application testApplication = getFacesContext().getApplication();
+
+        if (controlApplication == null) {
+            out.println(JSFTestUtil.FAIL + " Application.getCurrentInstance() " + "unexpectedly returned null.");
+            return;
+        }
+
+        if (controlApplication != testApplication) {
+            out.println(JSFTestUtil.FAIL + " The Application instance returned by " + "Application. getCurrentInstance() differs from the "
+                    + "Application returned by FacesContext.getApplication().");
+            out.println("Application.getCurrentInstance(): " + controlApplication);
+            out.println("FacesContext.getApplication():" + testApplication);
+            return;
+        }
+
+        out.println(JSFTestUtil.PASS);
+    }
+    // FacesContext.addMessage(UIComponent, FacesMessage) throws NPE if
+    // FacesMessage is null
+
+    public void facesCtxAddMessageNPETest(HttpServletRequest request, HttpServletResponse response) throws IOException {
+        PrintWriter out = response.getWriter();
+
+        JSFTestUtil.checkForNPE(getFacesContext(), "addMessage", new Class<?>[] { String.class, FacesMessage.class },
+                new Object[] { "id", null }, out);
     }
 
-    if (i.hasNext()) {
-      out.println(JSFTestUtil.FAIL
-          + " FacesContext.getClientIdsWithMessages() returned a"
-          + " non-empty Iterator even though no messages have been added.");
-      while (i.hasNext()) {
-        UIComponent comp = (UIComponent) i.next();
-        out.println("Component: " + ((comp == null) ? null : comp.getId()));
-      }
-      return;
+    // FacesContext.isProjectStage(ProjectStage stage) throws NPE if stage is null
+    public void facesCtxIsProjectStageNPETest(HttpServletRequest request, HttpServletResponse response) throws IOException {
+        PrintWriter out = response.getWriter();
+
+        JSFTestUtil.checkForNPE(getFacesContext(), "isProjectStage", new Class<?>[] { ProjectStage.class }, new Object[] { null }, out);
     }
 
-    context.addMessage(null, new FacesMessage());
-    context.addMessage(null, new FacesMessage());
-    i = context.getClientIdsWithMessages();
+    // FacesContext.getCurrentInstance()
+    public void facesCtxSetGetCurrentInstanceTest(HttpServletRequest request, HttpServletResponse response) throws IOException {
+        PrintWriter out = response.getWriter();
+        FacesContext controlContext = getFacesContext();
+        FacesContext testContext = FacesContext.getCurrentInstance();
 
-    if (i == null) {
-      out.println("Test FAILED[2]. FacesContext.getClientIds"
-          + "WithMessages() returned null when instead of an empty "
-          + "Iterator.");
-      return;
+        if (controlContext != testContext) {
+            out.println(JSFTestUtil.FAIL + " FacesContext.getCurrentInstance() " + "returned a FacesContext instance that differs from the "
+                    + "one that is currently services this request.");
+            out.println("Current FacesContext: " + controlContext);
+            out.println("FacesContext.getCurrentInstance(): " + testContext);
+            return;
+        }
+
+        out.println(JSFTestUtil.PASS);
     }
 
-    if (i.hasNext()) {
-      UIComponent comp = (UIComponent) i.next();
-      if (comp != null) {
-        out.println(
-            JSFTestUtil.FAIL + " Non-null value returned from iterator.");
-        return;
-      }
+    // FacesContext.getMaximumSeverity()
+    public void facesCtxGetMaximumSeverityTest(HttpServletRequest request, HttpServletResponse response) throws IOException {
+        PrintWriter out = response.getWriter();
+        FacesContext context = getFacesContext();
+        context.setViewRoot(new UIViewRoot());
+        FacesMessage message1 = new TCKMessage(FacesMessage.SEVERITY_INFO, "message1 summary", "message1 detail", "message1");
+        FacesMessage message2 = new TCKMessage(FacesMessage.SEVERITY_WARN, "message2 summary", "message2 detail", "message2");
+        FacesMessage message3 = new TCKMessage(FacesMessage.SEVERITY_ERROR, "message3 summary", "message3 detail", "message3");
+        FacesMessage message4 = new TCKMessage(FacesMessage.SEVERITY_FATAL, "message4 summary", "message4 detail", "message4");
 
-      if (i.hasNext()) {
-        out.println(JSFTestUtil.FAIL + " Iterator contained more than 1"
-            + " value after when getClientIdWithMessages() was "
-            + "called where a Message existed with no client id.");
-        return;
-      }
+        /*
+         * if no messages have been queued, then FacesContext.getMaximumSeverity should return null
+         */
+        if (context.getMaximumSeverity() != null) {
+            out.println(JSFTestUtil.FAIL + " FacesContext.getMaximumSeverity returned a"
+                    + "non null value when no messages have been added to the" + " FacesContext.");
+            out.println("Severity received: " + context.getMaximumSeverity().getOrdinal());
+            return;
+        }
+
+        context.addMessage(null, message1);
+        int severity = context.getMaximumSeverity().getOrdinal();
+        if (severity != FacesMessage.SEVERITY_INFO.getOrdinal()) {
+            out.println(JSFTestUtil.FAIL + " Expected FacesContext." + "getMaximumSeverity() to return FacesMessage."
+                    + "SEVERITY_INFO when only a SEVERITY_INFO message exists" + " in the FacesContext.");
+            out.println("Severity Recieved: " + severity);
+            out.println("Integer value of FacesMessage.SEVERITY_INFO: " + FacesMessage.SEVERITY_INFO);
+            return;
+        }
+
+        context.addMessage(null, message2);
+        severity = context.getMaximumSeverity().getOrdinal();
+        if (severity != FacesMessage.SEVERITY_WARN.getOrdinal()) {
+            out.println(JSFTestUtil.FAIL + " Expected FacesContext." + "getMaximumSeverity() to return FacesMessage."
+                    + "SEVERITY_WARN when both a SEVERITY_INFO and " + "SEVERITY_WARN message exist in the FacesContext.");
+            out.println("Severity Recieved: " + severity);
+            out.println("Integer value of FacesMessage.SEVERITY_WARN: " + FacesMessage.SEVERITY_WARN);
+            return;
+        }
+
+        context.addMessage(null, message3);
+        severity = context.getMaximumSeverity().getOrdinal();
+        if (severity != FacesMessage.SEVERITY_ERROR.getOrdinal()) {
+            out.println(JSFTestUtil.FAIL + " Expected FacesContext." + "getMaximumSeverity() to return FacesMessage."
+                    + "SEVERITY_ERROR when messages with SEVERITY_INFO, " + "SEVERITY_WARN, and SEVERITY_ERROR exist in the"
+                    + " FacesContext.");
+            out.println("Severity Recieved: " + severity);
+            out.println("Integer value of FacesMessage.SEVERITY_ERROR: " + FacesMessage.SEVERITY_ERROR);
+            return;
+        }
+
+        context.addMessage(null, message4);
+        severity = context.getMaximumSeverity().getOrdinal();
+        if (severity != FacesMessage.SEVERITY_FATAL.getOrdinal()) {
+            out.println(JSFTestUtil.FAIL + " Expected FacesContext." + "getMaximumSeverity() to return FacesMessage."
+                    + "SEVERITY_ERROR when messages with SEVERITY_INFO, " + "SEVERITY_WARN, SEVERITY_ERROR, SEVERITY_FATAL exist"
+                    + " in the FacesContext.");
+            out.println("Severity Recieved: " + severity);
+            out.println("Integer value of FacesMessage.SEVERITY_FATAL: " + FacesMessage.SEVERITY_FATAL);
+            return;
+        }
+
+        out.println(JSFTestUtil.PASS);
+    }
+    // FacesContext.getResponseComplete()
+    // FacesContext.responseComplete()
+
+    public void facesCtxResponseCompleteTest(HttpServletRequest request, HttpServletResponse response) throws IOException {
+        PrintWriter out = response.getWriter();
+        FacesContext context = getFacesContext();
+        context.setViewRoot(new UIViewRoot());
+
+        if (context.getResponseComplete()) {
+            out.println(JSFTestUtil.FAIL + " Expected FacesContext." + "getResponseComplete() to return false if FacesContext."
+                    + "responseComplete() hasn't been called.");
+            return;
+        }
+
+        context.responseComplete();
+
+        if (!context.getResponseComplete()) {
+            out.println(JSFTestUtil.FAIL + " Expected FacesContext." + "getResponseComplete() to return true if"
+                    + " FacesContext.responseComplete() has been called.");
+            return;
+        }
+
+        out.println(JSFTestUtil.PASS);
+    }
+    // FacesContext.getRenderResponse()
+    // FacesContext.renderResponse()
+
+    public void facexCtxRenderResponseTest(HttpServletRequest request, HttpServletResponse response) throws IOException {
+        PrintWriter out = response.getWriter();
+        FacesContext context = getFacesContext();
+        context.setViewRoot(new UIViewRoot());
+
+        if (context.getRenderResponse()) {
+            out.println(JSFTestUtil.FAIL + " Expected FacesContext." + "getRenderResponse() to return false if"
+                    + " FacesContext.renderResponse() hasn't been called.");
+            return;
+        }
+
+        context.renderResponse();
+
+        if (!context.getRenderResponse()) {
+            out.println(JSFTestUtil.FAIL + " Expected FacesContext." + "getRenderResponse() to return true if"
+                    + " FacesContext.renderResponse() has been called.");
+            return;
+        }
+
+        out.println(JSFTestUtil.PASS);
+    }
+    // FacesContext.setResponseWriter()
+    // FacesContext.getResponseWriter()
+
+    public void facesCtxSetGetResponseWriterTest(HttpServletRequest request, HttpServletResponse response) throws IOException {
+        PrintWriter out = response.getWriter();
+        FacesContext context = getFacesContext();
+        context.setViewRoot(new UIViewRoot());
+
+        ResponseWriter writer = new TCKResponseWriter();
+
+        context.setResponseWriter(writer);
+        ResponseWriter test = context.getResponseWriter();
+
+        if (test == null) {
+            out.println(JSFTestUtil.FAIL + " FacesContext.getResponseWriter() " + "returned null after FacesContext.setResponseWriter("
+                    + "ResponseWriter) was called.");
+            return;
+        }
+
+        if (test != writer) {
+            out.println(
+                    JSFTestUtil.FAIL + " FacesContext.getResponseWriter()" + " did not return the expected" + " ResponseWriter instance.");
+            out.println("Expected: " + writer);
+            out.println("Received: " + test);
+            return;
+        }
+
+        out.println(JSFTestUtil.PASS);
     }
 
-    out.println(JSFTestUtil.PASS);
-  }
-  // FacesContext.addMessage(UIComponent, FacesMessage)
-  // FacesContext.getMessages()
-  // FacesContext.getMessages(UIComponent)
-  // 7/18/05 updated test to ensure message order is retained by returned
-  // iterators.
+    // FacesContext.[get, set]ResponseStream()
+    public void facesCtxSetGetResponseStreamTest(HttpServletRequest request, HttpServletResponse response) throws IOException {
+        PrintWriter out = response.getWriter();
+        FacesContext context = getFacesContext();
+        context.setViewRoot(new UIViewRoot());
 
-  public void facesCtxAddGetMessagesTest(HttpServletRequest request,
-      HttpServletResponse response) throws IOException {
-    PrintWriter out = response.getWriter();
+        ResponseStream stream = new TCKResponseStream();
 
-    UIComponent component = getApplication()
-        .createComponent(UIInput.COMPONENT_TYPE);
-    component.setId("input1");
-    FacesMessage message1 = new TCKMessage(FacesMessage.SEVERITY_INFO,
-        "message1 summary", "message1 detail", "message1");
-    FacesMessage message2 = new TCKMessage(FacesMessage.SEVERITY_INFO,
-        "message2 summary", "message2 detail", "message2");
-    FacesMessage message3 = new TCKMessage(FacesMessage.SEVERITY_INFO,
-        "message3 summary", "message3 detail", "message3");
-    FacesMessage message4 = new TCKMessage(FacesMessage.SEVERITY_INFO,
-        "message4 summary", "message4 detail", "message4");
+        context.setResponseStream(stream);
+        ResponseStream test = context.getResponseStream();
 
-    FacesContext context = getFacesContext();
-    context.setViewRoot(createViewRoot());
+        if (test == null) {
+            out.println(JSFTestUtil.FAIL + " FacesContext.getResponseStream()" + " returned null after FacesContext.setResponseStream("
+                    + "ResponseStream) was called.");
+            return;
+        }
 
-    context.addMessage(component.getClientId(context), message1);
-    context.addMessage(component.getClientId(context), message3);
-    context.addMessage(null, message2);
-    context.addMessage(null, message4);
+        if (test != stream) {
+            out.println(JSFTestUtil.FAIL + " FacesContext.getResponseStream() " + "did not return the expected ResponseStream instance.");
+            out.println("Expected: " + stream);
+            out.println("Received: " + test);
+            return;
+        }
 
-    FacesMessage[] controlMessagesComp = { message1, message3 };
-    FacesMessage[] controlMessagesNoComp = { message1, message3, message2,
-        message4 };
-    FacesMessage[] controlMessagesNullComp = { message2, message4 };
+        out.println(JSFTestUtil.PASS);
 
-    FacesMessage[] testMessagesComp = getMessagesAsArray(
-        context.getMessages(component.getClientId(context)));
+    }// End facesCtxSetGetResponseStreamTest
 
-    // the next two should be equivalent
-    FacesMessage[] testMessagesNullComp = getMessagesAsArray(
-        context.getMessages(null));
-    FacesMessage[] testMessages = getMessagesAsArray(context.getMessages());
+    public void facesCtxSetResponseStreamNPETest(HttpServletRequest request, HttpServletResponse response) throws IOException {
+        PrintWriter out = response.getWriter();
 
-    // check the messages associated with a component
-    if (controlMessagesComp.length != testMessagesComp.length) {
-      out.println(JSFTestUtil.FAIL + " An unexpected number of messages"
-          + " returned when FacesContext. getMessages(UIComponent)"
-          + " was called.");
-      out.println("Expected 2 messages to be returned. Actual message "
-          + "count: " + testMessagesComp.length);
-      return;
+        JSFTestUtil.checkForNPE(getFacesContext(), "setResponseStream", new Class<?>[] { ResponseStream.class }, new Object[] { null },
+                out);
+
+    }// End facesCtxSetResponseStreamNPETest
+
+    public void facesCtxSetResponseWriterNPETest(HttpServletRequest request, HttpServletResponse response) throws IOException {
+        PrintWriter out = response.getWriter();
+
+        JSFTestUtil.checkForNPE(getFacesContext(), "setResponseWriter", new Class<?>[] { ResponseWriter.class }, new Object[] { null },
+                out);
+
+    }// End facesCtxSetResponseWriterNPETest
+
+    // FacesContext.[get, set]ViewRoot()
+    public void facesCtxSetGetViewRootTest(HttpServletRequest request, HttpServletResponse response) throws IOException {
+        PrintWriter out = response.getWriter();
+        FacesContext context = getFacesContext();
+        UIViewRoot root = (UIViewRoot) getApplication().createComponent(UIViewRoot.COMPONENT_TYPE);
+
+        context.setViewRoot(root);
+        UIViewRoot test = context.getViewRoot();
+
+        if (test == null) {
+            out.println(JSFTestUtil.FAIL + " FacesContext.getViewRoot() returned " + "null after FacesContext.setViewRoot(UIViewRoot) "
+                    + "was called.");
+            return;
+        }
+
+        if (test != root) {
+            out.println(JSFTestUtil.FAIL + " FacesContext.getViewRoot() did not " + "return the expected UIViewRoot instance.");
+            out.println("Expected: " + root);
+            out.println("Received: " + test);
+            return;
+        }
+
+        out.println(JSFTestUtil.PASS);
+
+    } // End facesCtxSetGetViewRootTest
+
+    // FacesContext.[is, set]ProcessingEvents()
+    public void facesCtxIsGetProcessingEventTest(HttpServletRequest request, HttpServletResponse response) throws IOException {
+        PrintWriter out = response.getWriter();
+        FacesContext context = getFacesContext();
+
+        context.setProcessingEvents(true);
+        if (!context.isProcessingEvents()) {
+            out.println(JSFTestUtil.FAIL + JSFTestUtil.NL + "Unexpected value returned from FacesContext.isProcessingEvents()"
+                    + JSFTestUtil.NL + "Expected: true" + JSFTestUtil.NL + "Received: " + context.isProcessingEvents());
+
+        } else {
+            context.setProcessingEvents(false);
+            if (context.isProcessingEvents()) {
+                out.println(JSFTestUtil.FAIL + JSFTestUtil.NL + "Unexpected value returned from FacesContext.isProcessingEvents()"
+                        + JSFTestUtil.NL + "Expected: false" + JSFTestUtil.NL + "Received: " + context.isProcessingEvents());
+
+            } else {
+                out.println(JSFTestUtil.PASS);
+            }
+        }
+
+    } // End facesCtxIsGetProcessingEventTest
+
+    // FacesContext.[get, set]CurrentPhaseId()
+    public void facesCtxSetGetCurrentPhaseIdTest(HttpServletRequest request, HttpServletResponse response) throws IOException {
+        PrintWriter out = response.getWriter();
+        FacesContext context = getFacesContext();
+
+        context.setCurrentPhaseId(PhaseId.ANY_PHASE);
+        PhaseId result = context.getCurrentPhaseId();
+        if (PhaseId.ANY_PHASE.equals(result)) {
+            out.println(JSFTestUtil.PASS);
+
+        } else {
+            out.println(JSFTestUtil.FAIL + " FacesContext.getCurrentPhaseId() did not " + "return the expected PhaseId.");
+            out.println("Expected: " + PhaseId.ANY_PHASE);
+            out.println("Received: " + result);
+        }
+
+    } // End facesCtxSetGetCurrentPhaseIdTest
+
+    // Ensure NPE is thrown if a null argument is passed to
+    // FacesContext.setViewRoot().
+    public void facesCtxSetViewRootNPETest(HttpServletRequest request, HttpServletResponse response) throws IOException {
+        PrintWriter out = response.getWriter();
+
+        JSFTestUtil.checkForNPE(getFacesContext(), "setViewRoot", new Class<?>[] { UIViewRoot.class }, new Object[] { null }, out);
     }
 
-    List messages = Arrays.asList(testMessagesComp);
-    for (int i = 0; i < controlMessagesComp.length; i++) {
-      if (!messages.get(i).equals(controlMessagesComp[i])) {
-        out.println(JSFTestUtil.FAIL + " Unable to find '"
-            + controlMessagesComp[i] + "' in the return value of FacesContext."
-            + "getMessages(UIComponent) when the appropriate"
-            + " component was provided.");
-        out.println(
-            "Messages returned: " + JSFTestUtil.getAsString(testMessagesComp));
-        return;
-      }
+    // All methods of FacesContext must throw an IllegalStateException
+    // if called after FacesContext.release() has been called with the
+    // Exception of those referenced in the exMethods List.
+    public void facesCtxISEAfterReleaseTest(HttpServletRequest request, HttpServletResponse response) throws IOException {
+        PrintWriter out = response.getWriter();
+        FacesContext context = getFacesContext();
+
+        // Excluded methods that do not throw IllegalStateException.
+        List<String> exMethods = new ArrayList<String>();
+        exMethods.add("release");
+        exMethods.add("isReleased");
+        exMethods.add("getComponentModificationManager");
+        exMethods.add("setCurrentInstance");
+        exMethods.add("getCurrentInstance");
+        exMethods.add("getCurrentPhaseId");
+        exMethods.add("setExceptionHandler");
+        exMethods.add("getExceptionHandler");
+        exMethods.add("setProcessingEvents");
+        exMethods.add("isProcessingEvents");
+
+        Method[] methods = FacesContext.class.getDeclaredMethods();
+        
+        // Loop through the remaining methods an ensure they all
+        // throw an IllegalStateException
+        context.release();
+
+        for (int i = 0; i < methods.length; i++) {
+            Method method = methods[i];
+            String name = method.getName();
+
+            if (!isExcluded(name, exMethods) && !name.startsWith("lambda$")) {
+                Class<?>[] types = method.getParameterTypes();
+                Object[] params = new Object[types.length];
+
+                if (name.equals("isProjectStage")) {
+                    params[0] = ProjectStage.Development;
+                }
+
+                JSFTestUtil.checkForISE(context, name, types, params, out);
+            }
+        }
     }
 
-    // check the messages returned when a null value is provided
-    // to FacesContext.getMessages(null)
-    if (controlMessagesNullComp.length != testMessagesNullComp.length) {
-      out.println(JSFTestUtil.FAIL + " An unexpected number of messages "
-          + "returned when FacesContext. getMessages(null) was " + "called.");
-      out.println("Expected 2 messages to be returned. Actual message "
-          + "count: " + testMessagesNullComp.length);
-      return;
+    public void facesCtxGetELContextTest(HttpServletRequest request, HttpServletResponse response) throws IOException {
+        PrintWriter out = response.getWriter();
+        FacesContext context = getFacesContext();
+
+        ELContext elContext = context.getELContext();
+
+        if (elContext == null) {
+            out.println(JSFTestUtil.FAIL + " FacesContext.getELContext() returned" + " null.");
+            return;
+        }
+
+        out.println(JSFTestUtil.PASS);
+
+    } // END facesCtxGetELContextTest
+
+    public void facesCtxGetAttributesTest(HttpServletRequest request, HttpServletResponse response) throws IOException {
+
+        PrintWriter out = response.getWriter();
+        FacesContext context = getFacesContext();
+
+        if (!(context.getAttributes() instanceof Map)) {
+            out.println("Test FAILED. Unexpected class type returned from" + "FacesContext.getAttributes() method." + JSFTestUtil.NL
+                    + "Expected: java.util.Map" + JSFTestUtil.NL + "Received: " + context.getAttributes().getClass().getName());
+            return;
+        } else {
+            try {
+                context.getAttributes().put("test_key", "test_value");
+
+            } catch (UnsupportedOperationException usoe) {
+                out.print("Test FAILED. Map Not Mutable!");
+                out.print(usoe.toString());
+            } catch (Exception e) {
+                /*
+                 * Swallow any other exception since we only care if the Map is mutable.
+                 */
+            }
+        }
+
+        out.println(JSFTestUtil.PASS);
+
+    } // END facesCtxgetAttributesTest
+
+    public void facesCtxGetAttributesEmptyTest(HttpServletRequest request, HttpServletResponse response) throws IOException {
+
+        PrintWriter out = response.getWriter();
+        FacesContext context = getFacesContext();
+
+        try {
+            context.getAttributes().put("test_key", "test_value");
+            // validate that the attribute was put in.
+            HashMap<?, ?> hm = (HashMap<?, ?>) context.getAttributes();
+            if (!hm.containsKey("test_key")) {
+                out.println("Test FAILED. Attribute not added to context" + "attribute Map!");
+                return;
+            } else {
+                // map should be empty after this call.
+                context.release();
+                if (!hm.isEmpty()) {
+                    out.println(
+                            "Test FAILED. Attributes still found in " + "context attribute Map, After 'context.release()" + "was called!");
+                    return;
+                }
+
+            }
+        } catch (Exception e) {
+            out.print("Test FAILED." + JSFTestUtil.NL + e.toString());
+        }
+
+        out.println(JSFTestUtil.PASS);
+
+    } // END facesCtxgetAttributesEmptyTest
+
+    public void facesCtxGetPartialViewContextTest(HttpServletRequest request, HttpServletResponse response) throws IOException {
+
+        PrintWriter out = response.getWriter();
+        FacesContext context = getFacesContext();
+
+        try {
+            PartialViewContext pvc = context.getPartialViewContext();
+            if (!(pvc instanceof PartialViewContext)) {
+                out.print("Test FAILED." + JSFTestUtil.NL + "Call to " + "FacesContext.getPartialViewContext() should have "
+                        + "returned a PartialViewContext." + JSFTestUtil.NL + "Instead Received: " + pvc.getClass().getSimpleName());
+                return;
+            }
+        } catch (Exception e) {
+            out.print("Test FAILED." + JSFTestUtil.NL + e.toString());
+        }
+
+        out.println(JSFTestUtil.PASS);
+
+    } // END facesCtxgetPartialViewContextTest
+
+    public void facesCtxSetGetExceptionHandlerTest(HttpServletRequest request, HttpServletResponse response) throws IOException {
+
+        PrintWriter out = response.getWriter();
+        FacesContext context = getFacesContext();
+        ExceptionHandler eh = new TCKExceptionHandler();
+        context.setExceptionHandler(eh);
+
+        String golden = "TCKExceptionHandler";
+        String result = context.getExceptionHandler().getClass().getSimpleName();
+
+        if (golden.equals(result)) {
+            out.println(JSFTestUtil.PASS);
+
+        } else {
+            out.print("Test FAILED." + JSFTestUtil.NL + " Unexpected value returned from" + "FacesContext.getExceptionHandler()!"
+                    + JSFTestUtil.NL + "Expected: " + golden + JSFTestUtil.NL + "Received: " + result);
+        }
+
+    } // END facesCtxSetGetExceptionHandlerTest
+
+    public void facesCtxsetExceptionHandlerTest(HttpServletRequest request, HttpServletResponse response) throws IOException {
+
+        PrintWriter out = response.getWriter();
+        FacesContext context = getFacesContext();
+
+        try {
+            context.setExceptionHandler(new TCKExceptionHandler());
+            ExceptionHandler eh = context.getExceptionHandler();
+            if (!("TCKExceptionHandler".equals(eh.getClass().getSimpleName()))) {
+                out.print("Test FAILED." + JSFTestUtil.NL + "Call to " + "FacesContext.setExceptionHandler() did not set " + "Handler!"
+                        + JSFTestUtil.NL + "Expected: TCKExceptionHandler" + JSFTestUtil.NL + "Received: " + eh.getClass().getSimpleName());
+                return;
+            }
+        } catch (Exception e) {
+            out.print("Test FAILED." + JSFTestUtil.NL + e.toString());
+        }
+
+        out.println(JSFTestUtil.PASS);
+
+    } // END facesCtxgetExceptionHandlerTest
+
+    public void facesCtxGetExternalContextTest(HttpServletRequest request, HttpServletResponse response) throws IOException {
+
+        PrintWriter out = response.getWriter();
+        FacesContext context = getFacesContext();
+
+        try {
+            ExternalContext ec = context.getExternalContext();
+            if (!(ec instanceof ExternalContext)) {
+                out.print("Test FAILED." + JSFTestUtil.NL + "Call to " + "FacesContext.getExternalContext did not return"
+                        + "correct instance type." + JSFTestUtil.NL + "Expected: ExternalContext" + JSFTestUtil.NL + "Received: "
+                        + ec.getClass().getSimpleName());
+                return;
+            }
+        } catch (Exception e) {
+            out.print("Test FAILED." + JSFTestUtil.NL + e.toString());
+        }
+
+        out.println(JSFTestUtil.PASS);
+
+    } // END facesCtxgetExternalContextTest
+
+    public void facesCtxisReleasedTest(HttpServletRequest request, HttpServletResponse response) throws IOException {
+        PrintWriter out = response.getWriter();
+        FacesContext context = getFacesContext();
+
+        // Test before release.
+        if (context.isReleased()) {
+            out.println("Test FAILED");
+            out.println("Unexpected value returned from FacesContext.isReleased() " + "before FacesContext.release() was callled."
+                    + JSFTestUtil.NL + "Expected: FALSE " + JSFTestUtil.NL + "Received: TRUE" + JSFTestUtil.NL);
+            return;
+        }
+
+        // Test After release
+        context.release();
+        if (!context.isReleased()) {
+            out.println("Test FAILED");
+            out.println("Unexpected value returned from FacesContext.isReleased() " + "after FacesContext.release() was called. "
+                    + JSFTestUtil.NL + "Expected: TRUE " + JSFTestUtil.NL + "Received: FALSE" + JSFTestUtil.NL);
+            return;
+        }
+
+        out.println(JSFTestUtil.PASS);
+
+    } // END facesCtxisReleasedTest
+
+    public void facesCtxGetRenderKitTest(HttpServletRequest request, HttpServletResponse response) throws IOException {
+
+        PrintWriter out = response.getWriter();
+        FacesContext context = getFacesContext();
+        UIViewRoot root = context.getViewRoot();
+        String rkn = "TCKRenderKit";
+
+        // Setup renderKit
+        RenderKit renderKit = new TCKRenderKit();
+        RenderKitFactory factory = (RenderKitFactory) FactoryFinder.getFactory(FactoryFinder.RENDER_KIT_FACTORY);
+        factory.addRenderKit(rkn, renderKit);
+
+        root.setRenderKitId(rkn);
+        RenderKit result = context.getRenderKit();
+
+        if (rkn.equals(result.getClass().getSimpleName())) {
+            out.println(JSFTestUtil.PASS);
+
+        } else {
+            out.println(JSFTestUtil.FAIL + JSFTestUtil.NL + "Unexpected RenderKit returned from FacesContext.getRenderKit()"
+                    + JSFTestUtil.NL + "Expected: " + rkn + JSFTestUtil.NL + "Received: " + result);
+        }
+    } // END facesCtxGetRenderKitTest
+
+    // ------------------------------------------- Private Methods -----------
+    private String validateIllegalStateException(Method methodToInvoke, Object target, Object[] params) {
+        String result = null;
+
+        try {
+            methodToInvoke.invoke(target, params);
+            result = JSFTestUtil.FAIL + " No Exception thrown when calling '" + methodToInvoke.getName() + "'"
+                    + " after FacesContext.release() was called.";
+
+        } catch (Throwable throwable) {
+            Throwable t = throwable;
+            if (throwable instanceof InvocationTargetException) {
+                t = ((InvocationTargetException) throwable).getTargetException();
+            }
+
+            if (!(t instanceof IllegalStateException)) {
+                StringBuffer sb = new StringBuffer(100);
+                sb.append(JSFTestUtil.FAIL + " Exception thrown when '").append(methodToInvoke.getName());
+                sb.append("' was called after FacesContext.release(), but it " + "wasn't an instance of");
+                sb.append(" IllegalStateException.\nException received: ").append(t.getClass().getName());
+                result = sb.toString();
+            }
+        }
+        return result;
     }
 
-    messages = Arrays.asList(testMessagesNullComp);
-    for (int i = 0; i < controlMessagesNullComp.length; i++) {
-      if (!messages.get(i).equals(controlMessagesNullComp[i])) {
-        out.println(
-            JSFTestUtil.FAIL + " Unable to find '" + controlMessagesNullComp[i]
-                + "' in the return value of FacesContext."
-                + "getMessages(UIComponent) when null was passed to the"
-                + " method.");
-        out.println("Messages returned: "
-            + JSFTestUtil.getAsString(testMessagesNullComp));
-        return;
-      }
+    private boolean isExcluded(String methodName, List<String> excludeList) {
+        boolean result = false;
+
+        for (String excluded : excludeList) {
+            if (excluded.equals(methodName) || methodName.charAt(0) == '$') {
+                result = true;
+            }
+        }
+
+        return result;
     }
 
-    // check the messages returned by FacesContext.getMessages()
-    if (controlMessagesNoComp.length != testMessages.length) {
-      out.println(JSFTestUtil.FAIL + " An unexpected number of messages "
-          + "returned when FacesContext." + "getMessages() was called.");
-      out.println("Expected 4 messages to be returned. Actual message"
-          + " count: " + testMessages.length);
-      return;
+    private FacesMessage[] getMessagesAsArray(Iterator iterator) {
+        List list = new ArrayList();
+        while (iterator.hasNext()) {
+            list.add(iterator.next());
+        }
+        return (FacesMessage[]) list.toArray(new FacesMessage[list.size()]);
     }
-
-    messages = Arrays.asList(testMessages);
-    for (int i = 0; i < controlMessagesNoComp.length; i++) {
-      if (!messages.get(i).equals(controlMessagesNoComp[i])) {
-        out.println(
-            JSFTestUtil.FAIL + " Unable to find '" + controlMessagesNoComp[i]
-                + "' in the return value of FacesContext." + "getMessages()");
-        out.println(
-            "Messages returned: " + JSFTestUtil.getAsString(testMessages));
-        return;
-      }
-    }
-    out.println(JSFTestUtil.PASS);
-  }
-  // FacesContext.getMessages(UIComponent)
-  // FacesContext.getMessages()
-  // - both return an empty Iterator if no messages were added.
-
-  public void facesCtxGetMessagesEmptyTest(HttpServletRequest request,
-      HttpServletResponse response) throws IOException {
-    PrintWriter out = response.getWriter();
-    FacesContext context = getFacesContext();
-    context.setViewRoot(createViewRoot());
-
-    Iterator i = context.getMessages();
-    if (i != null) {
-      if (i.hasNext()) {
-        out.println(JSFTestUtil.FAIL + " FacesContext.getMessages() "
-            + "returned a non-empty Iterator when no FacesMessage "
-            + "instances were added.");
-        return;
-      }
-    } else {
-      out.println(JSFTestUtil.FAIL + " FacesContext.getMessages() returned "
-          + "null as opposed to an empty Iterator.");
-      return;
-    }
-
-    i = context.getMessages(getApplication()
-        .createComponent(UIInput.COMPONENT_TYPE).getClientId(context));
-    if (i != null) {
-      if (i.hasNext()) {
-        out.println(JSFTestUtil.FAIL + " FacesContext.getMessages("
-            + "UIComponent) returned a non-empty Iterator when no "
-            + "FacesMessage instances were added.");
-        return;
-      }
-    } else {
-      out.println(JSFTestUtil.FAIL + " FacesContext.getMessages(UIComponent)"
-          + " returned null as opposed to an empty Iterator.");
-      return;
-    }
-
-    i = context.getMessages(null);
-    if (i != null) {
-      if (i.hasNext()) {
-        out.println(JSFTestUtil.FAIL + " FacesContext.getMessages(null) "
-            + "returned a non-empty Iterator when no FacesMessage"
-            + " instances were added.");
-        return;
-      }
-    } else {
-      out.println(JSFTestUtil.FAIL + " FacesContext.getMessages(null) "
-          + "returned null as opposed to an empty Iterator.");
-      return;
-    }
-
-    out.println(JSFTestUtil.PASS);
-  }
-
-  public void facesCtxGetMessageListTest(HttpServletRequest request,
-      HttpServletResponse response) throws IOException {
-
-    PrintWriter out = response.getWriter();
-    FacesContext context = getFacesContext();
-    this.addTestMessagesToContext(context, null);
-
-    try {
-      List allMessages = context.getMessageList();
-      if (allMessages.size() != 4) {
-        out.print("Test FAILED." + JSFTestUtil.NL + "Call to "
-            + "FacesContext.getMessageList unexepected size! " + JSFTestUtil.NL
-            + "Expected: 4" + JSFTestUtil.NL + "Received: "
-            + allMessages.size());
-        return;
-      }
-    } catch (Exception e) {
-      out.print("Test FAILED." + JSFTestUtil.NL + e.toString());
-    }
-
-    out.println(JSFTestUtil.PASS);
-
-  } // END facesCtxgetMessageListTest
-
-  public void facesCtxGetMessageListByIdTest(HttpServletRequest request,
-      HttpServletResponse response) throws IOException {
-
-    PrintWriter out = response.getWriter();
-    FacesContext context = getFacesContext();
-    this.addTestMessagesToContext(context, "test_one");
-
-    try {
-      List allMessages = context.getMessageList("test_one");
-      if (allMessages.size() != 2) {
-        out.print("Test FAILED." + JSFTestUtil.NL + "Call to "
-            + "FacesContext.getMessageList unexepected size! " + JSFTestUtil.NL
-            + "Expected: 2" + JSFTestUtil.NL + "Received: "
-            + allMessages.size());
-        return;
-      }
-    } catch (Exception e) {
-      out.print("Test FAILED." + JSFTestUtil.NL + e.toString());
-    }
-
-    out.println(JSFTestUtil.PASS);
-
-  } // END facesCtxgetMessageListByIdTest
-
-  public void facesCtxisValidationFailedTest(HttpServletRequest request,
-      HttpServletResponse response) throws IOException {
-
-    PrintWriter out = response.getWriter();
-    FacesContext context = getFacesContext();
-    Boolean isFailed;
-    try {
-      isFailed = context.isValidationFailed();
-      if (isFailed) {
-        out.print("Test FAILED." + JSFTestUtil.NL + "Unexpected result from "
-            + "FacesContext.isValadationFailed()" + JSFTestUtil.NL
-            + "Expected: false" + JSFTestUtil.NL + "Received: " + isFailed);
-        return;
-      }
-
-      context.validationFailed();
-      isFailed = context.isValidationFailed();
-      if (!isFailed) {
-        out.print("Test FAILED." + JSFTestUtil.NL + "Unexpected result from "
-            + "FacesContext.isValadationFailed() after calling "
-            + "FacesContext.validationFailed." + JSFTestUtil.NL
-            + "Expected: true" + JSFTestUtil.NL + "Received: " + isFailed);
-        return;
-      }
-    } catch (Exception e) {
-      out.print("Test FAILED." + JSFTestUtil.NL + e.toString());
-    }
-
-    out.println(JSFTestUtil.PASS);
-
-  } // END facesCtxisValidationFailedTest
-
-  public void facesCtxisPostbackTest(HttpServletRequest request,
-      HttpServletResponse response) throws IOException {
-
-    PrintWriter out = response.getWriter();
-    FacesContext context = getFacesContext();
-    context.getApplication();
-    Boolean isPB;
-
-    try {
-      isPB = context.isPostback();
-      if (isPB) {
-        out.print("Test FAILED." + JSFTestUtil.NL + "Unexpected result from "
-            + "FacesContext.isPostback() before calling "
-            + "StateManger.writeState()." + JSFTestUtil.NL + "Expected: false"
-            + JSFTestUtil.NL + "Received: " + isPB);
-        return;
-      }
-
-    } catch (Exception e) {
-      out.print("Test FAILED." + JSFTestUtil.NL + e.toString());
-    }
-
-    out.println(JSFTestUtil.PASS);
-
-  } // END facesCtxisPostbackTest
-
-  // FacesContext.getApplication()
-  public void facesCtxGetApplicationTest(HttpServletRequest request,
-      HttpServletResponse response) throws IOException {
-    PrintWriter out = response.getWriter();
-    Application controlApplication = getApplication();
-    Application testApplication = getFacesContext().getApplication();
-
-    if (controlApplication == null) {
-      out.println(JSFTestUtil.FAIL + " Application.getCurrentInstance() "
-          + "unexpectedly returned null.");
-      return;
-    }
-
-    if (controlApplication != testApplication) {
-      out.println(JSFTestUtil.FAIL + " The Application instance returned by "
-          + "Application. getCurrentInstance() differs from the "
-          + "Application returned by FacesContext.getApplication().");
-      out.println("Application.getCurrentInstance(): " + controlApplication);
-      out.println("FacesContext.getApplication():" + testApplication);
-      return;
-    }
-
-    out.println(JSFTestUtil.PASS);
-  }
-  // FacesContext.addMessage(UIComponent, FacesMessage) throws NPE if
-  // FacesMessage is null
-
-  public void facesCtxAddMessageNPETest(HttpServletRequest request,
-      HttpServletResponse response) throws IOException {
-    PrintWriter out = response.getWriter();
-
-    JSFTestUtil.checkForNPE(getFacesContext(), "addMessage",
-        new Class<?>[] { String.class, FacesMessage.class },
-        new Object[] { "id", null }, out);
-  }
-
-  // FacesContext.isProjectStage(ProjectStage stage) throws NPE if stage is null
-  public void facesCtxIsProjectStageNPETest(HttpServletRequest request,
-      HttpServletResponse response) throws IOException {
-    PrintWriter out = response.getWriter();
-
-    JSFTestUtil.checkForNPE(getFacesContext(), "isProjectStage",
-        new Class<?>[] { ProjectStage.class }, new Object[] { null }, out);
-  }
-
-  // FacesContext.getCurrentInstance()
-  public void facesCtxSetGetCurrentInstanceTest(HttpServletRequest request,
-      HttpServletResponse response) throws IOException {
-    PrintWriter out = response.getWriter();
-    FacesContext controlContext = getFacesContext();
-    FacesContext testContext = FacesContext.getCurrentInstance();
-
-    if (controlContext != testContext) {
-      out.println(JSFTestUtil.FAIL + " FacesContext.getCurrentInstance() "
-          + "returned a FacesContext instance that differs from the "
-          + "one that is currently services this request.");
-      out.println("Current FacesContext: " + controlContext);
-      out.println("FacesContext.getCurrentInstance(): " + testContext);
-      return;
-    }
-
-    out.println(JSFTestUtil.PASS);
-  }
-
-  // FacesContext.getMaximumSeverity()
-  public void facesCtxGetMaximumSeverityTest(HttpServletRequest request,
-      HttpServletResponse response) throws IOException {
-    PrintWriter out = response.getWriter();
-    FacesContext context = getFacesContext();
-    context.setViewRoot(new UIViewRoot());
-    FacesMessage message1 = new TCKMessage(FacesMessage.SEVERITY_INFO,
-        "message1 summary", "message1 detail", "message1");
-    FacesMessage message2 = new TCKMessage(FacesMessage.SEVERITY_WARN,
-        "message2 summary", "message2 detail", "message2");
-    FacesMessage message3 = new TCKMessage(FacesMessage.SEVERITY_ERROR,
-        "message3 summary", "message3 detail", "message3");
-    FacesMessage message4 = new TCKMessage(FacesMessage.SEVERITY_FATAL,
-        "message4 summary", "message4 detail", "message4");
 
     /*
-     * if no messages have been queued, then FacesContext.getMaximumSeverity
-     * should return null
+     * Add test messages to the given FacesContext.
      */
-    if (context.getMaximumSeverity() != null) {
-      out.println(
-          JSFTestUtil.FAIL + " FacesContext.getMaximumSeverity returned a"
-              + "non null value when no messages have been added to the"
-              + " FacesContext.");
-      out.println(
-          "Severity received: " + context.getMaximumSeverity().getOrdinal());
-      return;
-    }
+    private void addTestMessagesToContext(FacesContext context, String compId) {
 
-    context.addMessage(null, message1);
-    int severity = context.getMaximumSeverity().getOrdinal();
-    if (severity != FacesMessage.SEVERITY_INFO.getOrdinal()) {
-      out.println(JSFTestUtil.FAIL + " Expected FacesContext."
-          + "getMaximumSeverity() to return FacesMessage."
-          + "SEVERITY_INFO when only a SEVERITY_INFO message exists"
-          + " in the FacesContext.");
-      out.println("Severity Recieved: " + severity);
-      out.println("Integer value of FacesMessage.SEVERITY_INFO: "
-          + FacesMessage.SEVERITY_INFO);
-      return;
-    }
-
-    context.addMessage(null, message2);
-    severity = context.getMaximumSeverity().getOrdinal();
-    if (severity != FacesMessage.SEVERITY_WARN.getOrdinal()) {
-      out.println(JSFTestUtil.FAIL + " Expected FacesContext."
-          + "getMaximumSeverity() to return FacesMessage."
-          + "SEVERITY_WARN when both a SEVERITY_INFO and "
-          + "SEVERITY_WARN message exist in the FacesContext.");
-      out.println("Severity Recieved: " + severity);
-      out.println("Integer value of FacesMessage.SEVERITY_WARN: "
-          + FacesMessage.SEVERITY_WARN);
-      return;
-    }
-
-    context.addMessage(null, message3);
-    severity = context.getMaximumSeverity().getOrdinal();
-    if (severity != FacesMessage.SEVERITY_ERROR.getOrdinal()) {
-      out.println(JSFTestUtil.FAIL + " Expected FacesContext."
-          + "getMaximumSeverity() to return FacesMessage."
-          + "SEVERITY_ERROR when messages with SEVERITY_INFO, "
-          + "SEVERITY_WARN, and SEVERITY_ERROR exist in the"
-          + " FacesContext.");
-      out.println("Severity Recieved: " + severity);
-      out.println("Integer value of FacesMessage.SEVERITY_ERROR: "
-          + FacesMessage.SEVERITY_ERROR);
-      return;
-    }
-
-    context.addMessage(null, message4);
-    severity = context.getMaximumSeverity().getOrdinal();
-    if (severity != FacesMessage.SEVERITY_FATAL.getOrdinal()) {
-      out.println(JSFTestUtil.FAIL + " Expected FacesContext."
-          + "getMaximumSeverity() to return FacesMessage."
-          + "SEVERITY_ERROR when messages with SEVERITY_INFO, "
-          + "SEVERITY_WARN, SEVERITY_ERROR, SEVERITY_FATAL exist"
-          + " in the FacesContext.");
-      out.println("Severity Recieved: " + severity);
-      out.println("Integer value of FacesMessage.SEVERITY_FATAL: "
-          + FacesMessage.SEVERITY_FATAL);
-      return;
-    }
-
-    out.println(JSFTestUtil.PASS);
-  }
-  // FacesContext.getResponseComplete()
-  // FacesContext.responseComplete()
-
-  public void facesCtxResponseCompleteTest(HttpServletRequest request,
-      HttpServletResponse response) throws IOException {
-    PrintWriter out = response.getWriter();
-    FacesContext context = getFacesContext();
-    context.setViewRoot(new UIViewRoot());
-
-    if (context.getResponseComplete()) {
-      out.println(JSFTestUtil.FAIL + " Expected FacesContext."
-          + "getResponseComplete() to return false if FacesContext."
-          + "responseComplete() hasn't been called.");
-      return;
-    }
-
-    context.responseComplete();
-
-    if (!context.getResponseComplete()) {
-      out.println(JSFTestUtil.FAIL + " Expected FacesContext."
-          + "getResponseComplete() to return true if"
-          + " FacesContext.responseComplete() has been called.");
-      return;
-    }
-
-    out.println(JSFTestUtil.PASS);
-  }
-  // FacesContext.getRenderResponse()
-  // FacesContext.renderResponse()
-
-  public void facexCtxRenderResponseTest(HttpServletRequest request,
-      HttpServletResponse response) throws IOException {
-    PrintWriter out = response.getWriter();
-    FacesContext context = getFacesContext();
-    context.setViewRoot(new UIViewRoot());
-
-    if (context.getRenderResponse()) {
-      out.println(JSFTestUtil.FAIL + " Expected FacesContext."
-          + "getRenderResponse() to return false if"
-          + " FacesContext.renderResponse() hasn't been called.");
-      return;
-    }
-
-    context.renderResponse();
-
-    if (!context.getRenderResponse()) {
-      out.println(JSFTestUtil.FAIL + " Expected FacesContext."
-          + "getRenderResponse() to return true if"
-          + " FacesContext.renderResponse() has been called.");
-      return;
-    }
-
-    out.println(JSFTestUtil.PASS);
-  }
-  // FacesContext.setResponseWriter()
-  // FacesContext.getResponseWriter()
-
-  public void facesCtxSetGetResponseWriterTest(HttpServletRequest request,
-      HttpServletResponse response) throws IOException {
-    PrintWriter out = response.getWriter();
-    FacesContext context = getFacesContext();
-    context.setViewRoot(new UIViewRoot());
-
-    ResponseWriter writer = new TCKResponseWriter();
-
-    context.setResponseWriter(writer);
-    ResponseWriter test = context.getResponseWriter();
-
-    if (test == null) {
-      out.println(JSFTestUtil.FAIL + " FacesContext.getResponseWriter() "
-          + "returned null after FacesContext.setResponseWriter("
-          + "ResponseWriter) was called.");
-      return;
-    }
-
-    if (test != writer) {
-      out.println(JSFTestUtil.FAIL + " FacesContext.getResponseWriter()"
-          + " did not return the expected" + " ResponseWriter instance.");
-      out.println("Expected: " + writer);
-      out.println("Received: " + test);
-      return;
-    }
-
-    out.println(JSFTestUtil.PASS);
-  }
-
-  // FacesContext.[get, set]ResponseStream()
-  public void facesCtxSetGetResponseStreamTest(HttpServletRequest request,
-      HttpServletResponse response) throws IOException {
-    PrintWriter out = response.getWriter();
-    FacesContext context = getFacesContext();
-    context.setViewRoot(new UIViewRoot());
-
-    ResponseStream stream = new TCKResponseStream();
-
-    context.setResponseStream(stream);
-    ResponseStream test = context.getResponseStream();
-
-    if (test == null) {
-      out.println(JSFTestUtil.FAIL + " FacesContext.getResponseStream()"
-          + " returned null after FacesContext.setResponseStream("
-          + "ResponseStream) was called.");
-      return;
-    }
-
-    if (test != stream) {
-      out.println(JSFTestUtil.FAIL + " FacesContext.getResponseStream() "
-          + "did not return the expected ResponseStream instance.");
-      out.println("Expected: " + stream);
-      out.println("Received: " + test);
-      return;
-    }
-
-    out.println(JSFTestUtil.PASS);
-
-  }// End facesCtxSetGetResponseStreamTest
-
-  public void facesCtxSetResponseStreamNPETest(HttpServletRequest request,
-      HttpServletResponse response) throws IOException {
-    PrintWriter out = response.getWriter();
-
-    JSFTestUtil.checkForNPE(getFacesContext(), "setResponseStream",
-        new Class<?>[] { ResponseStream.class }, new Object[] { null }, out);
-
-  }// End facesCtxSetResponseStreamNPETest
-
-  public void facesCtxSetResponseWriterNPETest(HttpServletRequest request,
-      HttpServletResponse response) throws IOException {
-    PrintWriter out = response.getWriter();
-
-    JSFTestUtil.checkForNPE(getFacesContext(), "setResponseWriter",
-        new Class<?>[] { ResponseWriter.class }, new Object[] { null }, out);
-
-  }// End facesCtxSetResponseWriterNPETest
-
-  // FacesContext.[get, set]ViewRoot()
-  public void facesCtxSetGetViewRootTest(HttpServletRequest request,
-      HttpServletResponse response) throws IOException {
-    PrintWriter out = response.getWriter();
-    FacesContext context = getFacesContext();
-    UIViewRoot root = (UIViewRoot) getApplication()
-        .createComponent(UIViewRoot.COMPONENT_TYPE);
-
-    context.setViewRoot(root);
-    UIViewRoot test = context.getViewRoot();
-
-    if (test == null) {
-      out.println(JSFTestUtil.FAIL + " FacesContext.getViewRoot() returned "
-          + "null after FacesContext.setViewRoot(UIViewRoot) " + "was called.");
-      return;
-    }
-
-    if (test != root) {
-      out.println(JSFTestUtil.FAIL + " FacesContext.getViewRoot() did not "
-          + "return the expected UIViewRoot instance.");
-      out.println("Expected: " + root);
-      out.println("Received: " + test);
-      return;
-    }
-
-    out.println(JSFTestUtil.PASS);
-
-  } // End facesCtxSetGetViewRootTest
-
-  // FacesContext.[is, set]ProcessingEvents()
-  public void facesCtxIsGetProcessingEventTest(HttpServletRequest request,
-      HttpServletResponse response) throws IOException {
-    PrintWriter out = response.getWriter();
-    FacesContext context = getFacesContext();
-
-    context.setProcessingEvents(true);
-    if (!context.isProcessingEvents()) {
-      out.println(JSFTestUtil.FAIL + JSFTestUtil.NL
-          + "Unexpected value returned from FacesContext.isProcessingEvents()"
-          + JSFTestUtil.NL + "Expected: true" + JSFTestUtil.NL + "Received: "
-          + context.isProcessingEvents());
-
-    } else {
-      context.setProcessingEvents(false);
-      if (context.isProcessingEvents()) {
-        out.println(JSFTestUtil.FAIL + JSFTestUtil.NL
-            + "Unexpected value returned from FacesContext.isProcessingEvents()"
-            + JSFTestUtil.NL + "Expected: false" + JSFTestUtil.NL + "Received: "
-            + context.isProcessingEvents());
-
-      } else {
-        out.println(JSFTestUtil.PASS);
-      }
-    }
-
-  } // End facesCtxIsGetProcessingEventTest
-
-  // FacesContext.[get, set]CurrentPhaseId()
-  public void facesCtxSetGetCurrentPhaseIdTest(HttpServletRequest request,
-      HttpServletResponse response) throws IOException {
-    PrintWriter out = response.getWriter();
-    FacesContext context = getFacesContext();
-
-    context.setCurrentPhaseId(PhaseId.ANY_PHASE);
-    PhaseId result = context.getCurrentPhaseId();
-    if (PhaseId.ANY_PHASE.equals(result)) {
-      out.println(JSFTestUtil.PASS);
-
-    } else {
-      out.println(
-          JSFTestUtil.FAIL + " FacesContext.getCurrentPhaseId() did not "
-              + "return the expected PhaseId.");
-      out.println("Expected: " + PhaseId.ANY_PHASE);
-      out.println("Received: " + result);
-    }
-
-  } // End facesCtxSetGetCurrentPhaseIdTest
-
-  // Ensure NPE is thrown if a null argument is passed to
-  // FacesContext.setViewRoot().
-  public void facesCtxSetViewRootNPETest(HttpServletRequest request,
-      HttpServletResponse response) throws IOException {
-    PrintWriter out = response.getWriter();
-
-    JSFTestUtil.checkForNPE(getFacesContext(), "setViewRoot",
-        new Class<?>[] { UIViewRoot.class }, new Object[] { null }, out);
-  }
-
-  // All methods of FacesContext must throw an IllegalStateException
-  // if called after FacesContext.release() has been called with the
-  // Exception of those referenced in the exMethods List.
-  public void facesCtxISEAfterReleaseTest(HttpServletRequest request,
-      HttpServletResponse response) throws IOException {
-    PrintWriter out = response.getWriter();
-    FacesContext context = getFacesContext();
-
-    // Excluded methods that do not throw IllegalStateException.
-    List<String> exMethods = new ArrayList<String>();
-    exMethods.add("release");
-    exMethods.add("isReleased");
-    exMethods.add("getComponentModificationManager");
-    exMethods.add("setCurrentInstance");
-    exMethods.add("getCurrentInstance");
-    exMethods.add("getCurrentPhaseId");
-    exMethods.add("setExceptionHandler");
-    exMethods.add("getExceptionHandler");
-    exMethods.add("setProcessingEvents");
-    exMethods.add("isProcessingEvents");
-
-    Method[] methods = FacesContext.class.getDeclaredMethods();
-    // loop through the remaining methods an ensure they all
-    // throw an IllegalStateException
-    context.release();
-
-    for (int i = 0; i < methods.length; i++) {
-      Method method = methods[i];
-      String name = method.getName();
-
-      if (!isExcluded(name, exMethods)) {
-        Class<?>[] types = method.getParameterTypes();
-        Object[] params = new Object[types.length];
-
-        if (name.equals("isProjectStage")) {
-          params[0] = ProjectStage.Development;
+        UIComponent component = getApplication().createComponent(UIInput.COMPONENT_TYPE);
+        if (compId == null) {
+            component.setId("nothing");
+        } else {
+            component.setId(compId);
         }
 
-        JSFTestUtil.checkForISE(context, name, types, params, out);
+        FacesMessage message1 = new TCKMessage(FacesMessage.SEVERITY_INFO, "message1 summary", "message1 detail", "message1");
+        FacesMessage message2 = new TCKMessage(FacesMessage.SEVERITY_INFO, "message2 summary", "message2 detail", "message2");
+        FacesMessage message3 = new TCKMessage(FacesMessage.SEVERITY_INFO, "message3 summary", "message3 detail", "message3");
+        FacesMessage message4 = new TCKMessage(FacesMessage.SEVERITY_INFO, "message4 summary", "message4 detail", "message4");
 
-      }
-    }
-  }
+        context.setViewRoot(createViewRoot());
 
-  public void facesCtxGetELContextTest(HttpServletRequest request,
-      HttpServletResponse response) throws IOException {
-
-    PrintWriter out = response.getWriter();
-    FacesContext context = getFacesContext();
-
-    ELContext elContext = context.getELContext();
-
-    if (elContext == null) {
-      out.println(JSFTestUtil.FAIL + " FacesContext.getELContext() returned"
-          + " null.");
-      return;
+        context.addMessage(component.getClientId(context), message1);
+        context.addMessage(component.getClientId(context), message3);
+        context.addMessage(null, message2);
+        context.addMessage(null, message4);
     }
 
-    out.println(JSFTestUtil.PASS);
+    // ------------------------------------------- Inner Classes -----------
+    
+    // Skeletal implementation of ResponseStream
+    private static final class TCKResponseStream extends ResponseStream {
 
-  } // END facesCtxGetELContextTest
-
-  public void facesCtxGetAttributesTest(HttpServletRequest request,
-      HttpServletResponse response) throws IOException {
-
-    PrintWriter out = response.getWriter();
-    FacesContext context = getFacesContext();
-
-    if (!(context.getAttributes() instanceof Map)) {
-      out.println("Test FAILED. Unexpected class type returned from"
-          + "FacesContext.getAttributes() method." + JSFTestUtil.NL
-          + "Expected: java.util.Map" + JSFTestUtil.NL + "Received: "
-          + context.getAttributes().getClass().getName());
-      return;
-    } else {
-      try {
-        context.getAttributes().put("test_key", "test_value");
-
-      } catch (UnsupportedOperationException usoe) {
-        out.print("Test FAILED. Map Not Mutable!");
-        out.print(usoe.toString());
-      } catch (Exception e) {
-        /*
-         * Swallow any other exception since we only care if the Map is mutable.
-         */
-      }
+        @Override
+        public void write(int b) throws IOException {
+        }
     }
 
-    out.println(JSFTestUtil.PASS);
+    // Skeletal implementation of ResponseWriter
+    private static final class TCKResponseWriter extends ResponseWriter {
 
-  } // END facesCtxgetAttributesTest
-
-  public void facesCtxGetAttributesEmptyTest(HttpServletRequest request,
-      HttpServletResponse response) throws IOException {
-
-    PrintWriter out = response.getWriter();
-    FacesContext context = getFacesContext();
-
-    try {
-      context.getAttributes().put("test_key", "test_value");
-      // validate that the attribute was put in.
-      HashMap<?, ?> hm = (HashMap<?, ?>) context.getAttributes();
-      if (!hm.containsKey("test_key")) {
-        out.println(
-            "Test FAILED. Attribute not added to context" + "attribute Map!");
-        return;
-      } else {
-        // map should be empty after this call.
-        context.release();
-        if (!hm.isEmpty()) {
-          out.println("Test FAILED. Attributes still found in "
-              + "context attribute Map, After 'context.release()"
-              + "was called!");
-          return;
+        public void closeStartTag(UIComponent component) throws IOException {
         }
 
-      }
-    } catch (Exception e) {
-      out.print("Test FAILED." + JSFTestUtil.NL + e.toString());
+        @Override
+        public String getContentType() {
+            return null;
+        }
+
+        @Override
+        public String getCharacterEncoding() {
+            return null;
+        }
+
+        @Override
+        public void write(char cbuf[], int off, int len) throws IOException {
+        }
+
+        @Override
+        public void flush() throws IOException {
+        }
+
+        @Override
+        public void close() throws IOException {
+        }
+
+        @Override
+        public void startDocument() throws IOException {
+        }
+
+        @Override
+        public void endDocument() throws IOException {
+        }
+
+        @Override
+        public void startElement(String name, UIComponent component) throws IOException {
+        }
+
+        @Override
+        public void endElement(String name) throws IOException {
+        }
+
+        @Override
+        public void writeAttribute(String name, Object value, String property) throws IOException {
+        }
+
+        @Override
+        public void writeURIAttribute(String name, Object value, String property) throws IOException {
+        }
+
+        @Override
+        public void writeComment(Object comment) throws IOException {
+        }
+
+        @Override
+        public void writeText(Object text, String property) throws IOException {
+        }
+
+        @Override
+        public void writeText(char text[], int off, int len) throws IOException {
+        }
+
+        @Override
+        public ResponseWriter cloneWithWriter(Writer writer) {
+            return null;
+        }
     }
 
-    out.println(JSFTestUtil.PASS);
+    // Simple implementation of FacesMessage
+    private static final class TCKMessage extends FacesMessage {
 
-  } // END facesCtxgetAttributesEmptyTest
+        private FacesMessage.Severity messageSeverity;
 
-  public void facesCtxGetPartialViewContextTest(HttpServletRequest request,
-      HttpServletResponse response) throws IOException {
+        private String messageSummary;
 
-    PrintWriter out = response.getWriter();
-    FacesContext context = getFacesContext();
+        private String messageDetail;
 
-    try {
-      PartialViewContext pvc = context.getPartialViewContext();
-      if (!(pvc instanceof PartialViewContext)) {
-        out.print("Test FAILED." + JSFTestUtil.NL + "Call to "
-            + "FacesContext.getPartialViewContext() should have "
-            + "returned a PartialViewContext." + JSFTestUtil.NL
-            + "Instead Received: " + pvc.getClass().getSimpleName());
-        return;
-      }
-    } catch (Exception e) {
-      out.print("Test FAILED." + JSFTestUtil.NL + e.toString());
+        String name;
+
+        TCKMessage(FacesMessage.Severity severity, String messageSummary, String messageDetail, String name) {
+            this.messageSeverity = severity;
+            this.messageSummary = messageSummary;
+            this.messageDetail = messageDetail;
+            this.name = name;
+        }
+
+        @Override
+        public String getDetail() {
+            return messageDetail;
+        }
+
+        @Override
+        public FacesMessage.Severity getSeverity() {
+            return messageSeverity;
+        }
+
+        @Override
+        public String getSummary() {
+            return messageSummary;
+        }
+
+        @Override
+        public String toString() {
+            return name;
+        }
     }
 
-    out.println(JSFTestUtil.PASS);
+    // Simple implementation of ExceptionHandler
+    private static final class TCKExceptionHandler extends ExceptionHandlerWrapper {
 
-  } // END facesCtxgetPartialViewContextTest
+        @Override
+        public ExceptionHandler getWrapped() {
+            // TODO Auto-generated method stub
+            return null;
+        }
 
-  public void facesCtxSetGetExceptionHandlerTest(HttpServletRequest request,
-      HttpServletResponse response) throws IOException {
+    } // End TCKExceptionHandler
 
-    PrintWriter out = response.getWriter();
-    FacesContext context = getFacesContext();
-    ExceptionHandler eh = new TCKExceptionHandler();
-    context.setExceptionHandler(eh);
+    private static class TCKRenderKit extends RenderKitWrapper {
 
-    String golden = "TCKExceptionHandler";
-    String result = context.getExceptionHandler().getClass().getSimpleName();
+        @Override
+        public RenderKit getWrapped() {
+            return FacesContext.getCurrentInstance().getRenderKit();
+        }
 
-    if (golden.equals(result)) {
-      out.println(JSFTestUtil.PASS);
-
-    } else {
-      out.print(
-          "Test FAILED." + JSFTestUtil.NL + " Unexpected value returned from"
-              + "FacesContext.getExceptionHandler()!" + JSFTestUtil.NL
-              + "Expected: " + golden + JSFTestUtil.NL + "Received: " + result);
-    }
-
-  } // END facesCtxSetGetExceptionHandlerTest
-
-  public void facesCtxsetExceptionHandlerTest(HttpServletRequest request,
-      HttpServletResponse response) throws IOException {
-
-    PrintWriter out = response.getWriter();
-    FacesContext context = getFacesContext();
-
-    try {
-      context.setExceptionHandler(new TCKExceptionHandler());
-      ExceptionHandler eh = context.getExceptionHandler();
-      if (!("TCKExceptionHandler".equals(eh.getClass().getSimpleName()))) {
-        out.print("Test FAILED." + JSFTestUtil.NL + "Call to "
-            + "FacesContext.setExceptionHandler() did not set " + "Handler!"
-            + JSFTestUtil.NL + "Expected: TCKExceptionHandler" + JSFTestUtil.NL
-            + "Received: " + eh.getClass().getSimpleName());
-        return;
-      }
-    } catch (Exception e) {
-      out.print("Test FAILED." + JSFTestUtil.NL + e.toString());
-    }
-
-    out.println(JSFTestUtil.PASS);
-
-  } // END facesCtxgetExceptionHandlerTest
-
-  public void facesCtxGetExternalContextTest(HttpServletRequest request,
-      HttpServletResponse response) throws IOException {
-
-    PrintWriter out = response.getWriter();
-    FacesContext context = getFacesContext();
-
-    try {
-      ExternalContext ec = context.getExternalContext();
-      if (!(ec instanceof ExternalContext)) {
-        out.print("Test FAILED." + JSFTestUtil.NL + "Call to "
-            + "FacesContext.getExternalContext did not return"
-            + "correct instance type." + JSFTestUtil.NL
-            + "Expected: ExternalContext" + JSFTestUtil.NL + "Received: "
-            + ec.getClass().getSimpleName());
-        return;
-      }
-    } catch (Exception e) {
-      out.print("Test FAILED." + JSFTestUtil.NL + e.toString());
-    }
-
-    out.println(JSFTestUtil.PASS);
-
-  } // END facesCtxgetExternalContextTest
-
-  public void facesCtxisReleasedTest(HttpServletRequest request,
-      HttpServletResponse response) throws IOException {
-    PrintWriter out = response.getWriter();
-    FacesContext context = getFacesContext();
-
-    // Test before release.
-    if (context.isReleased()) {
-      out.println("Test FAILED");
-      out.println("Unexpected value returned from FacesContext.isReleased() "
-          + "before FacesContext.release() was callled." + JSFTestUtil.NL
-          + "Expected: FALSE " + JSFTestUtil.NL + "Received: TRUE"
-          + JSFTestUtil.NL);
-      return;
-    }
-
-    // Test After release
-    context.release();
-    if (!context.isReleased()) {
-      out.println("Test FAILED");
-      out.println("Unexpected value returned from FacesContext.isReleased() "
-          + "after FacesContext.release() was called. " + JSFTestUtil.NL
-          + "Expected: TRUE " + JSFTestUtil.NL + "Received: FALSE"
-          + JSFTestUtil.NL);
-      return;
-    }
-
-    out.println(JSFTestUtil.PASS);
-
-  } // END facesCtxisReleasedTest
-
-  public void facesCtxGetRenderKitTest(HttpServletRequest request,
-      HttpServletResponse response) throws IOException {
-
-    PrintWriter out = response.getWriter();
-    FacesContext context = getFacesContext();
-    UIViewRoot root = context.getViewRoot();
-    String rkn = "TCKRenderKit";
-
-    // Setup renderKit
-    RenderKit renderKit = new TCKRenderKit();
-    RenderKitFactory factory = (RenderKitFactory) FactoryFinder
-        .getFactory(FactoryFinder.RENDER_KIT_FACTORY);
-    factory.addRenderKit(rkn, renderKit);
-
-    root.setRenderKitId(rkn);
-    RenderKit result = context.getRenderKit();
-
-    if (rkn.equals(result.getClass().getSimpleName())) {
-      out.println(JSFTestUtil.PASS);
-
-    } else {
-      out.println(JSFTestUtil.FAIL + JSFTestUtil.NL
-          + "Unexpected RenderKit returned from FacesContext.getRenderKit()"
-          + JSFTestUtil.NL + "Expected: " + rkn + JSFTestUtil.NL + "Received: "
-          + result);
-    }
-  } // END facesCtxGetRenderKitTest
-
-  // ------------------------------------------- Private Methods -----------
-  private String validateIllegalStateException(Method methodToInvoke,
-      Object target, Object[] params) {
-    String result = null;
-
-    try {
-      methodToInvoke.invoke(target, params);
-      result = JSFTestUtil.FAIL + " No Exception thrown when calling '"
-          + methodToInvoke.getName() + "'"
-          + " after FacesContext.release() was called.";
-
-    } catch (Throwable throwable) {
-      Throwable t = throwable;
-      if (throwable instanceof InvocationTargetException) {
-        t = ((InvocationTargetException) throwable).getTargetException();
-      }
-
-      if (!(t instanceof IllegalStateException)) {
-        StringBuffer sb = new StringBuffer(100);
-        sb.append(JSFTestUtil.FAIL + " Exception thrown when '")
-            .append(methodToInvoke.getName());
-        sb.append("' was called after FacesContext.release(), but it "
-            + "wasn't an instance of");
-        sb.append(" IllegalStateException.\nException received: ")
-            .append(t.getClass().getName());
-        result = sb.toString();
-      }
-    }
-    return result;
-  }
-
-  private boolean isExcluded(String methodName, List<String> excludeList) {
-    boolean result = false;
-
-    for (String excluded : excludeList) {
-      if (excluded.equals(methodName) || methodName.charAt(0) == '$') {
-        result = true;
-      }
-    }
-
-    return result;
-  }
-
-  private FacesMessage[] getMessagesAsArray(Iterator iterator) {
-    List list = new ArrayList();
-    while (iterator.hasNext()) {
-      list.add(iterator.next());
-    }
-    return (FacesMessage[]) list.toArray(new FacesMessage[list.size()]);
-  }
-
-  /*
-   * Add test messages to the given FacesContext.
-   */
-  private void addTestMessagesToContext(FacesContext context, String compId) {
-
-    UIComponent component = getApplication()
-        .createComponent(UIInput.COMPONENT_TYPE);
-    if (compId == null) {
-      component.setId("nothing");
-    } else {
-      component.setId(compId);
-    }
-
-    FacesMessage message1 = new TCKMessage(FacesMessage.SEVERITY_INFO,
-        "message1 summary", "message1 detail", "message1");
-    FacesMessage message2 = new TCKMessage(FacesMessage.SEVERITY_INFO,
-        "message2 summary", "message2 detail", "message2");
-    FacesMessage message3 = new TCKMessage(FacesMessage.SEVERITY_INFO,
-        "message3 summary", "message3 detail", "message3");
-    FacesMessage message4 = new TCKMessage(FacesMessage.SEVERITY_INFO,
-        "message4 summary", "message4 detail", "message4");
-
-    context.setViewRoot(createViewRoot());
-
-    context.addMessage(component.getClientId(context), message1);
-    context.addMessage(component.getClientId(context), message3);
-    context.addMessage(null, message2);
-    context.addMessage(null, message4);
-  }
-
-  // ------------------------------------------- Inner Classes -----------
-  // skeletal implementation of ResponseStream
-  private static final class TCKResponseStream extends ResponseStream {
-
-    @Override
-    public void write(int b) throws IOException {
-    }
-  }
-
-  // skeletal implementation of ResponseWriter
-  private static final class TCKResponseWriter extends ResponseWriter {
-
-    public void closeStartTag(UIComponent component) throws IOException {
-    }
-
-    @Override
-    public String getContentType() {
-      return null;
-    }
-
-    @Override
-    public String getCharacterEncoding() {
-      return null;
-    }
-
-    @Override
-    public void write(char cbuf[], int off, int len) throws IOException {
-    }
-
-    @Override
-    public void flush() throws IOException {
-    }
-
-    @Override
-    public void close() throws IOException {
-    }
-
-    @Override
-    public void startDocument() throws IOException {
-    }
-
-    @Override
-    public void endDocument() throws IOException {
-    }
-
-    @Override
-    public void startElement(String name, UIComponent component)
-        throws IOException {
-    }
-
-    @Override
-    public void endElement(String name) throws IOException {
-    }
-
-    @Override
-    public void writeAttribute(String name, Object value, String property)
-        throws IOException {
-    }
-
-    @Override
-    public void writeURIAttribute(String name, Object value, String property)
-        throws IOException {
-    }
-
-    @Override
-    public void writeComment(Object comment) throws IOException {
-    }
-
-    @Override
-    public void writeText(Object text, String property) throws IOException {
-    }
-
-    @Override
-    public void writeText(char text[], int off, int len) throws IOException {
-    }
-
-    @Override
-    public ResponseWriter cloneWithWriter(Writer writer) {
-      return null;
-    }
-  }
-
-  // simple implementation of FacesMessage
-  private static final class TCKMessage extends FacesMessage {
-
-    private FacesMessage.Severity messageSeverity;
-
-    private String messageSummary;
-
-    private String messageDetail;
-
-    String name;
-
-    TCKMessage(FacesMessage.Severity severity, String messageSummary,
-        String messageDetail, String name) {
-      this.messageSeverity = severity;
-      this.messageSummary = messageSummary;
-      this.messageDetail = messageDetail;
-      this.name = name;
-    }
-
-    @Override
-    public String getDetail() {
-      return messageDetail;
-    }
-
-    @Override
-    public FacesMessage.Severity getSeverity() {
-      return messageSeverity;
-    }
-
-    @Override
-    public String getSummary() {
-      return messageSummary;
-    }
-
-    @Override
-    public String toString() {
-      return name;
-    }
-  }
-
-  // simple implementation of ExceptionHandler
-  private static final class TCKExceptionHandler
-      extends ExceptionHandlerWrapper {
-
-    @Override
-    public ExceptionHandler getWrapped() {
-      // TODO Auto-generated method stub
-      return null;
-    }
-
-  } // End TCKExceptionHandler
-
-  private static class TCKRenderKit extends RenderKitWrapper {
-
-    @Override
-    public RenderKit getWrapped() {
-      return FacesContext.getCurrentInstance().getRenderKit();
-    }
-
-  } // End TCKRenderKit
+    } // End TCKRenderKit
 
 }

--- a/tck/old-tck/source/src/com/sun/ts/tests/jsf/common/util/JSFTestUtil.java
+++ b/tck/old-tck/source/src/com/sun/ts/tests/jsf/common/util/JSFTestUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2024 Contributors to Eclipse Foundation.
+ * Copyright (c) 2022 Contributors to Eclipse Foundation.
  * Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -42,526 +42,596 @@ import jakarta.servlet.ServletContext;
 
 public final class JSFTestUtil {
 
-    public static final boolean DEBUG = true;
+  public static final boolean DEBUG = true;
 
-    public static final String NL = System.getProperty("line.separator", "\n");
+  public static final String NL = System.getProperty("line.separator", "\n");
 
-    public static final String PASS = "Test PASSED";
+  public static final String PASS = "Test PASSED";
 
-    public static final String FAIL = "Test FAILED";
+  public static final String FAIL = "Test FAILED";
 
-    public static final String NPE_MESS = FAIL + " Unexpected Exception Thrown!" + NL + 
-            "Expected: NullPointerException" + NL + 
-            "Received: ";
+  public static final String NPE_MESS = FAIL + " Unexpected Exception Thrown!"
+      + NL + "Expected: NullPointerException" + NL + "Received: ";
 
-    public static final String FE_MESS = FAIL + " Unexpected Exception Thrown!" + NL + 
-            "Expected: FacesException" + NL + 
-            "Received: ";
+  public static final String FE_MESS = FAIL + " Unexpected Exception Thrown!"
+      + NL + "Expected: FacesException" + NL + "Received: ";
 
-    public static final String ISE_MESS = FAIL + " Unexpected Exception Thrown!" + NL + 
-            "Expected: IllegalStateException" + NL + 
-            "Received: ";
+  public static final String ISE_MESS = FAIL + " Unexpected Exception Thrown!"
+      + NL + "Expected: IllegalStateException" + NL + "Received: ";
 
-    public static final String APE_MESS = FAIL + " Unexpected Exception Thrown!" + NL + 
-            "Expected: AbortProcessingException" + NL + 
-            "Received: ";
+  public static final String APE_MESS = FAIL + " Unexpected Exception Thrown!"
+      + NL + "Expected: AbortProcessingException" + NL + "Received: ";
 
-    public static final String APP_NULL_MSG = FAIL + " :Unable to obtain " + "Application instance.";
+  public static final String APP_NULL_MSG = FAIL + " :Unable to obtain "
+      + "Application instance.";
 
-    public static final String RESHANDLER_NULL_MSG = FAIL + NL + "Unable to obtain ResourceHandler instance.";
+  public static final String RESHANDLER_NULL_MSG = FAIL + NL
+      + "Unable to obtain ResourceHandler instance.";
 
-    private JSFTestUtil() {
-        throw new IllegalStateException();
+  private JSFTestUtil() {
+    throw new IllegalStateException();
+  }
+
+  /**
+   * Writes the provided message to System.out when <tt>debug</tt> is set.
+   * 
+   * @param message
+   *          - the message to write to System.out
+   */
+  public static void debug(String message) {
+    if (DEBUG) {
+      System.out.println(message);
+    }
+  }
+
+  /**
+   * <p>
+   * Compares the String values in an Enumeration against the provided String
+   * array of values in a case sensitive manner.
+   * </p>
+   * 
+   * <p>
+   * This method will return <code>false</code> under the following
+   * circumstances:
+   * <ul>
+   * <li>The number of elements in the {@link Iterator} and the number of
+   * elements in the Array are not equal (only when the
+   * <code>enforceSizes</code> parameter is <code>true</code></li>
+   * <li>If the input {@link Iterator} or Array are null</li>
+   * <li>If duplicates are found in the {@link Iterator} and
+   * <code>allowDuplicates</code> is false</li>
+   * </ul>
+   * 
+   * <p>
+   * If none of the above occur, then <code>true<code> will be returned.
+   * </p>
+   * 
+   * @param i
+   *          - Iterator to validate
+   * @param values
+   *          - the values expected to be found in the Enumeration
+   * @param enforceSizes
+   *          - ensures that the number of elements in the Enumeration matches
+   *          the number of elements in the array of values
+   * @param allowDuplicates
+   *          - If true, the method will true if duplicate elements are found in
+   *          the Enumeration, if false, then false will be return if duplicate
+   *          elements have been found.
+   * 
+   * @return true if all the expected values are found, otherwise false.
+   */
+  public static boolean checkIterator(Iterator<?> i, String[] values,
+      boolean enforceSizes, boolean allowDuplicates) {
+    List<Object> foundValues = null;
+
+    if (i == null || !i.hasNext() || values == null) {
+      return false;
     }
 
-    /**
-     * Writes the provided message to System.out when <tt>debug</tt> is set.
-     * 
-     * @param message - the message to write to System.out
-     */
-    public static void debug(String message) {
-        if (DEBUG) {
-            System.out.println(message);
-        }
+    if (!allowDuplicates) {
+      foundValues = new ArrayList<Object>();
     }
 
-    /**
-     * <p>
-     * Compares the String values in an Enumeration against the provided String array of values in a case sensitive manner.
-     * </p>
-     * 
-     * <p>
-     * This method will return <code>false</code> under the following circumstances:
-     * <ul>
-     * <li>The number of elements in the {@link Iterator} and the number of elements in the Array are not equal (only when
-     * the <code>enforceSizes</code> parameter is <code>true</code></li>
-     * <li>If the input {@link Iterator} or Array are null</li>
-     * <li>If duplicates are found in the {@link Iterator} and <code>allowDuplicates</code> is false</li>
-     * </ul>
-     * 
-     * <p>
-     * If none of the above occur, then <code>true<code> will be returned.
-     * </p>
-     * 
-     * @param i - Iterator to validate
-     * @param values - the values expected to be found in the Enumeration
-     * @param enforceSizes - ensures that the number of elements in the Enumeration matches the number of elements in the
-     * array of values
-     * @param allowDuplicates - If true, the method will true if duplicate elements are found in the Enumeration, if false,
-     * then false will be return if duplicate elements have been found.
-     * 
-     * @return true if all the expected values are found, otherwise false.
-     */
-    public static boolean checkIterator(Iterator<?> i, String[] values, boolean enforceSizes, boolean allowDuplicates) {
-        List<Object> foundValues = null;
-
-        if (i == null || !i.hasNext() || values == null) {
-            return false;
-        }
-
+    boolean valuesFound = true;
+    Arrays.sort(values);
+    int count = 0;
+    while (i.hasNext()) {
+      Object val;
+      try {
+        val = i.next();
+        count++;
         if (!allowDuplicates) {
-            foundValues = new ArrayList<Object>();
+          if (foundValues.contains(val)) {
+            debug("[JSFTestUtil] Duplicate values found in "
+                + "Iterator when duplicates are not allowed."
+                + "Values found in the Iterator: " + getAsString(i));
+            valuesFound = false;
+            break;
+          }
+          foundValues.add(val);
         }
 
-        boolean valuesFound = true;
-        Arrays.sort(values);
-        int count = 0;
-        while (i.hasNext()) {
-            Object val;
-            try {
-                val = i.next();
-                count++;
-                if (!allowDuplicates) {
-                    if (foundValues.contains(val)) {
-                        debug("[JSFTestUtil] Duplicate values found in " + "Iterator when duplicates are not allowed."
-                                + "Values found in the Iterator: " + getAsString(i));
-                        valuesFound = false;
-                        break;
-                    }
-                    foundValues.add(val);
-                }
-
-            } catch (NoSuchElementException nsee) {
-                debug("[JSFTestUtil] There were less elements in the " + "Iterator than expected");
-                valuesFound = false;
-                break;
-            }
-            debug("[JSFTestUtil] Looking for '" + val + "' in values: " + getAsString(values));
-            if ((Arrays.binarySearch(values, val) < 0) && (enforceSizes)) {
-                debug("[JSFTestUtil] Value '" + val + "' not found.");
-                valuesFound = false;
-            }
-        }
-
-        if (enforceSizes) {
-            if (i.hasNext()) {
-                // more elements than should have been.
-                debug("[JSFTestUtil] There were more elements in the Iterator " + "than expected.");
-                valuesFound = false;
-            }
-            if (count != values.length) {
-                debug("[JSFTestUtil] There number of elements in the Iterator " + "did not match number of expected values."
-                        + "Expected number of Values=" + values.length + ", Actual number of Iterator elements=" + count);
-
-                valuesFound = false;
-            }
-        }
-        return valuesFound;
+      } catch (NoSuchElementException nsee) {
+        debug("[JSFTestUtil] There were less elements in the "
+            + "Iterator than expected");
+        valuesFound = false;
+        break;
+      }
+      debug("[JSFTestUtil] Looking for '" + val + "' in values: "
+          + getAsString(values));
+      if ((Arrays.binarySearch(values, val) < 0) && (enforceSizes)) {
+        debug("[JSFTestUtil] Value '" + val + "' not found.");
+        valuesFound = false;
+      }
     }
 
-    /**
-     * <p>
-     * Returns the elements of the provided {@link Iterator} as a String in the following format: <code>[n1,n2,n...]</code>.
-     * </p>
-     * 
-     * @param i - an Iterator
-     * 
-     * @return - a printable version of the contents of the Iterator
-     */
-    public static String getAsString(Iterator<?> i) {
-        return getAsString(getAsArray(i));
+    if (enforceSizes) {
+      if (i.hasNext()) {
+        // more elements than should have been.
+        debug("[JSFTestUtil] There were more elements in the Iterator "
+            + "than expected.");
+        valuesFound = false;
+      }
+      if (count != values.length) {
+        debug("[JSFTestUtil] There number of elements in the Iterator "
+            + "did not match number of expected values."
+            + "Expected number of Values=" + values.length
+            + ", Actual number of Iterator elements=" + count);
+
+        valuesFound = false;
+      }
+    }
+    return valuesFound;
+  }
+
+  /**
+   * <p>
+   * Returns the elements of the provided {@link Iterator} as a String in the
+   * following format: <code>[n1,n2,n...]</code>.
+   * </p>
+   * 
+   * @param i
+   *          - an Iterator
+   * 
+   * @return - a printable version of the contents of the Iterator
+   */
+  public static String getAsString(Iterator<?> i) {
+    return getAsString(getAsArray(i));
+  }
+
+  /**
+   * <p>
+   * Returns the elements contained in the String array in the following format:
+   * <code>[n1,n2,n...]</code>.
+   * </p>
+   * 
+   * @param sArray
+   *          - an array of Objects
+   * @return - a String based off the values in the array
+   */
+  public static String getAsString(Object[] sArray) {
+    if (sArray == null) {
+      return null;
+    }
+    StringBuffer buf = new StringBuffer();
+    buf.append("[");
+    for (int i = 0; i < sArray.length; i++) {
+      buf.append(sArray[i].toString());
+      if ((i + 1) != sArray.length) {
+        buf.append(",");
+      }
+    }
+    buf.append("]");
+    return buf.toString();
+  }
+
+  /**
+   * <p>
+   * Returns a String representation of the {@link Map} provided.
+   * </p>
+   * 
+   * @param map
+   *          input map
+   * @return String representation of the Map
+   */
+  public static String getAsString(Map<String, Object> map) {
+    StringBuffer sb = new StringBuffer(32);
+    Set<Map.Entry<String, Object>> entrySet = map.entrySet();
+    sb.append("Map Entries\n----------------\n");
+    for (Map.Entry<String, Object> entry : entrySet) {
+      sb.append(entry.getKey()).append(", ").append(entry.getValue());
+      sb.append('\n');
+    }
+    sb.append('\n');
+    return sb.toString();
+  }
+
+  /**
+   * <p>
+   * Returns the elements within the provided {@link Iterator} as an Array.
+   * </p>
+   * 
+   * @param i
+   *          - an Iterator
+   * @return - the elements of the Iterator as an array of Objects
+   */
+  public static Object[] getAsArray(Iterator<?> i) {
+    List<Object> list = new ArrayList<Object>();
+    while (i.hasNext()) {
+      list.add(i.next());
+    }
+    return list.toArray(new Object[list.size()]);
+  }
+
+  /**
+   * <p>
+   * Returns the elements of the passed {@link Iterator} as an array of Strings.
+   * </p>
+   * 
+   * @param i
+   *          an Iterator
+   * @return the contents of the Iterator as an array of Strings
+   */
+  public static String[] getAsStringArray(Iterator<String> i) {
+    List<String> list = new ArrayList<String>();
+    while (i.hasNext()) {
+      list.add(i.next());
+    }
+    return list.toArray(new String[list.size()]);
+  }
+
+  /**
+   * <p>
+   * Returns the elements of the {@link Enumeration} as an array of S trings.
+   * </p>
+   * 
+   * @param e
+   *          an Enumeration
+   * @return the contexts of the Enumeration as an array of Strings
+   */
+  public static String[] getAsStringArray(Enumeration<?> e) {
+    List<Object> list = new ArrayList<Object>();
+    while (e.hasMoreElements()) {
+      list.add(e.nextElement());
+    }
+    return list.toArray(new String[list.size()]);
+  }
+
+  /**
+   * <p>
+   * Attempts to load the specified <code>className</code> using the current
+   * Thread's context class loader.
+   * </p>
+   * 
+   * @param className
+   *          fully qualified class name
+   * @return the loaded Class or <code>null</code> if no Class could be found
+   */
+  public static Class<?> loadClass(String className) {
+    Class<?> c = null;
+    try {
+      c = Thread.currentThread().getContextClassLoader().loadClass(className);
+    } catch (Throwable t) {
+      debug("[JSFTestUtil] Exception occurred trying to get class: "
+          + t.toString());
+      t.printStackTrace();
     }
 
-    /**
-     * <p>
-     * Returns the elements contained in the String array in the following format: <code>[n1,n2,n...]</code>.
-     * </p>
-     * 
-     * @param sArray - an array of Objects
-     * @return - a String based off the values in the array
-     */
-    public static String getAsString(Object[] sArray) {
-        if (sArray == null) {
-            return null;
-        }
-        StringBuffer buf = new StringBuffer();
-        buf.append("[");
-        for (int i = 0; i < sArray.length; i++) {
-            buf.append(sArray[i].toString());
-            if ((i + 1) != sArray.length) {
-                buf.append(",");
-            }
-        }
-        buf.append("]");
-        return buf.toString();
+    return c;
+  }
+
+  /**
+   * <p>
+   * Returns the ordinal value of a {@link FacesMessage.Severity} Object as a
+   * String value.
+   * </p>
+   * <ul>
+   * <li>FacesMessage.SEVERITY_INFO returns SEVERITY_INFO</li>
+   * <li>FacesMessage.SEVERITY_ERROR returns SEVERITY_ERROR</li>
+   * <li>FacesMessage.SEVERITY_FATAL returns SEVERITY_FATAL</li>
+   * <li>FacesMessage.SEVERITY_WARN returns SEVERITY_WARN</li>
+   * </ul>
+   * 
+   * @param severity
+   *          the ordinal value of a FacesMessage.Severity Object
+   * @return The String equivalent of the passed value.
+   */
+  public static String getSeverityAsString(int severity) {
+    if (severity == FacesMessage.SEVERITY_INFO.getOrdinal())
+      return "SEVERITY_INFO";
+    else if (severity == FacesMessage.SEVERITY_ERROR.getOrdinal())
+      return "SEVERITY_ERROR";
+    else if (severity == FacesMessage.SEVERITY_FATAL.getOrdinal())
+      return "SEVERITY_FATAL";
+    else if (severity == FacesMessage.SEVERITY_WARN.getOrdinal())
+      return "SEVERITY_WARN";
+    else
+      return "UNKNOWN_SEVERITY";
+  }
+
+  /**
+   * <p>
+   * Return a <code>String</code> representation of the <code>PhaseId</code>
+   * ordinal.
+   * </p>
+   */
+  public static String getPhaseIdAsString(PhaseId phaseId) {
+    int ordinal = phaseId.getOrdinal();
+    if (ordinal == PhaseId.ANY_PHASE.getOrdinal())
+      return "ANY_PHASE";
+    else if (ordinal == PhaseId.APPLY_REQUEST_VALUES.getOrdinal())
+      return "APPLY_REQUEST_VALUES";
+    else if (ordinal == PhaseId.INVOKE_APPLICATION.getOrdinal())
+      return "INVOKE_APPLICATION";
+    else if (ordinal == PhaseId.PROCESS_VALIDATIONS.getOrdinal())
+      return "PROCESS_VALIDATIONS";
+    else if (ordinal == PhaseId.RENDER_RESPONSE.getOrdinal())
+      return "RENDER_RESPONSE";
+    else if (ordinal == PhaseId.RESTORE_VIEW.getOrdinal())
+      return "RESTORE_VIEW";
+    else if (ordinal == PhaseId.UPDATE_MODEL_VALUES.getOrdinal())
+      return "UPDATE_MODEL_VALUES";
+    else
+      return "UNKNOWN_PHASE";
+  }
+
+  /**
+   * <p>
+   * Convenience method to obtain an EL <code>ExpressionFactory</code>.
+   * </p>
+   */
+  public static ExpressionFactory getExpressionFactory(ServletContext ctx) {
+
+    return ELManager.getExpressionFactory();
+
+  } // END getExpressionFactory
+
+  /**
+   * Checks to see if a NullPointerException is thrown from a given
+   * method(methName) from a given Class(className). use this method for any
+   * none Abstract classes you wish to test.
+   * 
+   * @param className
+   *          - The Class that has the method under test.
+   * @param methName
+   *          - The method that you want to test.
+   * @param argTypes
+   *          - The type value of the arguments for the method under test.
+   * @param params
+   *          - The parameters you are feeding into the method under test.
+   * @param pw
+   *          - The PrintWrite that you want the results written to.
+   */
+  public static void checkForNPE(String className, String methName,
+      Class<?>[] argTypes, Object[] params, PrintWriter pw) {
+
+    try {
+      JSFTestUtil.checkForNPE(Class.forName(className), methName, argTypes,
+          params, pw);
+
+    } catch (ClassNotFoundException cnfe) {
+      pw.println(JSFTestUtil.FAIL + JSFTestUtil.NL);
+      cnfe.printStackTrace();
     }
 
-    /**
-     * <p>
-     * Returns a String representation of the {@link Map} provided.
-     * </p>
-     * 
-     * @param map input map
-     * @return String representation of the Map
-     */
-    public static String getAsString(Map<String, Object> map) {
-        StringBuffer sb = new StringBuffer(32);
-        Set<Map.Entry<String, Object>> entrySet = map.entrySet();
-        sb.append("Map Entries\n----------------\n");
-        for (Map.Entry<String, Object> entry : entrySet) {
-            sb.append(entry.getKey()).append(", ").append(entry.getValue());
-            sb.append('\n');
-        }
-        sb.append('\n');
-        return sb.toString();
+  } // End checkForNPE
+
+  /**
+   * Checks to see if a NullPointerException is thrown from a given
+   * method(methName) from a given Class. use this method for any Abstract
+   * classes you wish to test. You can pass in the instantiated class that you
+   * want to test.
+   * 
+   * @param Class
+   *          - The class you want to test.
+   * @param methName
+   *          - The method that you want to test.
+   * @param argTypes
+   *          - The type value of the arguments for the method under test.
+   * @param params
+   *          - The parameters you are feeding into the method under test.
+   * @param pw
+   *          - The PrintWrite that you want the results written to.
+   */
+  public static void checkForNPE(Class<?> clazz, String methName,
+      Class<?>[] argTypes, Object[] params, PrintWriter pw) {
+
+    try {
+      JSFTestUtil.checkForNPE(clazz.newInstance(), methName, argTypes, params,
+          pw);
+
+    } catch (Exception e) {
+      pw.println(JSFTestUtil.FAIL + JSFTestUtil.NL);
+      e.printStackTrace();
     }
 
-    /**
-     * <p>
-     * Returns the elements within the provided {@link Iterator} as an Array.
-     * </p>
-     * 
-     * @param i - an Iterator
-     * @return - the elements of the Iterator as an array of Objects
-     */
-    public static Object[] getAsArray(Iterator<?> i) {
-        List<Object> list = new ArrayList<Object>();
-        while (i.hasNext()) {
-            list.add(i.next());
-        }
-        return list.toArray(new Object[list.size()]);
+  } // End checkForNPE
+
+  /**
+   * Checks to see if a NullPointerException is thrown from a given
+   * method(methName) from a given Class. use this method for any Abstract
+   * classes you wish to test. You can pass in the instantiated class that you
+   * want to test.
+   * 
+   * @param object
+   *          - The Object you want to test.
+   * @param methName
+   *          - The method that you want to test.
+   * @param argTypes
+   *          - The type value of the arguments for the method under test.
+   * @param params
+   *          - The parameters you are feeding into the method under test.
+   * @param pw
+   *          - The PrintWrite that you want the results written to.
+   */
+  public static void checkForNPE(Object object, String methName,
+      Class<?>[] argTypes, Object[] params, PrintWriter pw) {
+    String className = object.getClass().getName();
+    Method[] methods = null;
+
+    try {
+      methods = object.getClass().getMethods();
+      Method execMeth = object.getClass().getMethod(methName, argTypes);
+      execMeth.invoke(object, params);
+
+      pw.println(JSFTestUtil.FAIL + " No Exception thrown!" + JSFTestUtil.NL
+          + "Expected a NullPointerException " + "to be thrown "
+          + JSFTestUtil.NL + "when testing: " + className + "." + methName);
+
+    } catch (InvocationTargetException ite) {
+      if (ite.getCause() instanceof NullPointerException) {
+        pw.println(JSFTestUtil.PASS);
+
+      } else {
+        pw.println(JSFTestUtil.NPE_MESS
+            + ite.getCause().getClass().getSimpleName() + JSFTestUtil.NL
+            + "When testing: " + className + "." + methName);
+        ite.getCause().printStackTrace();
+      }
+
+    } catch (NoSuchMethodException nsme) {
+      pw.println(JSFTestUtil.NPE_MESS + nsme.getClass().getSimpleName()
+          + JSFTestUtil.NL);
+
+      JSFTestUtil.printMethods(className, methods, params, pw);
+
+    } catch (Throwable t) {
+      pw.println(JSFTestUtil.NPE_MESS + t.getClass().getSimpleName()
+          + JSFTestUtil.NL + "When testing: " + className + "." + methName);
+      t.printStackTrace();
     }
+  } // End checkForNPE
 
-    /**
-     * <p>
-     * Returns the elements of the passed {@link Iterator} as an array of Strings.
-     * </p>
-     * 
-     * @param i an Iterator
-     * @return the contents of the Iterator as an array of Strings
-     */
-    public static String[] getAsStringArray(Iterator<String> i) {
-        List<String> list = new ArrayList<String>();
-        while (i.hasNext()) {
-            list.add(i.next());
-        }
-        return list.toArray(new String[list.size()]);
+  /**
+   * Checks to see if a FacesException is thrown from a given method.
+   * 
+   * @param object
+   *          - The Object you want to test.
+   * @param methName
+   *          - The method that you want to test.
+   * @param argTypes
+   *          - The type value of the arguments for the method under test.
+   * @param params
+   *          - The parameters you are feeding into the method under test.
+   * @param pw
+   *          - The PrintWrite that you want the results written to.
+   */
+  public static void checkForFE(Object object, String methName,
+      Class<?>[] argTypes, Object[] params, PrintWriter pw) {
+    String className = object.getClass().getName();
+    Method[] methods = null;
+
+    try {
+      methods = object.getClass().getMethods();
+      Method execMeth = object.getClass().getMethod(methName, argTypes);
+      execMeth.invoke(object, params);
+
+      pw.println(JSFTestUtil.FAIL + " No Exception thrown!" + JSFTestUtil.NL
+          + "Expected a FacesException " + "to be thrown " + JSFTestUtil.NL
+          + "when testing: " + className + "." + methName);
+
+    } catch (InvocationTargetException ite) {
+      if (ite.getCause() instanceof FacesException) {
+        pw.println(JSFTestUtil.PASS);
+
+      } else {
+        pw.println(JSFTestUtil.FE_MESS
+            + ite.getCause().getClass().getSimpleName() + JSFTestUtil.NL
+            + "When testing: " + className + "." + methName);
+        ite.getCause().printStackTrace();
+      }
+
+    } catch (NoSuchMethodException nsme) {
+      pw.println(JSFTestUtil.FE_MESS + nsme.getClass().getSimpleName()
+          + JSFTestUtil.NL);
+
+      JSFTestUtil.printMethods(className, methods, params, pw);
+
+    } catch (Throwable t) {
+      pw.println(JSFTestUtil.FE_MESS + t.getClass().getSimpleName()
+          + JSFTestUtil.NL + "When testing: " + className + "." + methName);
+      t.printStackTrace();
     }
+  } // End checkForFE
 
-    /**
-     * <p>
-     * Returns the elements of the {@link Enumeration} as an array of S trings.
-     * </p>
-     * 
-     * @param e an Enumeration
-     * @return the contexts of the Enumeration as an array of Strings
-     */
-    public static String[] getAsStringArray(Enumeration<?> e) {
-        List<Object> list = new ArrayList<Object>();
-        while (e.hasMoreElements()) {
-            list.add(e.nextElement());
-        }
-        return list.toArray(new String[list.size()]);
+  /**
+   * Checks to see if a IllegalStateException is thrown from a given method.
+   * 
+   * @param object
+   *          - The Object you want to test.
+   * @param methName
+   *          - The method that you want to test.
+   * @param argTypes
+   *          - The type value of the arguments for the method under test.
+   * @param params
+   *          - The parameters you are feeding into the method under test.
+   * @param pw
+   *          - The PrintWrite that you want the results written to.
+   */
+  public static void checkForISE(Object object, String methName,
+      Class<?>[] argTypes, Object[] params, PrintWriter pw) {
+    String className = object.getClass().getName();
+    Method[] methods = null;
+
+    try {
+      methods = object.getClass().getMethods();
+      Method execMeth = object.getClass().getMethod(methName, argTypes);
+      execMeth.invoke(object, params);
+
+      pw.println(JSFTestUtil.FAIL + " No Exception thrown!" + JSFTestUtil.NL
+          + "Expected a IllegalStateException " + "to be thrown "
+          + JSFTestUtil.NL + "when testing: " + className + "." + methName);
+
+    } catch (InvocationTargetException ite) {
+      if (ite.getCause() instanceof IllegalStateException) {
+        pw.println(JSFTestUtil.PASS);
+
+      } else {
+        pw.println(JSFTestUtil.ISE_MESS
+            + ite.getCause().getClass().getSimpleName() + JSFTestUtil.NL
+            + "When testing: " + className + "." + methName);
+        ite.getCause().printStackTrace();
+      }
+
+    } catch (NoSuchMethodException nsme) {
+      pw.println(JSFTestUtil.ISE_MESS + nsme.getClass().getSimpleName()
+          + JSFTestUtil.NL);
+
+      JSFTestUtil.printMethods(className, methods, params, pw);
+
+    } catch (Throwable t) {
+      pw.println(JSFTestUtil.ISE_MESS + t.getClass().getSimpleName()
+          + JSFTestUtil.NL + "When testing: " + className + "." + methName);
+      t.printStackTrace();
     }
+  } // End checkForFE
 
-    /**
-     * <p>
-     * Attempts to load the specified <code>className</code> using the current Thread's context class loader.
-     * </p>
-     * 
-     * @param className fully qualified class name
-     * @return the loaded Class or <code>null</code> if no Class could be found
-     */
-    public static Class<?> loadClass(String className) {
-        Class<?> c = null;
-        try {
-            c = Thread.currentThread().getContextClassLoader().loadClass(className);
-        } catch (Throwable t) {
-            debug("[JSFTestUtil] Exception occurred trying to get class: " + t.toString());
-            t.printStackTrace();
+  // ------------------------------------------------------ private methods
+
+  private static void printMethods(String className, Method[] methods,
+      Object[] params, PrintWriter pw) {
+    pw.println("Existing methods in the " + className + " Object Are: "
+        + JSFTestUtil.NL);
+
+    Class<?>[] parms = null;
+    for (int i = 0; i < methods.length; i++) {
+      parms = methods[i].getParameterTypes();
+
+      pw.print("Method: " + methods[i].getName() + "(");
+
+      int plength = parms.length;
+      for (int ii = 0; ii < plength; ii++) {
+        pw.print(parms[ii].getSimpleName());
+
+        if ((ii + 1) != plength) {
+          pw.print(", ");
         }
+      }
 
-        return c;
+      parms = null;
+      pw.print(")");
+      pw.print(JSFTestUtil.NL);
     }
-
-    /**
-     * <p>
-     * Returns the ordinal value of a {@link FacesMessage.Severity} Object as a String value.
-     * </p>
-     * <ul>
-     * <li>FacesMessage.SEVERITY_INFO returns SEVERITY_INFO</li>
-     * <li>FacesMessage.SEVERITY_ERROR returns SEVERITY_ERROR</li>
-     * <li>FacesMessage.SEVERITY_FATAL returns SEVERITY_FATAL</li>
-     * <li>FacesMessage.SEVERITY_WARN returns SEVERITY_WARN</li>
-     * </ul>
-     * 
-     * @param severity the ordinal value of a FacesMessage.Severity Object
-     * @return The String equivalent of the passed value.
-     */
-    public static String getSeverityAsString(int severity) {
-        if (severity == FacesMessage.SEVERITY_INFO.getOrdinal())
-            return "SEVERITY_INFO";
-        else if (severity == FacesMessage.SEVERITY_ERROR.getOrdinal())
-            return "SEVERITY_ERROR";
-        else if (severity == FacesMessage.SEVERITY_FATAL.getOrdinal())
-            return "SEVERITY_FATAL";
-        else if (severity == FacesMessage.SEVERITY_WARN.getOrdinal())
-            return "SEVERITY_WARN";
-        else
-            return "UNKNOWN_SEVERITY";
-    }
-
-    /**
-     * <p>
-     * Return a <code>String</code> representation of the <code>PhaseId</code> ordinal.
-     * </p>
-     */
-    public static String getPhaseIdAsString(PhaseId phaseId) {
-        int ordinal = phaseId.getOrdinal();
-        if (ordinal == PhaseId.ANY_PHASE.getOrdinal())
-            return "ANY_PHASE";
-        else if (ordinal == PhaseId.APPLY_REQUEST_VALUES.getOrdinal())
-            return "APPLY_REQUEST_VALUES";
-        else if (ordinal == PhaseId.INVOKE_APPLICATION.getOrdinal())
-            return "INVOKE_APPLICATION";
-        else if (ordinal == PhaseId.PROCESS_VALIDATIONS.getOrdinal())
-            return "PROCESS_VALIDATIONS";
-        else if (ordinal == PhaseId.RENDER_RESPONSE.getOrdinal())
-            return "RENDER_RESPONSE";
-        else if (ordinal == PhaseId.RESTORE_VIEW.getOrdinal())
-            return "RESTORE_VIEW";
-        else if (ordinal == PhaseId.UPDATE_MODEL_VALUES.getOrdinal())
-            return "UPDATE_MODEL_VALUES";
-        else
-            return "UNKNOWN_PHASE";
-    }
-
-    /**
-     * <p>
-     * Convenience method to obtain an EL <code>ExpressionFactory</code>.
-     * </p>
-     */
-    public static ExpressionFactory getExpressionFactory(ServletContext ctx) {
-
-        return ELManager.getExpressionFactory();
-
-    } // END getExpressionFactory
-
-    /**
-     * Checks to see if a NullPointerException is thrown from a given method(methName) from a given Class(className). use
-     * this method for any none Abstract classes you wish to test.
-     * 
-     * @param className - The Class that has the method under test.
-     * @param methName - The method that you want to test.
-     * @param argTypes - The type value of the arguments for the method under test.
-     * @param params - The parameters you are feeding into the method under test.
-     * @param pw - The PrintWrite that you want the results written to.
-     */
-    public static void checkForNPE(String className, String methName, Class<?>[] argTypes, Object[] params, PrintWriter pw) {
-
-        try {
-            JSFTestUtil.checkForNPE(Class.forName(className), methName, argTypes, params, pw);
-
-        } catch (ClassNotFoundException cnfe) {
-            pw.println(JSFTestUtil.FAIL + JSFTestUtil.NL);
-            cnfe.printStackTrace();
-        }
-
-    } // End checkForNPE
-
-    /**
-     * Checks to see if a NullPointerException is thrown from a given method(methName) from a given Class. use this method
-     * for any Abstract classes you wish to test. You can pass in the instantiated class that you want to test.
-     * 
-     * @param Class - The class you want to test.
-     * @param methName - The method that you want to test.
-     * @param argTypes - The type value of the arguments for the method under test.
-     * @param params - The parameters you are feeding into the method under test.
-     * @param pw - The PrintWrite that you want the results written to.
-     */
-    public static void checkForNPE(Class<?> clazz, String methName, Class<?>[] argTypes, Object[] params, PrintWriter pw) {
-
-        try {
-            JSFTestUtil.checkForNPE(clazz.newInstance(), methName, argTypes, params, pw);
-
-        } catch (Exception e) {
-            pw.println(JSFTestUtil.FAIL + JSFTestUtil.NL);
-            e.printStackTrace();
-        }
-
-    } // End checkForNPE
-
-    /**
-     * Checks to see if a NullPointerException is thrown from a given method(methName) from a given Class. use this method
-     * for any Abstract classes you wish to test. You can pass in the instantiated class that you want to test.
-     * 
-     * @param object - The Object you want to test.
-     * @param methName - The method that you want to test.
-     * @param argTypes - The type value of the arguments for the method under test.
-     * @param params - The parameters you are feeding into the method under test.
-     * @param pw - The PrintWrite that you want the results written to.
-     */
-    public static void checkForNPE(Object object, String methName, Class<?>[] argTypes, Object[] params, PrintWriter pw) {
-        String className = object.getClass().getName();
-        Method[] methods = null;
-
-        try {
-            methods = object.getClass().getMethods();
-            Method execMeth = object.getClass().getMethod(methName, argTypes);
-            execMeth.invoke(object, params);
-
-            pw.println(JSFTestUtil.FAIL + " No Exception thrown!" + JSFTestUtil.NL + "Expected a NullPointerException " + "to be thrown "
-                    + JSFTestUtil.NL + "when testing: " + className + "." + methName);
-
-        } catch (InvocationTargetException ite) {
-            if (ite.getCause() instanceof NullPointerException) {
-                pw.println(JSFTestUtil.PASS);
-
-            } else {
-                pw.println(JSFTestUtil.NPE_MESS + ite.getCause().getClass().getSimpleName() + JSFTestUtil.NL + "When testing: " + className
-                        + "." + methName);
-                ite.getCause().printStackTrace();
-            }
-
-        } catch (NoSuchMethodException nsme) {
-            pw.println(JSFTestUtil.NPE_MESS + nsme.getClass().getSimpleName() + JSFTestUtil.NL);
-
-            JSFTestUtil.printMethods(className, methods, params, pw);
-
-        } catch (Throwable t) {
-            pw.println(
-                    JSFTestUtil.NPE_MESS + t.getClass().getSimpleName() + JSFTestUtil.NL + "When testing: " + className + "." + methName);
-            t.printStackTrace();
-        }
-    } // End checkForNPE
-
-    /**
-     * Checks to see if a FacesException is thrown from a given method.
-     * 
-     * @param object - The Object you want to test.
-     * @param methName - The method that you want to test.
-     * @param argTypes - The type value of the arguments for the method under test.
-     * @param params - The parameters you are feeding into the method under test.
-     * @param pw - The PrintWrite that you want the results written to.
-     */
-    public static void checkForFE(Object object, String methName, Class<?>[] argTypes, Object[] params, PrintWriter pw) {
-        String className = object.getClass().getName();
-        Method[] methods = null;
-
-        try {
-            methods = object.getClass().getMethods();
-            Method execMeth = object.getClass().getMethod(methName, argTypes);
-            execMeth.invoke(object, params);
-
-            pw.println(JSFTestUtil.FAIL + " No Exception thrown!" + JSFTestUtil.NL + "Expected a FacesException " + "to be thrown "
-                    + JSFTestUtil.NL + "when testing: " + className + "." + methName);
-
-        } catch (InvocationTargetException ite) {
-            if (ite.getCause() instanceof FacesException) {
-                pw.println(JSFTestUtil.PASS);
-
-            } else {
-                pw.println(JSFTestUtil.FE_MESS + ite.getCause().getClass().getSimpleName() + JSFTestUtil.NL + "When testing: " + className
-                        + "." + methName);
-                ite.getCause().printStackTrace();
-            }
-
-        } catch (NoSuchMethodException nsme) {
-            pw.println(JSFTestUtil.FE_MESS + nsme.getClass().getSimpleName() + JSFTestUtil.NL);
-
-            JSFTestUtil.printMethods(className, methods, params, pw);
-
-        } catch (Throwable t) {
-            pw.println(JSFTestUtil.FE_MESS + t.getClass().getSimpleName() + JSFTestUtil.NL + "When testing: " + className + "." + methName);
-            t.printStackTrace();
-        }
-    } // End checkForFE
-
-    /**
-     * Checks to see if a IllegalStateException is thrown from a given method.
-     * 
-     * @param object - The Object you want to test.
-     * @param methName - The method that you want to test.
-     * @param argTypes - The type value of the arguments for the method under test.
-     * @param params - The parameters you are feeding into the method under test.
-     * @param pw - The PrintWrite that you want the results written to.
-     */
-    public static void checkForISE(Object object, String methName, Class<?>[] argTypes, Object[] params, PrintWriter pw) {
-        String className = object.getClass().getName();
-        Method[] methods = null;
-
-        try {
-            methods = object.getClass().getMethods();
-            Method execMeth = object.getClass().getMethod(methName, argTypes);
-            execMeth.invoke(object, params);
-
-            pw.println(JSFTestUtil.FAIL + 
-                " No Exception thrown!" + JSFTestUtil.NL + 
-                "Expected a IllegalStateException " + "to be thrown " + JSFTestUtil.NL + 
-                "When testing: " + className + "." + methName);
-
-        } catch (InvocationTargetException ite) {
-            if (ite.getCause() instanceof IllegalStateException) {
-                pw.println(JSFTestUtil.PASS);
-
-            } else {
-                pw.println(JSFTestUtil.ISE_MESS + 
-                    ite.getCause().getClass().getSimpleName() + JSFTestUtil.NL + 
-                    "When testing: " + className + "." + methName);
-                
-                ite.getCause().printStackTrace();
-            }
-
-        } catch (NoSuchMethodException nsme) {
-            pw.println(JSFTestUtil.ISE_MESS + 
-                nsme.getClass().getSimpleName() + JSFTestUtil.NL + 
-                "When testing: " + className + "." + methName);
-
-            JSFTestUtil.printMethods(className, methods, params, pw);
-
-        } catch (Throwable t) {
-            pw.println(JSFTestUtil.ISE_MESS + 
-                t.getClass().getSimpleName() + JSFTestUtil.NL + 
-                "When testing: " + className + "." + methName);
-            
-            t.printStackTrace();
-        }
-    } // End checkForFE
-
-    // ------------------------------------------------------ private methods
-
-    private static void printMethods(String className, Method[] methods, Object[] params, PrintWriter pw) {
-        pw.println("Existing methods in the " + className + " Object Are: " + JSFTestUtil.NL);
-
-        Class<?>[] parms = null;
-        for (int i = 0; i < methods.length; i++) {
-            parms = methods[i].getParameterTypes();
-
-            pw.print("Method: " + methods[i].getName() + "(");
-
-            int plength = parms.length;
-            for (int ii = 0; ii < plength; ii++) {
-                pw.print(parms[ii].getSimpleName());
-
-                if ((ii + 1) != plength) {
-                    pw.print(", ");
-                }
-            }
-
-            parms = null;
-            pw.print(")");
-            pw.print(JSFTestUtil.NL);
-        }
-    }
+  }
 
 }

--- a/tck/old-tck/source/src/com/sun/ts/tests/jsf/common/util/JSFTestUtil.java
+++ b/tck/old-tck/source/src/com/sun/ts/tests/jsf/common/util/JSFTestUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Contributors to Eclipse Foundation.
+ * Copyright (c) 2022, 2024 Contributors to Eclipse Foundation.
  * Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -42,596 +42,526 @@ import jakarta.servlet.ServletContext;
 
 public final class JSFTestUtil {
 
-  public static final boolean DEBUG = true;
+    public static final boolean DEBUG = true;
 
-  public static final String NL = System.getProperty("line.separator", "\n");
+    public static final String NL = System.getProperty("line.separator", "\n");
 
-  public static final String PASS = "Test PASSED";
+    public static final String PASS = "Test PASSED";
 
-  public static final String FAIL = "Test FAILED";
+    public static final String FAIL = "Test FAILED";
 
-  public static final String NPE_MESS = FAIL + " Unexpected Exception Thrown!"
-      + NL + "Expected: NullPointerException" + NL + "Received: ";
+    public static final String NPE_MESS = FAIL + " Unexpected Exception Thrown!" + NL + 
+            "Expected: NullPointerException" + NL + 
+            "Received: ";
 
-  public static final String FE_MESS = FAIL + " Unexpected Exception Thrown!"
-      + NL + "Expected: FacesException" + NL + "Received: ";
+    public static final String FE_MESS = FAIL + " Unexpected Exception Thrown!" + NL + 
+            "Expected: FacesException" + NL + 
+            "Received: ";
 
-  public static final String ISE_MESS = FAIL + " Unexpected Exception Thrown!"
-      + NL + "Expected: IllegalStateException" + NL + "Received: ";
+    public static final String ISE_MESS = FAIL + " Unexpected Exception Thrown!" + NL + 
+            "Expected: IllegalStateException" + NL + 
+            "Received: ";
 
-  public static final String APE_MESS = FAIL + " Unexpected Exception Thrown!"
-      + NL + "Expected: AbortProcessingException" + NL + "Received: ";
+    public static final String APE_MESS = FAIL + " Unexpected Exception Thrown!" + NL + 
+            "Expected: AbortProcessingException" + NL + 
+            "Received: ";
 
-  public static final String APP_NULL_MSG = FAIL + " :Unable to obtain "
-      + "Application instance.";
+    public static final String APP_NULL_MSG = FAIL + " :Unable to obtain " + "Application instance.";
 
-  public static final String RESHANDLER_NULL_MSG = FAIL + NL
-      + "Unable to obtain ResourceHandler instance.";
+    public static final String RESHANDLER_NULL_MSG = FAIL + NL + "Unable to obtain ResourceHandler instance.";
 
-  private JSFTestUtil() {
-    throw new IllegalStateException();
-  }
-
-  /**
-   * Writes the provided message to System.out when <tt>debug</tt> is set.
-   * 
-   * @param message
-   *          - the message to write to System.out
-   */
-  public static void debug(String message) {
-    if (DEBUG) {
-      System.out.println(message);
-    }
-  }
-
-  /**
-   * <p>
-   * Compares the String values in an Enumeration against the provided String
-   * array of values in a case sensitive manner.
-   * </p>
-   * 
-   * <p>
-   * This method will return <code>false</code> under the following
-   * circumstances:
-   * <ul>
-   * <li>The number of elements in the {@link Iterator} and the number of
-   * elements in the Array are not equal (only when the
-   * <code>enforceSizes</code> parameter is <code>true</code></li>
-   * <li>If the input {@link Iterator} or Array are null</li>
-   * <li>If duplicates are found in the {@link Iterator} and
-   * <code>allowDuplicates</code> is false</li>
-   * </ul>
-   * 
-   * <p>
-   * If none of the above occur, then <code>true<code> will be returned.
-   * </p>
-   * 
-   * @param i
-   *          - Iterator to validate
-   * @param values
-   *          - the values expected to be found in the Enumeration
-   * @param enforceSizes
-   *          - ensures that the number of elements in the Enumeration matches
-   *          the number of elements in the array of values
-   * @param allowDuplicates
-   *          - If true, the method will true if duplicate elements are found in
-   *          the Enumeration, if false, then false will be return if duplicate
-   *          elements have been found.
-   * 
-   * @return true if all the expected values are found, otherwise false.
-   */
-  public static boolean checkIterator(Iterator<?> i, String[] values,
-      boolean enforceSizes, boolean allowDuplicates) {
-    List<Object> foundValues = null;
-
-    if (i == null || !i.hasNext() || values == null) {
-      return false;
+    private JSFTestUtil() {
+        throw new IllegalStateException();
     }
 
-    if (!allowDuplicates) {
-      foundValues = new ArrayList<Object>();
+    /**
+     * Writes the provided message to System.out when <tt>debug</tt> is set.
+     * 
+     * @param message - the message to write to System.out
+     */
+    public static void debug(String message) {
+        if (DEBUG) {
+            System.out.println(message);
+        }
     }
 
-    boolean valuesFound = true;
-    Arrays.sort(values);
-    int count = 0;
-    while (i.hasNext()) {
-      Object val;
-      try {
-        val = i.next();
-        count++;
+    /**
+     * <p>
+     * Compares the String values in an Enumeration against the provided String array of values in a case sensitive manner.
+     * </p>
+     * 
+     * <p>
+     * This method will return <code>false</code> under the following circumstances:
+     * <ul>
+     * <li>The number of elements in the {@link Iterator} and the number of elements in the Array are not equal (only when
+     * the <code>enforceSizes</code> parameter is <code>true</code></li>
+     * <li>If the input {@link Iterator} or Array are null</li>
+     * <li>If duplicates are found in the {@link Iterator} and <code>allowDuplicates</code> is false</li>
+     * </ul>
+     * 
+     * <p>
+     * If none of the above occur, then <code>true<code> will be returned.
+     * </p>
+     * 
+     * @param i - Iterator to validate
+     * @param values - the values expected to be found in the Enumeration
+     * @param enforceSizes - ensures that the number of elements in the Enumeration matches the number of elements in the
+     * array of values
+     * @param allowDuplicates - If true, the method will true if duplicate elements are found in the Enumeration, if false,
+     * then false will be return if duplicate elements have been found.
+     * 
+     * @return true if all the expected values are found, otherwise false.
+     */
+    public static boolean checkIterator(Iterator<?> i, String[] values, boolean enforceSizes, boolean allowDuplicates) {
+        List<Object> foundValues = null;
+
+        if (i == null || !i.hasNext() || values == null) {
+            return false;
+        }
+
         if (!allowDuplicates) {
-          if (foundValues.contains(val)) {
-            debug("[JSFTestUtil] Duplicate values found in "
-                + "Iterator when duplicates are not allowed."
-                + "Values found in the Iterator: " + getAsString(i));
-            valuesFound = false;
-            break;
-          }
-          foundValues.add(val);
+            foundValues = new ArrayList<Object>();
         }
 
-      } catch (NoSuchElementException nsee) {
-        debug("[JSFTestUtil] There were less elements in the "
-            + "Iterator than expected");
-        valuesFound = false;
-        break;
-      }
-      debug("[JSFTestUtil] Looking for '" + val + "' in values: "
-          + getAsString(values));
-      if ((Arrays.binarySearch(values, val) < 0) && (enforceSizes)) {
-        debug("[JSFTestUtil] Value '" + val + "' not found.");
-        valuesFound = false;
-      }
-    }
+        boolean valuesFound = true;
+        Arrays.sort(values);
+        int count = 0;
+        while (i.hasNext()) {
+            Object val;
+            try {
+                val = i.next();
+                count++;
+                if (!allowDuplicates) {
+                    if (foundValues.contains(val)) {
+                        debug("[JSFTestUtil] Duplicate values found in " + "Iterator when duplicates are not allowed."
+                                + "Values found in the Iterator: " + getAsString(i));
+                        valuesFound = false;
+                        break;
+                    }
+                    foundValues.add(val);
+                }
 
-    if (enforceSizes) {
-      if (i.hasNext()) {
-        // more elements than should have been.
-        debug("[JSFTestUtil] There were more elements in the Iterator "
-            + "than expected.");
-        valuesFound = false;
-      }
-      if (count != values.length) {
-        debug("[JSFTestUtil] There number of elements in the Iterator "
-            + "did not match number of expected values."
-            + "Expected number of Values=" + values.length
-            + ", Actual number of Iterator elements=" + count);
-
-        valuesFound = false;
-      }
-    }
-    return valuesFound;
-  }
-
-  /**
-   * <p>
-   * Returns the elements of the provided {@link Iterator} as a String in the
-   * following format: <code>[n1,n2,n...]</code>.
-   * </p>
-   * 
-   * @param i
-   *          - an Iterator
-   * 
-   * @return - a printable version of the contents of the Iterator
-   */
-  public static String getAsString(Iterator<?> i) {
-    return getAsString(getAsArray(i));
-  }
-
-  /**
-   * <p>
-   * Returns the elements contained in the String array in the following format:
-   * <code>[n1,n2,n...]</code>.
-   * </p>
-   * 
-   * @param sArray
-   *          - an array of Objects
-   * @return - a String based off the values in the array
-   */
-  public static String getAsString(Object[] sArray) {
-    if (sArray == null) {
-      return null;
-    }
-    StringBuffer buf = new StringBuffer();
-    buf.append("[");
-    for (int i = 0; i < sArray.length; i++) {
-      buf.append(sArray[i].toString());
-      if ((i + 1) != sArray.length) {
-        buf.append(",");
-      }
-    }
-    buf.append("]");
-    return buf.toString();
-  }
-
-  /**
-   * <p>
-   * Returns a String representation of the {@link Map} provided.
-   * </p>
-   * 
-   * @param map
-   *          input map
-   * @return String representation of the Map
-   */
-  public static String getAsString(Map<String, Object> map) {
-    StringBuffer sb = new StringBuffer(32);
-    Set<Map.Entry<String, Object>> entrySet = map.entrySet();
-    sb.append("Map Entries\n----------------\n");
-    for (Map.Entry<String, Object> entry : entrySet) {
-      sb.append(entry.getKey()).append(", ").append(entry.getValue());
-      sb.append('\n');
-    }
-    sb.append('\n');
-    return sb.toString();
-  }
-
-  /**
-   * <p>
-   * Returns the elements within the provided {@link Iterator} as an Array.
-   * </p>
-   * 
-   * @param i
-   *          - an Iterator
-   * @return - the elements of the Iterator as an array of Objects
-   */
-  public static Object[] getAsArray(Iterator<?> i) {
-    List<Object> list = new ArrayList<Object>();
-    while (i.hasNext()) {
-      list.add(i.next());
-    }
-    return list.toArray(new Object[list.size()]);
-  }
-
-  /**
-   * <p>
-   * Returns the elements of the passed {@link Iterator} as an array of Strings.
-   * </p>
-   * 
-   * @param i
-   *          an Iterator
-   * @return the contents of the Iterator as an array of Strings
-   */
-  public static String[] getAsStringArray(Iterator<String> i) {
-    List<String> list = new ArrayList<String>();
-    while (i.hasNext()) {
-      list.add(i.next());
-    }
-    return list.toArray(new String[list.size()]);
-  }
-
-  /**
-   * <p>
-   * Returns the elements of the {@link Enumeration} as an array of S trings.
-   * </p>
-   * 
-   * @param e
-   *          an Enumeration
-   * @return the contexts of the Enumeration as an array of Strings
-   */
-  public static String[] getAsStringArray(Enumeration<?> e) {
-    List<Object> list = new ArrayList<Object>();
-    while (e.hasMoreElements()) {
-      list.add(e.nextElement());
-    }
-    return list.toArray(new String[list.size()]);
-  }
-
-  /**
-   * <p>
-   * Attempts to load the specified <code>className</code> using the current
-   * Thread's context class loader.
-   * </p>
-   * 
-   * @param className
-   *          fully qualified class name
-   * @return the loaded Class or <code>null</code> if no Class could be found
-   */
-  public static Class<?> loadClass(String className) {
-    Class<?> c = null;
-    try {
-      c = Thread.currentThread().getContextClassLoader().loadClass(className);
-    } catch (Throwable t) {
-      debug("[JSFTestUtil] Exception occurred trying to get class: "
-          + t.toString());
-      t.printStackTrace();
-    }
-
-    return c;
-  }
-
-  /**
-   * <p>
-   * Returns the ordinal value of a {@link FacesMessage.Severity} Object as a
-   * String value.
-   * </p>
-   * <ul>
-   * <li>FacesMessage.SEVERITY_INFO returns SEVERITY_INFO</li>
-   * <li>FacesMessage.SEVERITY_ERROR returns SEVERITY_ERROR</li>
-   * <li>FacesMessage.SEVERITY_FATAL returns SEVERITY_FATAL</li>
-   * <li>FacesMessage.SEVERITY_WARN returns SEVERITY_WARN</li>
-   * </ul>
-   * 
-   * @param severity
-   *          the ordinal value of a FacesMessage.Severity Object
-   * @return The String equivalent of the passed value.
-   */
-  public static String getSeverityAsString(int severity) {
-    if (severity == FacesMessage.SEVERITY_INFO.getOrdinal())
-      return "SEVERITY_INFO";
-    else if (severity == FacesMessage.SEVERITY_ERROR.getOrdinal())
-      return "SEVERITY_ERROR";
-    else if (severity == FacesMessage.SEVERITY_FATAL.getOrdinal())
-      return "SEVERITY_FATAL";
-    else if (severity == FacesMessage.SEVERITY_WARN.getOrdinal())
-      return "SEVERITY_WARN";
-    else
-      return "UNKNOWN_SEVERITY";
-  }
-
-  /**
-   * <p>
-   * Return a <code>String</code> representation of the <code>PhaseId</code>
-   * ordinal.
-   * </p>
-   */
-  public static String getPhaseIdAsString(PhaseId phaseId) {
-    int ordinal = phaseId.getOrdinal();
-    if (ordinal == PhaseId.ANY_PHASE.getOrdinal())
-      return "ANY_PHASE";
-    else if (ordinal == PhaseId.APPLY_REQUEST_VALUES.getOrdinal())
-      return "APPLY_REQUEST_VALUES";
-    else if (ordinal == PhaseId.INVOKE_APPLICATION.getOrdinal())
-      return "INVOKE_APPLICATION";
-    else if (ordinal == PhaseId.PROCESS_VALIDATIONS.getOrdinal())
-      return "PROCESS_VALIDATIONS";
-    else if (ordinal == PhaseId.RENDER_RESPONSE.getOrdinal())
-      return "RENDER_RESPONSE";
-    else if (ordinal == PhaseId.RESTORE_VIEW.getOrdinal())
-      return "RESTORE_VIEW";
-    else if (ordinal == PhaseId.UPDATE_MODEL_VALUES.getOrdinal())
-      return "UPDATE_MODEL_VALUES";
-    else
-      return "UNKNOWN_PHASE";
-  }
-
-  /**
-   * <p>
-   * Convenience method to obtain an EL <code>ExpressionFactory</code>.
-   * </p>
-   */
-  public static ExpressionFactory getExpressionFactory(ServletContext ctx) {
-
-    return ELManager.getExpressionFactory();
-
-  } // END getExpressionFactory
-
-  /**
-   * Checks to see if a NullPointerException is thrown from a given
-   * method(methName) from a given Class(className). use this method for any
-   * none Abstract classes you wish to test.
-   * 
-   * @param className
-   *          - The Class that has the method under test.
-   * @param methName
-   *          - The method that you want to test.
-   * @param argTypes
-   *          - The type value of the arguments for the method under test.
-   * @param params
-   *          - The parameters you are feeding into the method under test.
-   * @param pw
-   *          - The PrintWrite that you want the results written to.
-   */
-  public static void checkForNPE(String className, String methName,
-      Class<?>[] argTypes, Object[] params, PrintWriter pw) {
-
-    try {
-      JSFTestUtil.checkForNPE(Class.forName(className), methName, argTypes,
-          params, pw);
-
-    } catch (ClassNotFoundException cnfe) {
-      pw.println(JSFTestUtil.FAIL + JSFTestUtil.NL);
-      cnfe.printStackTrace();
-    }
-
-  } // End checkForNPE
-
-  /**
-   * Checks to see if a NullPointerException is thrown from a given
-   * method(methName) from a given Class. use this method for any Abstract
-   * classes you wish to test. You can pass in the instantiated class that you
-   * want to test.
-   * 
-   * @param Class
-   *          - The class you want to test.
-   * @param methName
-   *          - The method that you want to test.
-   * @param argTypes
-   *          - The type value of the arguments for the method under test.
-   * @param params
-   *          - The parameters you are feeding into the method under test.
-   * @param pw
-   *          - The PrintWrite that you want the results written to.
-   */
-  public static void checkForNPE(Class<?> clazz, String methName,
-      Class<?>[] argTypes, Object[] params, PrintWriter pw) {
-
-    try {
-      JSFTestUtil.checkForNPE(clazz.newInstance(), methName, argTypes, params,
-          pw);
-
-    } catch (Exception e) {
-      pw.println(JSFTestUtil.FAIL + JSFTestUtil.NL);
-      e.printStackTrace();
-    }
-
-  } // End checkForNPE
-
-  /**
-   * Checks to see if a NullPointerException is thrown from a given
-   * method(methName) from a given Class. use this method for any Abstract
-   * classes you wish to test. You can pass in the instantiated class that you
-   * want to test.
-   * 
-   * @param object
-   *          - The Object you want to test.
-   * @param methName
-   *          - The method that you want to test.
-   * @param argTypes
-   *          - The type value of the arguments for the method under test.
-   * @param params
-   *          - The parameters you are feeding into the method under test.
-   * @param pw
-   *          - The PrintWrite that you want the results written to.
-   */
-  public static void checkForNPE(Object object, String methName,
-      Class<?>[] argTypes, Object[] params, PrintWriter pw) {
-    String className = object.getClass().getName();
-    Method[] methods = null;
-
-    try {
-      methods = object.getClass().getMethods();
-      Method execMeth = object.getClass().getMethod(methName, argTypes);
-      execMeth.invoke(object, params);
-
-      pw.println(JSFTestUtil.FAIL + " No Exception thrown!" + JSFTestUtil.NL
-          + "Expected a NullPointerException " + "to be thrown "
-          + JSFTestUtil.NL + "when testing: " + className + "." + methName);
-
-    } catch (InvocationTargetException ite) {
-      if (ite.getCause() instanceof NullPointerException) {
-        pw.println(JSFTestUtil.PASS);
-
-      } else {
-        pw.println(JSFTestUtil.NPE_MESS
-            + ite.getCause().getClass().getSimpleName() + JSFTestUtil.NL
-            + "When testing: " + className + "." + methName);
-        ite.getCause().printStackTrace();
-      }
-
-    } catch (NoSuchMethodException nsme) {
-      pw.println(JSFTestUtil.NPE_MESS + nsme.getClass().getSimpleName()
-          + JSFTestUtil.NL);
-
-      JSFTestUtil.printMethods(className, methods, params, pw);
-
-    } catch (Throwable t) {
-      pw.println(JSFTestUtil.NPE_MESS + t.getClass().getSimpleName()
-          + JSFTestUtil.NL + "When testing: " + className + "." + methName);
-      t.printStackTrace();
-    }
-  } // End checkForNPE
-
-  /**
-   * Checks to see if a FacesException is thrown from a given method.
-   * 
-   * @param object
-   *          - The Object you want to test.
-   * @param methName
-   *          - The method that you want to test.
-   * @param argTypes
-   *          - The type value of the arguments for the method under test.
-   * @param params
-   *          - The parameters you are feeding into the method under test.
-   * @param pw
-   *          - The PrintWrite that you want the results written to.
-   */
-  public static void checkForFE(Object object, String methName,
-      Class<?>[] argTypes, Object[] params, PrintWriter pw) {
-    String className = object.getClass().getName();
-    Method[] methods = null;
-
-    try {
-      methods = object.getClass().getMethods();
-      Method execMeth = object.getClass().getMethod(methName, argTypes);
-      execMeth.invoke(object, params);
-
-      pw.println(JSFTestUtil.FAIL + " No Exception thrown!" + JSFTestUtil.NL
-          + "Expected a FacesException " + "to be thrown " + JSFTestUtil.NL
-          + "when testing: " + className + "." + methName);
-
-    } catch (InvocationTargetException ite) {
-      if (ite.getCause() instanceof FacesException) {
-        pw.println(JSFTestUtil.PASS);
-
-      } else {
-        pw.println(JSFTestUtil.FE_MESS
-            + ite.getCause().getClass().getSimpleName() + JSFTestUtil.NL
-            + "When testing: " + className + "." + methName);
-        ite.getCause().printStackTrace();
-      }
-
-    } catch (NoSuchMethodException nsme) {
-      pw.println(JSFTestUtil.FE_MESS + nsme.getClass().getSimpleName()
-          + JSFTestUtil.NL);
-
-      JSFTestUtil.printMethods(className, methods, params, pw);
-
-    } catch (Throwable t) {
-      pw.println(JSFTestUtil.FE_MESS + t.getClass().getSimpleName()
-          + JSFTestUtil.NL + "When testing: " + className + "." + methName);
-      t.printStackTrace();
-    }
-  } // End checkForFE
-
-  /**
-   * Checks to see if a IllegalStateException is thrown from a given method.
-   * 
-   * @param object
-   *          - The Object you want to test.
-   * @param methName
-   *          - The method that you want to test.
-   * @param argTypes
-   *          - The type value of the arguments for the method under test.
-   * @param params
-   *          - The parameters you are feeding into the method under test.
-   * @param pw
-   *          - The PrintWrite that you want the results written to.
-   */
-  public static void checkForISE(Object object, String methName,
-      Class<?>[] argTypes, Object[] params, PrintWriter pw) {
-    String className = object.getClass().getName();
-    Method[] methods = null;
-
-    try {
-      methods = object.getClass().getMethods();
-      Method execMeth = object.getClass().getMethod(methName, argTypes);
-      execMeth.invoke(object, params);
-
-      pw.println(JSFTestUtil.FAIL + " No Exception thrown!" + JSFTestUtil.NL
-          + "Expected a IllegalStateException " + "to be thrown "
-          + JSFTestUtil.NL + "when testing: " + className + "." + methName);
-
-    } catch (InvocationTargetException ite) {
-      if (ite.getCause() instanceof IllegalStateException) {
-        pw.println(JSFTestUtil.PASS);
-
-      } else {
-        pw.println(JSFTestUtil.ISE_MESS
-            + ite.getCause().getClass().getSimpleName() + JSFTestUtil.NL
-            + "When testing: " + className + "." + methName);
-        ite.getCause().printStackTrace();
-      }
-
-    } catch (NoSuchMethodException nsme) {
-      pw.println(JSFTestUtil.ISE_MESS + nsme.getClass().getSimpleName()
-          + JSFTestUtil.NL);
-
-      JSFTestUtil.printMethods(className, methods, params, pw);
-
-    } catch (Throwable t) {
-      pw.println(JSFTestUtil.ISE_MESS + t.getClass().getSimpleName()
-          + JSFTestUtil.NL + "When testing: " + className + "." + methName);
-      t.printStackTrace();
-    }
-  } // End checkForFE
-
-  // ------------------------------------------------------ private methods
-
-  private static void printMethods(String className, Method[] methods,
-      Object[] params, PrintWriter pw) {
-    pw.println("Existing methods in the " + className + " Object Are: "
-        + JSFTestUtil.NL);
-
-    Class<?>[] parms = null;
-    for (int i = 0; i < methods.length; i++) {
-      parms = methods[i].getParameterTypes();
-
-      pw.print("Method: " + methods[i].getName() + "(");
-
-      int plength = parms.length;
-      for (int ii = 0; ii < plength; ii++) {
-        pw.print(parms[ii].getSimpleName());
-
-        if ((ii + 1) != plength) {
-          pw.print(", ");
+            } catch (NoSuchElementException nsee) {
+                debug("[JSFTestUtil] There were less elements in the " + "Iterator than expected");
+                valuesFound = false;
+                break;
+            }
+            debug("[JSFTestUtil] Looking for '" + val + "' in values: " + getAsString(values));
+            if ((Arrays.binarySearch(values, val) < 0) && (enforceSizes)) {
+                debug("[JSFTestUtil] Value '" + val + "' not found.");
+                valuesFound = false;
+            }
         }
-      }
 
-      parms = null;
-      pw.print(")");
-      pw.print(JSFTestUtil.NL);
+        if (enforceSizes) {
+            if (i.hasNext()) {
+                // more elements than should have been.
+                debug("[JSFTestUtil] There were more elements in the Iterator " + "than expected.");
+                valuesFound = false;
+            }
+            if (count != values.length) {
+                debug("[JSFTestUtil] There number of elements in the Iterator " + "did not match number of expected values."
+                        + "Expected number of Values=" + values.length + ", Actual number of Iterator elements=" + count);
+
+                valuesFound = false;
+            }
+        }
+        return valuesFound;
     }
-  }
+
+    /**
+     * <p>
+     * Returns the elements of the provided {@link Iterator} as a String in the following format: <code>[n1,n2,n...]</code>.
+     * </p>
+     * 
+     * @param i - an Iterator
+     * 
+     * @return - a printable version of the contents of the Iterator
+     */
+    public static String getAsString(Iterator<?> i) {
+        return getAsString(getAsArray(i));
+    }
+
+    /**
+     * <p>
+     * Returns the elements contained in the String array in the following format: <code>[n1,n2,n...]</code>.
+     * </p>
+     * 
+     * @param sArray - an array of Objects
+     * @return - a String based off the values in the array
+     */
+    public static String getAsString(Object[] sArray) {
+        if (sArray == null) {
+            return null;
+        }
+        StringBuffer buf = new StringBuffer();
+        buf.append("[");
+        for (int i = 0; i < sArray.length; i++) {
+            buf.append(sArray[i].toString());
+            if ((i + 1) != sArray.length) {
+                buf.append(",");
+            }
+        }
+        buf.append("]");
+        return buf.toString();
+    }
+
+    /**
+     * <p>
+     * Returns a String representation of the {@link Map} provided.
+     * </p>
+     * 
+     * @param map input map
+     * @return String representation of the Map
+     */
+    public static String getAsString(Map<String, Object> map) {
+        StringBuffer sb = new StringBuffer(32);
+        Set<Map.Entry<String, Object>> entrySet = map.entrySet();
+        sb.append("Map Entries\n----------------\n");
+        for (Map.Entry<String, Object> entry : entrySet) {
+            sb.append(entry.getKey()).append(", ").append(entry.getValue());
+            sb.append('\n');
+        }
+        sb.append('\n');
+        return sb.toString();
+    }
+
+    /**
+     * <p>
+     * Returns the elements within the provided {@link Iterator} as an Array.
+     * </p>
+     * 
+     * @param i - an Iterator
+     * @return - the elements of the Iterator as an array of Objects
+     */
+    public static Object[] getAsArray(Iterator<?> i) {
+        List<Object> list = new ArrayList<Object>();
+        while (i.hasNext()) {
+            list.add(i.next());
+        }
+        return list.toArray(new Object[list.size()]);
+    }
+
+    /**
+     * <p>
+     * Returns the elements of the passed {@link Iterator} as an array of Strings.
+     * </p>
+     * 
+     * @param i an Iterator
+     * @return the contents of the Iterator as an array of Strings
+     */
+    public static String[] getAsStringArray(Iterator<String> i) {
+        List<String> list = new ArrayList<String>();
+        while (i.hasNext()) {
+            list.add(i.next());
+        }
+        return list.toArray(new String[list.size()]);
+    }
+
+    /**
+     * <p>
+     * Returns the elements of the {@link Enumeration} as an array of S trings.
+     * </p>
+     * 
+     * @param e an Enumeration
+     * @return the contexts of the Enumeration as an array of Strings
+     */
+    public static String[] getAsStringArray(Enumeration<?> e) {
+        List<Object> list = new ArrayList<Object>();
+        while (e.hasMoreElements()) {
+            list.add(e.nextElement());
+        }
+        return list.toArray(new String[list.size()]);
+    }
+
+    /**
+     * <p>
+     * Attempts to load the specified <code>className</code> using the current Thread's context class loader.
+     * </p>
+     * 
+     * @param className fully qualified class name
+     * @return the loaded Class or <code>null</code> if no Class could be found
+     */
+    public static Class<?> loadClass(String className) {
+        Class<?> c = null;
+        try {
+            c = Thread.currentThread().getContextClassLoader().loadClass(className);
+        } catch (Throwable t) {
+            debug("[JSFTestUtil] Exception occurred trying to get class: " + t.toString());
+            t.printStackTrace();
+        }
+
+        return c;
+    }
+
+    /**
+     * <p>
+     * Returns the ordinal value of a {@link FacesMessage.Severity} Object as a String value.
+     * </p>
+     * <ul>
+     * <li>FacesMessage.SEVERITY_INFO returns SEVERITY_INFO</li>
+     * <li>FacesMessage.SEVERITY_ERROR returns SEVERITY_ERROR</li>
+     * <li>FacesMessage.SEVERITY_FATAL returns SEVERITY_FATAL</li>
+     * <li>FacesMessage.SEVERITY_WARN returns SEVERITY_WARN</li>
+     * </ul>
+     * 
+     * @param severity the ordinal value of a FacesMessage.Severity Object
+     * @return The String equivalent of the passed value.
+     */
+    public static String getSeverityAsString(int severity) {
+        if (severity == FacesMessage.SEVERITY_INFO.getOrdinal())
+            return "SEVERITY_INFO";
+        else if (severity == FacesMessage.SEVERITY_ERROR.getOrdinal())
+            return "SEVERITY_ERROR";
+        else if (severity == FacesMessage.SEVERITY_FATAL.getOrdinal())
+            return "SEVERITY_FATAL";
+        else if (severity == FacesMessage.SEVERITY_WARN.getOrdinal())
+            return "SEVERITY_WARN";
+        else
+            return "UNKNOWN_SEVERITY";
+    }
+
+    /**
+     * <p>
+     * Return a <code>String</code> representation of the <code>PhaseId</code> ordinal.
+     * </p>
+     */
+    public static String getPhaseIdAsString(PhaseId phaseId) {
+        int ordinal = phaseId.getOrdinal();
+        if (ordinal == PhaseId.ANY_PHASE.getOrdinal())
+            return "ANY_PHASE";
+        else if (ordinal == PhaseId.APPLY_REQUEST_VALUES.getOrdinal())
+            return "APPLY_REQUEST_VALUES";
+        else if (ordinal == PhaseId.INVOKE_APPLICATION.getOrdinal())
+            return "INVOKE_APPLICATION";
+        else if (ordinal == PhaseId.PROCESS_VALIDATIONS.getOrdinal())
+            return "PROCESS_VALIDATIONS";
+        else if (ordinal == PhaseId.RENDER_RESPONSE.getOrdinal())
+            return "RENDER_RESPONSE";
+        else if (ordinal == PhaseId.RESTORE_VIEW.getOrdinal())
+            return "RESTORE_VIEW";
+        else if (ordinal == PhaseId.UPDATE_MODEL_VALUES.getOrdinal())
+            return "UPDATE_MODEL_VALUES";
+        else
+            return "UNKNOWN_PHASE";
+    }
+
+    /**
+     * <p>
+     * Convenience method to obtain an EL <code>ExpressionFactory</code>.
+     * </p>
+     */
+    public static ExpressionFactory getExpressionFactory(ServletContext ctx) {
+
+        return ELManager.getExpressionFactory();
+
+    } // END getExpressionFactory
+
+    /**
+     * Checks to see if a NullPointerException is thrown from a given method(methName) from a given Class(className). use
+     * this method for any none Abstract classes you wish to test.
+     * 
+     * @param className - The Class that has the method under test.
+     * @param methName - The method that you want to test.
+     * @param argTypes - The type value of the arguments for the method under test.
+     * @param params - The parameters you are feeding into the method under test.
+     * @param pw - The PrintWrite that you want the results written to.
+     */
+    public static void checkForNPE(String className, String methName, Class<?>[] argTypes, Object[] params, PrintWriter pw) {
+
+        try {
+            JSFTestUtil.checkForNPE(Class.forName(className), methName, argTypes, params, pw);
+
+        } catch (ClassNotFoundException cnfe) {
+            pw.println(JSFTestUtil.FAIL + JSFTestUtil.NL);
+            cnfe.printStackTrace();
+        }
+
+    } // End checkForNPE
+
+    /**
+     * Checks to see if a NullPointerException is thrown from a given method(methName) from a given Class. use this method
+     * for any Abstract classes you wish to test. You can pass in the instantiated class that you want to test.
+     * 
+     * @param Class - The class you want to test.
+     * @param methName - The method that you want to test.
+     * @param argTypes - The type value of the arguments for the method under test.
+     * @param params - The parameters you are feeding into the method under test.
+     * @param pw - The PrintWrite that you want the results written to.
+     */
+    public static void checkForNPE(Class<?> clazz, String methName, Class<?>[] argTypes, Object[] params, PrintWriter pw) {
+
+        try {
+            JSFTestUtil.checkForNPE(clazz.newInstance(), methName, argTypes, params, pw);
+
+        } catch (Exception e) {
+            pw.println(JSFTestUtil.FAIL + JSFTestUtil.NL);
+            e.printStackTrace();
+        }
+
+    } // End checkForNPE
+
+    /**
+     * Checks to see if a NullPointerException is thrown from a given method(methName) from a given Class. use this method
+     * for any Abstract classes you wish to test. You can pass in the instantiated class that you want to test.
+     * 
+     * @param object - The Object you want to test.
+     * @param methName - The method that you want to test.
+     * @param argTypes - The type value of the arguments for the method under test.
+     * @param params - The parameters you are feeding into the method under test.
+     * @param pw - The PrintWrite that you want the results written to.
+     */
+    public static void checkForNPE(Object object, String methName, Class<?>[] argTypes, Object[] params, PrintWriter pw) {
+        String className = object.getClass().getName();
+        Method[] methods = null;
+
+        try {
+            methods = object.getClass().getMethods();
+            Method execMeth = object.getClass().getMethod(methName, argTypes);
+            execMeth.invoke(object, params);
+
+            pw.println(JSFTestUtil.FAIL + " No Exception thrown!" + JSFTestUtil.NL + "Expected a NullPointerException " + "to be thrown "
+                    + JSFTestUtil.NL + "when testing: " + className + "." + methName);
+
+        } catch (InvocationTargetException ite) {
+            if (ite.getCause() instanceof NullPointerException) {
+                pw.println(JSFTestUtil.PASS);
+
+            } else {
+                pw.println(JSFTestUtil.NPE_MESS + ite.getCause().getClass().getSimpleName() + JSFTestUtil.NL + "When testing: " + className
+                        + "." + methName);
+                ite.getCause().printStackTrace();
+            }
+
+        } catch (NoSuchMethodException nsme) {
+            pw.println(JSFTestUtil.NPE_MESS + nsme.getClass().getSimpleName() + JSFTestUtil.NL);
+
+            JSFTestUtil.printMethods(className, methods, params, pw);
+
+        } catch (Throwable t) {
+            pw.println(
+                    JSFTestUtil.NPE_MESS + t.getClass().getSimpleName() + JSFTestUtil.NL + "When testing: " + className + "." + methName);
+            t.printStackTrace();
+        }
+    } // End checkForNPE
+
+    /**
+     * Checks to see if a FacesException is thrown from a given method.
+     * 
+     * @param object - The Object you want to test.
+     * @param methName - The method that you want to test.
+     * @param argTypes - The type value of the arguments for the method under test.
+     * @param params - The parameters you are feeding into the method under test.
+     * @param pw - The PrintWrite that you want the results written to.
+     */
+    public static void checkForFE(Object object, String methName, Class<?>[] argTypes, Object[] params, PrintWriter pw) {
+        String className = object.getClass().getName();
+        Method[] methods = null;
+
+        try {
+            methods = object.getClass().getMethods();
+            Method execMeth = object.getClass().getMethod(methName, argTypes);
+            execMeth.invoke(object, params);
+
+            pw.println(JSFTestUtil.FAIL + " No Exception thrown!" + JSFTestUtil.NL + "Expected a FacesException " + "to be thrown "
+                    + JSFTestUtil.NL + "when testing: " + className + "." + methName);
+
+        } catch (InvocationTargetException ite) {
+            if (ite.getCause() instanceof FacesException) {
+                pw.println(JSFTestUtil.PASS);
+
+            } else {
+                pw.println(JSFTestUtil.FE_MESS + ite.getCause().getClass().getSimpleName() + JSFTestUtil.NL + "When testing: " + className
+                        + "." + methName);
+                ite.getCause().printStackTrace();
+            }
+
+        } catch (NoSuchMethodException nsme) {
+            pw.println(JSFTestUtil.FE_MESS + nsme.getClass().getSimpleName() + JSFTestUtil.NL);
+
+            JSFTestUtil.printMethods(className, methods, params, pw);
+
+        } catch (Throwable t) {
+            pw.println(JSFTestUtil.FE_MESS + t.getClass().getSimpleName() + JSFTestUtil.NL + "When testing: " + className + "." + methName);
+            t.printStackTrace();
+        }
+    } // End checkForFE
+
+    /**
+     * Checks to see if a IllegalStateException is thrown from a given method.
+     * 
+     * @param object - The Object you want to test.
+     * @param methName - The method that you want to test.
+     * @param argTypes - The type value of the arguments for the method under test.
+     * @param params - The parameters you are feeding into the method under test.
+     * @param pw - The PrintWrite that you want the results written to.
+     */
+    public static void checkForISE(Object object, String methName, Class<?>[] argTypes, Object[] params, PrintWriter pw) {
+        String className = object.getClass().getName();
+        Method[] methods = null;
+
+        try {
+            methods = object.getClass().getMethods();
+            Method execMeth = object.getClass().getMethod(methName, argTypes);
+            execMeth.invoke(object, params);
+
+            pw.println(JSFTestUtil.FAIL + 
+                " No Exception thrown!" + JSFTestUtil.NL + 
+                "Expected a IllegalStateException " + "to be thrown " + JSFTestUtil.NL + 
+                "When testing: " + className + "." + methName);
+
+        } catch (InvocationTargetException ite) {
+            if (ite.getCause() instanceof IllegalStateException) {
+                pw.println(JSFTestUtil.PASS);
+
+            } else {
+                pw.println(JSFTestUtil.ISE_MESS + 
+                    ite.getCause().getClass().getSimpleName() + JSFTestUtil.NL + 
+                    "When testing: " + className + "." + methName);
+                
+                ite.getCause().printStackTrace();
+            }
+
+        } catch (NoSuchMethodException nsme) {
+            pw.println(JSFTestUtil.ISE_MESS + 
+                nsme.getClass().getSimpleName() + JSFTestUtil.NL + 
+                "When testing: " + className + "." + methName);
+
+            JSFTestUtil.printMethods(className, methods, params, pw);
+
+        } catch (Throwable t) {
+            pw.println(JSFTestUtil.ISE_MESS + 
+                t.getClass().getSimpleName() + JSFTestUtil.NL + 
+                "When testing: " + className + "." + methName);
+            
+            t.printStackTrace();
+        }
+    } // End checkForFE
+
+    // ------------------------------------------------------ private methods
+
+    private static void printMethods(String className, Method[] methods, Object[] params, PrintWriter pw) {
+        pw.println("Existing methods in the " + className + " Object Are: " + JSFTestUtil.NL);
+
+        Class<?>[] parms = null;
+        for (int i = 0; i < methods.length; i++) {
+            parms = methods[i].getParameterTypes();
+
+            pw.print("Method: " + methods[i].getName() + "(");
+
+            int plength = parms.length;
+            for (int ii = 0; ii < plength; ii++) {
+                pw.print(parms[ii].getSimpleName());
+
+                if ((ii + 1) != plength) {
+                    pw.print(", ");
+                }
+            }
+
+            parms = null;
+            pw.print(")");
+            pw.print(JSFTestUtil.NL);
+        }
+    }
 
 }


### PR DESCRIPTION
Using:

```java
if (!isExcluded(name, exMethods) && !name.startsWith("lambda$"))
```

Note that unfortunately "lambda$" is not standard, and if this issue persists we may have to alter our strategy here.