### PR TITLE
Correct applicationSubscribeToEventNPETest

### DIFF
--- a/tck/old-tck/source/src/com/sun/ts/tests/jsf/api/jakarta_faces/application/application/TestServlet.java
+++ b/tck/old-tck/source/src/com/sun/ts/tests/jsf/api/jakarta_faces/application/application/TestServlet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Contributors to Eclipse Foundation.
+ * Copyright (c) 2022, 2024 Contributors to Eclipse Foundation.
  * Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -2311,7 +2311,7 @@ public class TestServlet extends HttpTCKServlet {
         new Object[] { null, srcClass, sel }, out);
 
     out.append("Running==> application.subscribeToEvent(Class, "
-        + "SystemEventListener, null)" + JSFTestUtil.NL);
+        + "Class, null)" + JSFTestUtil.NL);
     JSFTestUtil.checkForNPE(application, "subscribeToEvent",
         new Class<?>[] { Class.class, Class.class, SystemEventListener.class },
         new Object[] { TCKSystemEvent.class, srcClass, null }, out);
@@ -2320,7 +2320,7 @@ public class TestServlet extends HttpTCKServlet {
         + JSFTestUtil.NL);
     JSFTestUtil.checkForNPE(application, "subscribeToEvent",
         new Class<?>[] { Class.class, Class.class, SystemEventListener.class },
-        new Object[] { TCKSystemEvent.class, srcClass, null }, out);
+        new Object[] { TCKSystemEvent.class, null, null }, out);
 
     out.append("Running==> application.subscribeToEvent(null, null, null)"
         + JSFTestUtil.NL);


### PR DESCRIPTION
fixes #1711

The following tests are being updated. Below are the tests without modification for discussion:

```
    out.append("Running==> application.subscribeToEvent(Class, "
        + "SystemEventListener, null)" + JSFTestUtil.NL);
    JSFTestUtil.checkForNPE(application, "subscribeToEvent",
        new Class<?>[] { Class.class, Class.class, SystemEventListener.class },
        new Object[] { TCKSystemEvent.class, srcClass, null }, out);

    out.append("Running==> application.subscribeToEvent(Class, null, null)"
        + JSFTestUtil.NL);
    JSFTestUtil.checkForNPE(application, "subscribeToEvent",
        new Class<?>[] { Class.class, Class.class, SystemEventListener.class },
        new Object[] { TCKSystemEvent.class, srcClass, null }, out);
```

Details on the first test:

- I'm updating the log: `Running==> application.subscribeToEvent(Class, "
        + "SystemEventListener, null)"` because the test is doing the following: `TCKSystemEvent.class, srcClass, null`. I'm changing `SystemEventListener` to `Class` since it is the `srcClass` parameter, not the `SystemEventListener` parameter.

Details on the second test:

- Currently, the test is an exact copy of the first test except for what is being logged. I'm updating this test to reflect what is being logged: `Running==> application.subscribeToEvent(Class, null, null)"` This also follows the pattern used for the first two NPE checks at the beginning of this test: `null first parameter followed by null srcClass (which can be null), and null first parameter followed by non-null srcClass`

API for reference: https://jakarta.ee/specifications/faces/4.0/apidocs/jakarta/faces/application/application#subscribeToEvent(java.lang.Class,java.lang.Class,jakarta.faces.event.SystemEventListener)

> public void subscribeToEvent([Class](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/lang/Class.html)<? extends [SystemEvent](https://jakarta.ee/specifications/faces/4.0/apidocs/jakarta/faces/event/systemevent)> systemEvent[Class](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/lang/Class.html),
>  Class<?> sourceClass,
>  [SystemEventListener](https://jakarta.ee/specifications/faces/4.0/apidocs/jakarta/faces/event/systemeventlistener) listener)
> 
> Install the listener instance referenced by argument listener into the application as a listener for events of type systemEventClass that originate from objects of type sourceClass.
> 
> If argument sourceClass is non-null, sourceClass and systemEventClass must be used to store the argument listener in the application in such a way that the listener can be quickly looked up by the implementation of [publishEvent(jakarta.faces.context.FacesContext, java.lang.Class<? extends jakarta.faces.event.SystemEvent>, java.lang.Object)](https://jakarta.ee/specifications/faces/4.0/apidocs/jakarta/faces/application/application#publishEvent(jakarta.faces.context.FacesContext,java.lang.Class,java.lang.Object)) given systemEventClass and an instance of the Class referenced by sourceClass. If argument sourceClass is null, the listener must be discoverable by the implementation of [publishEvent(jakarta.faces.context.FacesContext, java.lang.Class<? extends jakarta.faces.event.SystemEvent>, java.lang.Object)](https://jakarta.ee/specifications/faces/4.0/apidocs/jakarta/faces/application/application#publishEvent(jakarta.faces.context.FacesContext,java.lang.Class,java.lang.Object)) given only systemEventClass.
> 
> It is valid to call this method during the processing of an event which was subscribed to by a previous call to this method.
> 
> Parameters:
>     systemEventClass - the Class of event for which listener must be fired.
>     sourceClass - the Class of the instance which causes events of type systemEventClass to be fired. May be null.
>     listener - the implementation of [SystemEventListener](https://jakarta.ee/specifications/faces/4.0/apidocs/jakarta/faces/event/systemeventlistener) whose [SystemEventListener.processEvent(jakarta.faces.event.SystemEvent)](https://jakarta.ee/specifications/faces/4.0/apidocs/jakarta/faces/event/systemeventlistener#processEvent(jakarta.faces.event.SystemEvent)) method must be called when events of type systemEventClass are fired.
> Throws:
>     [NullPointerException](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/lang/NullPointerException.html) - if any combination of systemEventClass, or listener are null.
> Since:
>     2.0