### PR TITLE
Move Java 21 enforcer rule to the Glassfish profile

### DIFF
--- a/tck/pom.xml
+++ b/tck/pom.xml
@@ -369,9 +369,6 @@ mvn clean install -pl :old-tck-run -Dglassfish.suspend
                         <requireMavenVersion>
                             <version>3.6.3</version>
                         </requireMavenVersion>
-                        <requireJavaVersion>
-                            <version>21</version>
-                        </requireJavaVersion>
                     </rules>
                 </configuration>
                 <executions>
@@ -519,6 +516,23 @@ mvn clean install -pl :old-tck-run -Dglassfish.suspend
 
             <build>
                 <plugins>
+                    <plugin>
+                        <artifactId>maven-enforcer-plugin</artifactId>
+                        <configuration>
+                            <rules>
+                                <requireJavaVersion>
+                                    <version>21</version>
+                                </requireJavaVersion>
+                            </rules>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>enforce</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
                     <plugin>
                         <artifactId>maven-dependency-plugin</artifactId>
                         <executions>


### PR DESCRIPTION
See: https://www.eclipse.org/lists/faces-dev/msg00388.html

The `Java 21` enforcer rule was not within the Glassfish profile as it should have been.