### PR TITLE
TCK for https://github.com/eclipse-ee4j/mojarra/issues/5415

### DIFF
--- a/tck/faces40/ajax/src/main/webapp/issue5415IT.xhtml
+++ b/tck/faces40/ajax/src/main/webapp/issue5415IT.xhtml
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<!--
+
+    Copyright (c) 2024 Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+<html
+    xmlns:h="jakarta.faces.html"
+    xmlns:my="jakarta.faces.composite/components"
+>
+    <h:head>
+        <title>Issue5415IT</title>
+    </h:head>
+    <h:body>
+        <h:form id="form">
+            <my:outerComponent id="firstInstanceOfOuterComponent" />
+            <my:outerComponent id="secondInstanceOfOuterComponent" />
+        </h:form>
+    </h:body>
+</html>

--- a/tck/faces40/ajax/src/main/webapp/resources/components/innerComponent.xhtml
+++ b/tck/faces40/ajax/src/main/webapp/resources/components/innerComponent.xhtml
@@ -1,0 +1,31 @@
+<!--
+
+    Copyright (c) 2024 Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+<ui:component
+    xmlns:ui="jakarta.faces.facelets"
+    xmlns:f="jakarta.faces.core"
+    xmlns:h="jakarta.faces.html"
+    xmlns:cc="jakarta.faces.composite"
+    xmlns:my="jakarta.faces.composite/components"
+>
+    <cc:interface>
+        <cc:clientBehavior name="change" event="change" targets="input" />
+    </cc:interface>
+    <cc:implementation>
+        <h:selectOneMenu id="input" />
+    </cc:implementation>
+</ui:component>

--- a/tck/faces40/ajax/src/main/webapp/resources/components/middleComponent.xhtml
+++ b/tck/faces40/ajax/src/main/webapp/resources/components/middleComponent.xhtml
@@ -1,0 +1,32 @@
+<!--
+
+    Copyright (c) 2024 Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+<ui:component
+    xmlns:ui="jakarta.faces.facelets"
+    xmlns:f="jakarta.faces.core"
+    xmlns:h="jakarta.faces.html"
+    xmlns:cc="jakarta.faces.composite"
+    xmlns:my="jakarta.faces.composite/components"
+>
+    <cc:interface>
+    </cc:interface>
+    <cc:implementation>
+        <my:innerComponent>
+            <f:ajax execute="#{cc.clientId}" event="change" />
+        </my:innerComponent>
+    </cc:implementation>
+</ui:component>

--- a/tck/faces40/ajax/src/main/webapp/resources/components/outerComponent.xhtml
+++ b/tck/faces40/ajax/src/main/webapp/resources/components/outerComponent.xhtml
@@ -1,0 +1,11 @@
+<ui:component
+    xmlns:ui="jakarta.faces.facelets"
+    xmlns:cc="jakarta.faces.composite"
+    xmlns:my="jakarta.faces.composite/components"
+>
+    <cc:interface>
+    </cc:interface>
+    <cc:implementation>
+        <my:middleComponent id="middleComponentInOuterComponent" />
+    </cc:implementation>
+</ui:component>

--- a/tck/faces40/ajax/src/test/java/ee/jakarta/tck/faces/test/servlet50/ajax_selenium/Issue5415IT.java
+++ b/tck/faces40/ajax/src/test/java/ee/jakarta/tck/faces/test/servlet50/ajax_selenium/Issue5415IT.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.faces.test.servlet50.ajax_selenium;
+
+import static org.junit.Assert.assertEquals;
+
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.component.behavior.AjaxBehavior;
+
+import org.junit.Test;
+
+import ee.jakarta.tck.faces.test.util.selenium.BaseITNG;
+import ee.jakarta.tck.faces.test.util.selenium.WebPage;
+
+public class Issue5415IT extends BaseITNG {
+
+    /**
+     * @see AjaxBehavior#getExecute()
+     * @see UIComponent#getCompositeComponentParent(UIComponent)
+     * @see https://github.com/eclipse-ee4j/mojarra/issues/5415
+     */
+    @Test
+    public void testExecuteCcClientId() throws Exception {
+        WebPage page = getPage("issue5415IT.xhtml");
+        assertEquals(200, page.getResponseStatus());
+        assertEquals("Issue5415IT", page.getTitle());
+    }
+
+}


### PR DESCRIPTION
https://github.com/eclipse-ee4j/mojarra/issues/5415

This is essentially user-supplied test from ticket. Currently it just checks if it returns 200 and not 500. Functionality is not tested but should probably be added.

NOTE: Mojarra 4.1 will fail on this unless https://github.com/eclipse-ee4j/mojarra/pull/5419 is merged from 4.0 into 4.1.