### PR TITLE
remove jax-ws dependency

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -215,14 +215,6 @@
         </dependency>
 
         <dependency>
-            <groupId>jakarta.xml.ws</groupId>
-            <artifactId>jakarta.xml.ws-api</artifactId>
-            <version>4.0.2</version>
-            <scope>provided</scope>
-            <optional>true</optional>
-        </dependency>
-
-        <dependency>
             <groupId>jakarta.annotation</groupId>
             <artifactId>jakarta.annotation-api</artifactId>
             <version>3.0.0</version>

--- a/api/src/main/module/module-info.java
+++ b/api/src/main/module/module-info.java
@@ -28,7 +28,6 @@ module jakarta.faces {
     requires static jakarta.websocket;
     requires static jakarta.persistence;
     requires static jakarta.ejb;
-    requires static jakarta.xml.ws;
     requires static jakarta.json;
     requires transitive java.desktop;
     requires transitive java.sql;

--- a/spec/src/main/asciidoc/ExpressionLanguageFacility.adoc
+++ b/spec/src/main/asciidoc/ExpressionLanguageFacility.adoc
@@ -232,10 +232,6 @@ feature. Here is a summary of the Jakarta EE annotations one may use in a
 
 - _@jakarta.ejb.EJBs_
 
-- _@jakarta.xml.ws.WebServiceRef_
-
-- _@jakarta.xml.ws.WebServiceRefs_
-
 - _@jakarta.persistence.PersistenceContext_
 
 - _@jakarta.persistence.PersistenceContexts_


### PR DESCRIPTION
#1913 remove JAX-WS dependency as it has been removed from Jakarta EE 11.

related PR in Mojarra impl side https://github.com/eclipse-ee4j/mojarra/pull/5453