### PR TITLE
Move non impl specific unit tests from mojarra to faces

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -224,6 +224,23 @@
             <scope>provided</scope>
             <optional>true</optional>
         </dependency>
+        
+        
+        <!-- Test -->
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.10.2</version>
+            <scope>test</scope>
+        </dependency>
+        
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>5.11.0</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/api/src/test/java/jakarta/faces/FacesWrapperTest.java
+++ b/api/src/test/java/jakarta/faces/FacesWrapperTest.java
@@ -16,6 +16,9 @@
 
 package jakarta.faces;
 
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.io.File;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
@@ -23,7 +26,8 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import junit.framework.TestCase;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 /**
  * <p>
@@ -32,7 +36,7 @@ import junit.framework.TestCase;
  * should help to keep the wrapper classes in synch with the wrapped classes.
  * </p>
  */
-public class FacesWrapperTestCase extends TestCase {
+class FacesWrapperTest {
 
     private static List<Class<?>> wrapperClasses;
     private static List<Class<?>> noWrapperClasses;
@@ -44,8 +48,8 @@ public class FacesWrapperTestCase extends TestCase {
      * implementing FacesWrapper.
      * @throws java.lang.Exception
      */
-    @Override
-    protected void setUp() throws Exception {
+    @BeforeAll
+    protected static void setUp() throws Exception {
         if (wrapperClasses == null) {
             loadWrapperClasses();
             methodsToIgnore = new ArrayList<Method>();
@@ -56,23 +60,23 @@ public class FacesWrapperTestCase extends TestCase {
     /**
      * Unit test to assert wrapperClasses list was loaded (see {@link #setUp()}.
      */
-    public void testWrapperClassesLoaded() {
+    @Test
+    void testWrapperClassesLoaded() {
         assertNotNull(wrapperClasses);
-        assertTrue("no wrapper classes found!", !wrapperClasses.isEmpty());
+        assertTrue(!wrapperClasses.isEmpty(), "no wrapper classes found!");
     }
 
     /**
      * Unit test to assert there are no *Wrapper classes not implementing
      * FacesWrapper.
      */
-    public void testWrapperClassesImplementFacesWrapper() {
+    @Test
+    void testWrapperClassesImplementFacesWrapper() {
         assertNotNull(noWrapperClasses);
         if (noWrapperClasses.size() > 0) {
-            System.out.println("Wrapper classes not implementing jakarta.faces.FacesWrapper:");
-            System.out.println(noWrapperClasses.toString());
+            System.out.println("[ERROR] Wrapper classes not implementing jakarta.faces.FacesWrapper: " + noWrapperClasses);
         }
-        assertTrue("Found wrapper classes not implementing FacesWrapper!", noWrapperClasses
-                .isEmpty());
+        assertTrue(noWrapperClasses.isEmpty(), "Found wrapper classes not implementing FacesWrapper!");
     }
 
     /**
@@ -80,7 +84,8 @@ public class FacesWrapperTestCase extends TestCase {
      * implementing FacesWrapper do wrap all public and protected methods of the
      * wrapped class.
      */
-    public void testWrapperClassWrapsPublicAndProtectedMethods() {
+    @Test
+    void testWrapperClassWrapsPublicAndProtectedMethods() {
         for (Class<?> wrapper : wrapperClasses) {
             if (wrapper.isInterface()) {
                 continue;
@@ -88,14 +93,14 @@ public class FacesWrapperTestCase extends TestCase {
             List<Method> wrapperMethods = getPublicAndProtectedMethods(wrapper);
             List<Method> methodsToWrap = getPublicAndProtectedMethods(wrapper.getSuperclass());
 
-            System.out.println("verify " + wrapper.getName() + " is wrapping "
-                    + wrapper.getSuperclass().getName() + " well");
+            System.out.println("[INFO] Verifying that " + wrapper.getName() + " is wrapping "
+                    + wrapper.getSuperclass().getName() + " correctly ...");
             String msg = wrapper.getCanonicalName() + " does not wrap method: ";
             for (Method m : methodsToWrap) {
                 if (isMethodContained(m, methodsToIgnore)) {
                     continue;
                 }
-                assertTrue(msg + m.toString(), isMethodContained(m, wrapperMethods));
+                assertTrue(isMethodContained(m, wrapperMethods), msg + m.toString());
             }
         }
     }
@@ -147,7 +152,7 @@ public class FacesWrapperTestCase extends TestCase {
     /**
      * Collect the wrapper classes.
      */
-    private void loadWrapperClasses() {
+    private static void loadWrapperClasses() {
         wrapperClasses = new ArrayList<>();
         noWrapperClasses = new ArrayList<>();
 
@@ -171,7 +176,7 @@ public class FacesWrapperTestCase extends TestCase {
      * @param jakartaFacesFolder current File (directory or file)
      * @throws Exception might throw ClassNotFoundException from class loading.
      */
-    private void collectWrapperClasses(ClassLoader classLoader, String pkg, File jakartaFacesFolder) throws Exception {
+    private static void collectWrapperClasses(ClassLoader classLoader, String pkg, File jakartaFacesFolder) throws Exception {
         for (File file : jakartaFacesFolder.listFiles()) {
             if (file.isDirectory()) {
                 collectWrapperClasses(classLoader, pkg + file.getName() + ".", file);
@@ -192,7 +197,7 @@ public class FacesWrapperTestCase extends TestCase {
      * @param f the File to analyse.
      * @throws Exception ClassLoader exceptions.
      */
-    private void addWrapperClassToWrapperClassesList(ClassLoader cl, String pkg, File f)
+    private static void addWrapperClassToWrapperClassesList(ClassLoader cl, String pkg, File f)
             throws Exception {
         String name = f.getName();
         if (!name.endsWith(".class")) {

--- a/api/src/test/java/jakarta/faces/convert/BigIntegerConverterTest.java
+++ b/api/src/test/java/jakarta/faces/convert/BigIntegerConverterTest.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 1997, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.faces.convert;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.math.BigInteger;
+
+import jakarta.faces.component.UIPanel;
+import jakarta.faces.context.FacesContext;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+/**
+ * The JUnit tests for the BigIntegerConverter class.
+ */
+class BigIntegerConverterTest {
+
+    /**
+     * Test getAsObject method.
+     */
+    @Test
+    void testGetAsObject() {
+        BigIntegerConverter converter = new BigIntegerConverter();
+        assertThrows(NullPointerException.class, () -> converter.getAsObject(null, null, null));
+    }
+
+    /**
+     * Test getAsObject method.
+     */
+    @Test
+    void testGetAsObject2() {
+        BigIntegerConverter converter = new BigIntegerConverter();
+        FacesContext facesContext = Mockito.mock(FacesContext.class);
+        assertNull(converter.getAsObject(facesContext, new UIPanel(), null));
+    }
+
+    /**
+     * Test getAsObject method.
+     */
+    @Test
+    void testGetAsObject3() {
+        BigIntegerConverter converter = new BigIntegerConverter();
+        FacesContext facesContext = Mockito.mock(FacesContext.class);
+        assertNull(converter.getAsObject(facesContext, new UIPanel(), "     "));
+    }
+
+    /**
+     * Test getAsObject method.
+     */
+    @Test
+    void testGetAsObject4() {
+        BigIntegerConverter converter = new BigIntegerConverter();
+        FacesContext facesContext = Mockito.mock(FacesContext.class);
+        assertEquals(BigInteger.valueOf(123), converter.getAsObject(facesContext, new UIPanel(), "123"));
+    }
+
+    /**
+     * Test getAsString method.
+     */
+    @Test
+    void testGetAsString() {
+        BigIntegerConverter converter = new BigIntegerConverter();
+        assertThrows(NullPointerException.class, () -> converter.getAsString(null, null, null));
+    }
+
+    /**
+     * Test getAsString method.
+     */
+    @Test
+    void testGetAsString2() {
+        BigIntegerConverter converter = new BigIntegerConverter();
+        FacesContext facesContext = Mockito.mock(FacesContext.class);
+        assertEquals("", converter.getAsString(facesContext, new UIPanel(), null));
+    }
+
+    /**
+     * Test getAsString method.
+     */
+    @Test
+    void testGetAsString3() {
+        BigIntegerConverter converter = new BigIntegerConverter();
+        FacesContext facesContext = Mockito.mock(FacesContext.class);
+        assertEquals("123", converter.getAsString(facesContext, new UIPanel(), "123"));
+    }
+
+    /**
+     * Test getAsString method.
+     */
+    @Test
+    void testGetAsString4() {
+        BigIntegerConverter converter = new BigIntegerConverter();
+        FacesContext facesContext = Mockito.mock(FacesContext.class);
+        assertEquals("123", converter.getAsString(facesContext, new UIPanel(), BigInteger.valueOf(123)));
+    }
+}

--- a/api/src/test/java/jakarta/faces/convert/DoubleConverterTest.java
+++ b/api/src/test/java/jakarta/faces/convert/DoubleConverterTest.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 1997, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.faces.convert;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import jakarta.faces.component.UIPanel;
+import jakarta.faces.context.FacesContext;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+/**
+ * The JUnit tests for the DoubleConverter class.
+ */
+class DoubleConverterTest {
+
+    /**
+     * Test getAsObject method.
+     */
+    @Test
+    void testGetAsObject() {
+        DoubleConverter converter = new DoubleConverter();
+        assertThrows(NullPointerException.class, () -> converter.getAsObject(null, null, null));
+    }
+
+    /**
+     * Test getAsObject method.
+     */
+    @Test
+    void testGetAsObject2() {
+        DoubleConverter converter = new DoubleConverter();
+        FacesContext facesContext = Mockito.mock(FacesContext.class);
+        assertNull(converter.getAsObject(facesContext, new UIPanel(), null));
+    }
+
+    /**
+     * Test getAsObject method.
+     */
+    @Test
+    void testGetAsObject3() {
+        DoubleConverter converter = new DoubleConverter();
+        FacesContext facesContext = Mockito.mock(FacesContext.class);
+        assertNull(converter.getAsObject(facesContext, new UIPanel(), "     "));
+    }
+
+    /**
+     * Test getAsObject method.
+     */
+    @Test
+    void testGetAsObject4() {
+        DoubleConverter converter = new DoubleConverter();
+        FacesContext facesContext = Mockito.mock(FacesContext.class);
+        assertEquals(Double.valueOf("12.3"), converter.getAsObject(facesContext, new UIPanel(), "12.3"));
+    }
+
+    /**
+     * Test getAsString method.
+     */
+    @Test
+    void testGetAsString() {
+        DoubleConverter converter = new DoubleConverter();
+        assertThrows(NullPointerException.class, () -> converter.getAsString(null, null, null));
+    }
+
+    /**
+     * Test getAsString method.
+     */
+    @Test
+    void testGetAsString2() {
+        DoubleConverter converter = new DoubleConverter();
+        FacesContext facesContext = Mockito.mock(FacesContext.class);
+        assertEquals("", converter.getAsString(facesContext, new UIPanel(), null));
+    }
+
+    /**
+     * Test getAsString method.
+     */
+    @Test
+    void testGetAsString3() {
+        DoubleConverter converter = new DoubleConverter();
+        FacesContext facesContext = Mockito.mock(FacesContext.class);
+        assertEquals("12.3", converter.getAsString(facesContext, new UIPanel(), "12.3"));
+    }
+
+    /**
+     * Test getAsString method.
+     */
+    @Test
+    void testGetAsString4() {
+        DoubleConverter converter = new DoubleConverter();
+        FacesContext facesContext = Mockito.mock(FacesContext.class);
+        assertEquals("12.3", converter.getAsString(facesContext, new UIPanel(), Double.valueOf("12.3")));
+    }
+}

--- a/api/src/test/java/jakarta/faces/convert/FloatConverterTest.java
+++ b/api/src/test/java/jakarta/faces/convert/FloatConverterTest.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 1997, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.faces.convert;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import jakarta.faces.component.UIPanel;
+import jakarta.faces.context.FacesContext;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+/**
+ * The JUnit tests for the FloatConverter class.
+ */
+class FloatConverterTest {
+
+    /**
+     * Test getAsObject method.
+     */
+    @Test
+    void testGetAsObject() {
+        FloatConverter converter = new FloatConverter();
+        assertThrows(NullPointerException.class, () -> converter.getAsObject(null, null, null));
+    }
+
+    /**
+     * Test getAsObject method.
+     */
+    @Test
+    void testGetAsObject2() {
+        FloatConverter converter = new FloatConverter();
+        FacesContext facesContext = Mockito.mock(FacesContext.class);
+        assertNull(converter.getAsObject(facesContext, new UIPanel(), null));
+    }
+
+    /**
+     * Test getAsObject method.
+     */
+    @Test
+    void testGetAsObject3() {
+        FloatConverter converter = new FloatConverter();
+        FacesContext facesContext = Mockito.mock(FacesContext.class);
+        assertNull(converter.getAsObject(facesContext, new UIPanel(), "     "));
+    }
+
+    /**
+     * Test getAsObject method.
+     */
+    @Test
+    void testGetAsObject4() {
+        FloatConverter converter = new FloatConverter();
+        FacesContext facesContext = Mockito.mock(FacesContext.class);
+        assertEquals(Float.valueOf("12.3"), converter.getAsObject(facesContext, new UIPanel(), "12.3"));
+    }
+
+    /**
+     * Test getAsString method.
+     */
+    @Test
+    void testGetAsString() {
+        FloatConverter converter = new FloatConverter();
+        assertThrows(NullPointerException.class, () -> converter.getAsString(null, null, null));
+    }
+
+    /**
+     * Test getAsString method.
+     */
+    @Test
+    void testGetAsString2() {
+        FloatConverter converter = new FloatConverter();
+        FacesContext facesContext = Mockito.mock(FacesContext.class);
+        assertEquals("", converter.getAsString(facesContext, new UIPanel(), null));
+    }
+
+    /**
+     * Test getAsString method.
+     */
+    @Test
+    void testGetAsString3() {
+        FloatConverter converter = new FloatConverter();
+        FacesContext facesContext = Mockito.mock(FacesContext.class);
+        assertEquals("12.3", converter.getAsString(facesContext, new UIPanel(), "12.3"));
+    }
+
+    /**
+     * Test getAsString method.
+     */
+    @Test
+    void testGetAsString4() {
+        FloatConverter converter = new FloatConverter();
+        FacesContext facesContext = Mockito.mock(FacesContext.class);
+        assertEquals("12.3", converter.getAsString(facesContext, new UIPanel(), Float.valueOf("12.3")));
+    }
+}

--- a/api/src/test/java/jakarta/faces/convert/IntegerConverterTest.java
+++ b/api/src/test/java/jakarta/faces/convert/IntegerConverterTest.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 1997, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.faces.convert;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import jakarta.faces.component.UIPanel;
+import jakarta.faces.context.FacesContext;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+/**
+ * The JUnit tests for the IntegerConverter class.
+ */
+class IntegerConverterTest {
+
+    /**
+     * Test getAsObject method.
+     */
+    @Test
+    void testGetAsObject() {
+        IntegerConverter converter = new IntegerConverter();
+        assertThrows(NullPointerException.class, () -> converter.getAsObject(null, null, null));
+    }
+
+    /**
+     * Test getAsObject method.
+     */
+    @Test
+    void testGetAsObject2() {
+        IntegerConverter converter = new IntegerConverter();
+        FacesContext facesContext = Mockito.mock(FacesContext.class);
+        assertNull(converter.getAsObject(facesContext, new UIPanel(), null));
+    }
+
+    /**
+     * Test getAsObject method.
+     */
+    @Test
+    void testGetAsObject3() {
+        IntegerConverter converter = new IntegerConverter();
+        FacesContext facesContext = Mockito.mock(FacesContext.class);
+        assertNull(converter.getAsObject(facesContext, new UIPanel(), "     "));
+    }
+
+    /**
+     * Test getAsObject method.
+     */
+    @Test
+    void testGetAsObject4() {
+        IntegerConverter converter = new IntegerConverter();
+        FacesContext facesContext = Mockito.mock(FacesContext.class);
+        assertEquals(Integer.valueOf("123"), converter.getAsObject(facesContext, new UIPanel(), "123"));
+    }
+
+    /**
+     * Test getAsString method.
+     */
+    @Test
+    void testGetAsString() {
+        IntegerConverter converter = new IntegerConverter();
+        assertThrows(NullPointerException.class, () -> converter.getAsString(null, null, null));
+    }
+
+    /**
+     * Test getAsString method.
+     */
+    @Test
+    void testGetAsString2() {
+        IntegerConverter converter = new IntegerConverter();
+        FacesContext facesContext = Mockito.mock(FacesContext.class);
+        assertEquals("", converter.getAsString(facesContext, new UIPanel(), null));
+    }
+
+    /**
+     * Test getAsString method.
+     */
+    @Test
+    void testGetAsString3() {
+        IntegerConverter converter = new IntegerConverter();
+        FacesContext facesContext = Mockito.mock(FacesContext.class);
+        assertEquals("123", converter.getAsString(facesContext, new UIPanel(), "123"));
+    }
+
+    /**
+     * Test getAsString method.
+     */
+    @Test
+    void testGetAsString4() {
+        IntegerConverter converter = new IntegerConverter();
+        FacesContext facesContext = Mockito.mock(FacesContext.class);
+        assertEquals("123", converter.getAsString(facesContext, new UIPanel(), Integer.valueOf("123")));
+    }
+}

--- a/api/src/test/java/jakarta/faces/convert/LongConverterTest.java
+++ b/api/src/test/java/jakarta/faces/convert/LongConverterTest.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 1997, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.faces.convert;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import jakarta.faces.component.UIPanel;
+import jakarta.faces.context.FacesContext;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+/**
+ * The JUnit tests for the LongConverter class.
+ */
+class LongConverterTest {
+
+    /**
+     * Test getAsObject method.
+     */
+    @Test
+    void testGetAsObject() {
+        LongConverter converter = new LongConverter();
+        assertThrows(NullPointerException.class, () -> converter.getAsObject(null, null, null));
+    }
+
+    /**
+     * Test getAsObject method.
+     */
+    @Test
+    void testGetAsObject2() {
+        LongConverter converter = new LongConverter();
+        FacesContext facesContext = Mockito.mock(FacesContext.class);
+        assertNull(converter.getAsObject(facesContext, new UIPanel(), null));
+    }
+
+    /**
+     * Test getAsObject method.
+     */
+    @Test
+    void testGetAsObject3() {
+        LongConverter converter = new LongConverter();
+        FacesContext facesContext = Mockito.mock(FacesContext.class);
+        assertNull(converter.getAsObject(facesContext, new UIPanel(), "     "));
+    }
+
+    /**
+     * Test getAsObject method.
+     */
+    @Test
+    void testGetAsObject4() {
+        LongConverter converter = new LongConverter();
+        FacesContext facesContext = Mockito.mock(FacesContext.class);
+        assertEquals(Long.valueOf("123"), converter.getAsObject(facesContext, new UIPanel(), "123"));
+    }
+
+    /**
+     * Test getAsString method.
+     */
+    @Test
+    void testGetAsString() {
+        LongConverter converter = new LongConverter();
+        assertThrows(NullPointerException.class, () -> converter.getAsString(null, null, null));
+    }
+
+    /**
+     * Test getAsString method.
+     */
+    @Test
+    void testGetAsString2() {
+        LongConverter converter = new LongConverter();
+        FacesContext facesContext = Mockito.mock(FacesContext.class);
+        assertEquals("", converter.getAsString(facesContext, new UIPanel(), null));
+    }
+
+    /**
+     * Test getAsString method.
+     */
+    @Test
+    void testGetAsString3() {
+        LongConverter converter = new LongConverter();
+        FacesContext facesContext = Mockito.mock(FacesContext.class);
+        assertEquals("123", converter.getAsString(facesContext, new UIPanel(), "123"));
+    }
+
+    /**
+     * Test getAsString method.
+     */
+    @Test
+    void testGetAsString4() {
+        LongConverter converter = new LongConverter();
+        FacesContext facesContext = Mockito.mock(FacesContext.class);
+        assertEquals("123", converter.getAsString(facesContext, new UIPanel(), Long.valueOf("123")));
+    }
+}

--- a/api/src/test/java/jakarta/faces/convert/ShortConverterTest.java
+++ b/api/src/test/java/jakarta/faces/convert/ShortConverterTest.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 1997, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.faces.convert;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import jakarta.faces.component.UIPanel;
+import jakarta.faces.context.FacesContext;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+/**
+ * The JUnit tests for the ShortConverter class.
+ */
+class ShortConverterTest {
+
+    /**
+     * Test getAsObject method.
+     */
+    @Test
+    void testGetAsObject() {
+        ShortConverter converter = new ShortConverter();
+        assertThrows(NullPointerException.class, () -> converter.getAsObject(null, null, null));
+    }
+
+    /**
+     * Test getAsObject method.
+     */
+    @Test
+    void testGetAsObject2() {
+        ShortConverter converter = new ShortConverter();
+        FacesContext facesContext = Mockito.mock(FacesContext.class);
+        assertNull(converter.getAsObject(facesContext, new UIPanel(), null));
+    }
+
+    /**
+     * Test getAsObject method.
+     */
+    @Test
+    void testGetAsObject3() {
+        ShortConverter converter = new ShortConverter();
+        FacesContext facesContext = Mockito.mock(FacesContext.class);
+        assertNull(converter.getAsObject(facesContext, new UIPanel(), "     "));
+    }
+
+    /**
+     * Test getAsObject method.
+     */
+    @Test
+    void testGetAsObject4() {
+        ShortConverter converter = new ShortConverter();
+        FacesContext facesContext = Mockito.mock(FacesContext.class);
+        assertEquals(Short.valueOf("123"), converter.getAsObject(facesContext, new UIPanel(), "123"));
+    }
+
+    /**
+     * Test getAsString method.
+     */
+    @Test
+    void testGetAsString() {
+        ShortConverter converter = new ShortConverter();
+        assertThrows(NullPointerException.class, () -> converter.getAsString(null, null, null));
+    }
+
+    /**
+     * Test getAsString method.
+     */
+    @Test
+    void testGetAsString2() {
+        ShortConverter converter = new ShortConverter();
+        FacesContext facesContext = Mockito.mock(FacesContext.class);
+        assertEquals("", converter.getAsString(facesContext, new UIPanel(), null));
+    }
+
+    /**
+     * Test getAsString method.
+     */
+    @Test
+    void testGetAsString3() {
+        ShortConverter converter = new ShortConverter();
+        FacesContext facesContext = Mockito.mock(FacesContext.class);
+        assertEquals("123", converter.getAsString(facesContext, new UIPanel(), "123"));
+    }
+
+    /**
+     * Test getAsString method.
+     */
+    @Test
+    void testGetAsString4() {
+        ShortConverter converter = new ShortConverter();
+        FacesContext facesContext = Mockito.mock(FacesContext.class);
+        assertEquals("123", converter.getAsString(facesContext, new UIPanel(), Short.valueOf("123")));
+    }
+}

--- a/api/src/test/java/jakarta/faces/event/PhaseIdTest.java
+++ b/api/src/test/java/jakarta/faces/event/PhaseIdTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 1997, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.faces.event;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Iterator;
+
+import org.junit.jupiter.api.Test;
+
+class PhaseIdTest {
+
+    @Test
+    void testToString() {
+        Iterator<PhaseId> valueIter = PhaseId.VALUES.iterator();
+        String cur = null;
+        while (valueIter.hasNext()) {
+            cur = valueIter.next().toString();
+            assertTrue(cur.length() > 3);
+        }
+
+    }
+
+}

--- a/api/src/test/java/jakarta/faces/model/ArrayDataModelTestCase.java
+++ b/api/src/test/java/jakarta/faces/model/ArrayDataModelTestCase.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 1997, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.faces.model;
+
+import org.junit.jupiter.api.BeforeEach;
+
+/**
+ * <p>
+ * Unit tests for {@link ArrayDataModel}.</p>
+ */
+class ArrayDataModelTestCase extends DataModelTestCaseBase {
+
+    // ------------------------------------------------------ Instance Variables
+    // ---------------------------------------------------- Overall Test Methods
+    // Set up instance variables required by this test case.
+    @BeforeEach
+    void setUp() throws Exception {
+        beans = new MockedJavaBean[5];
+        for (int i = 0; i < beans.length; i++) {
+            beans[i] = new MockedJavaBean();
+        }
+        configure();
+        model = new ArrayDataModel<MockedJavaBean>(beans);
+    }
+
+    // ------------------------------------------------- Individual Test Methods
+    // ------------------------------------------------------- Protected Methods
+}

--- a/api/src/test/java/jakarta/faces/model/CollectionDataModelTest.java
+++ b/api/src/test/java/jakarta/faces/model/CollectionDataModelTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 1997, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.faces.model;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.util.ArrayList;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * The JUnit tests for CollectionDataModel.
+ *
+ * @author Manfred Riem
+ */
+class CollectionDataModelTest {
+
+    /**
+     * Test getWrappedData method.
+     */
+    @Test
+    void testGetWrappedData() {
+        CollectionDataModel<Object> model = new CollectionDataModel<>();
+        assertNull(model.getWrappedData());
+        ArrayList<String> list = new ArrayList<>();
+        model.setWrappedData(list);
+        assertNotNull(model.getWrappedData());
+        model.setWrappedData(null);
+        assertNull(model.getWrappedData());
+    }
+}

--- a/api/src/test/java/jakarta/faces/model/DataModelTestCaseBase.java
+++ b/api/src/test/java/jakarta/faces/model/DataModelTestCaseBase.java
@@ -1,0 +1,332 @@
+/*
+ * Copyright (c) 1997, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.faces.model;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.lang.reflect.Method;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.NoSuchElementException;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * <p>
+ * Abstract base class for {@link DataModel} tests.</p>
+ */
+abstract class DataModelTestCaseBase {
+
+    // ------------------------------------------------------ Instance Variables
+    // The array of beans we will be wrapping (must be initialized before setUp)
+    protected MockedJavaBean beans[] = new MockedJavaBean[0];
+
+    // The DataModel we are testing
+    protected DataModel<?> model = null;
+
+    // ---------------------------------------------------- Overall Test Methods
+    // Configure the properties of the beans we will be wrapping
+    protected void configure() {
+        for (int i = 0; i < beans.length; i++) {
+            MockedJavaBean bean = beans[i];
+            bean.setBooleanProperty((i % 2) == 0);
+            bean.setBooleanSecond(!bean.getBooleanProperty());
+            bean.setByteProperty((byte) i);
+            bean.setDoubleProperty(i * 100.0);
+            bean.setFloatProperty(i * ((float) 10.0));
+            bean.setIntProperty(1000 * i);
+            bean.setLongProperty((long) 10000 * (long) i);
+            bean.setStringProperty("This is string " + i);
+        }
+    }
+
+    // ------------------------------------------------- Individual Test Methods
+
+    // Test invalid arguments to listener methods
+    @Test
+    void testInvalidListeners() throws Exception {
+        try {
+            model.addDataModelListener(null);
+            fail("Should have thrown NullPointerException");
+        } catch (NullPointerException e) {
+            // Expected result
+        }
+
+        try {
+            model.removeDataModelListener(null);
+            fail("Should have thrown NullPointerException");
+        } catch (NullPointerException e) {
+            // Expected result
+        }
+    }
+
+    // Test positioning to all rows in ascending order
+    @Test
+    void testPositionAscending() throws Exception {
+        StringBuilder sb = new StringBuilder();
+        model.setRowIndex(-1);
+        model.addDataModelListener(new ListenerTestImpl());
+        ListenerTestImpl.trace(null);
+
+        int n = model.getRowCount();
+        for (int i = 0; i < n; i++) {
+            checkRow(i);
+            sb.append('/').append(i);
+        }
+        assertEquals(sb.toString(), ListenerTestImpl.trace());
+    }
+
+    // Test positioning to all rows in descending order
+    @Test
+    void testPositionDescending() throws Exception {
+        StringBuilder sb = new StringBuilder();
+        model.setRowIndex(-1);
+        model.addDataModelListener(new ListenerTestImpl());
+        ListenerTestImpl.trace(null);
+
+        int n = model.getRowCount();
+        for (int i = (n - 1); i >= 0; i--) {
+            checkRow(i);
+            sb.append('/').append(i);
+        }
+        assertEquals(sb.toString(), ListenerTestImpl.trace());
+    }
+
+    // Test a pristine DataModel instance
+    @Test
+    void testPristine() throws Exception {
+        // Unopened instance
+        assertNotNull(beans);
+        assertNotNull(model);
+
+        // Correct row count
+        if (model instanceof ResultSetDataModel) {
+            assertEquals(-1, model.getRowCount());
+        } else {
+            assertEquals(beans.length,
+                    model.getRowCount());
+        }
+
+        // Correct row index
+        assertEquals(0, model.getRowIndex());
+    }
+
+    // Test removing listener
+    @Test
+    void testRemoveListener() throws Exception {
+        ListenerTestImpl listener = new ListenerTestImpl();
+        ListenerTestImpl.trace(null);
+        model.addDataModelListener(listener);
+        model.setRowIndex(-1);
+        model.setRowIndex(0);
+        model.setRowIndex(0); // No movement so no event
+        model.setRowIndex(-1);
+        model.removeDataModelListener(listener);
+        model.setRowIndex(0);
+        assertEquals("/-1/0/-1", ListenerTestImpl.trace());
+    }
+
+    // Test resetting the wrapped data (should trigger an event
+    @Test
+    void testReset() throws Exception {
+        ListenerTestImpl listener = new ListenerTestImpl();
+        ListenerTestImpl.trace(null);
+        model.addDataModelListener(listener);
+
+        assertEquals(0, model.getRowIndex());
+        model.setWrappedData(model.getWrappedData());
+        assertEquals("/0", ListenerTestImpl.trace());
+    }
+
+    // Test row available manipulations
+    @Test
+    void testRowAvailable() throws Exception {
+        // Position to the "no current row" position
+        model.setRowIndex(-1);
+        assertTrue(!model.isRowAvailable());
+
+        // Position to an arbitrarily high row number
+        model.setRowIndex(beans.length);
+        assertTrue(!model.isRowAvailable());
+
+        // Position to a known good row number
+        model.setRowIndex(0);
+        assertTrue(model.isRowAvailable());
+    }
+
+    // Test the ability to update through the Map returned by getRowData()
+    @Test
+    @SuppressWarnings("unchecked")
+    void testRowData() throws Exception {
+        // Retrieve the row data for row zero
+        model.setRowIndex(0);
+        Object data = model.getRowData();
+        assertNotNull(data);
+
+        // Modify several property values
+        MockedJavaBean bean = beans[0];
+        bean.setBooleanProperty(!bean.getBooleanProperty());
+        if (data instanceof Map) {
+            ((Map<String, Boolean>) data).put("booleanProperty",
+                    bean.getBooleanProperty()
+                    ? Boolean.TRUE : Boolean.FALSE);
+        } else {
+            Method m = data.getClass().getMethod("setBooleanProperty", Boolean.TYPE);
+            m.invoke(data, bean.getBooleanProperty() ? Boolean.TRUE : Boolean.FALSE);
+        }
+        bean.setIntProperty(bean.getIntProperty() + 5);
+        if (data instanceof Map) {
+            ((Map<String, Integer>) data).put("intProperty",
+                    bean.getIntProperty());
+        } else {
+            Method m = data.getClass().getMethod("setIntProperty", Integer.TYPE);
+            m.invoke(data, bean.getIntProperty());
+        }
+        bean.setStringProperty(bean.getStringProperty() + "XYZ");
+        if (data instanceof Map) {
+            ((Map<String, String>) data).put("stringProperty",
+                    bean.getStringProperty() + "XYZ");
+        } else {
+            Method m = data.getClass().getMethod("setStringProperty", String.class);
+            m.invoke(data, bean.getStringProperty());
+        }
+
+        // Ensure that all the modifications flowed through to beans[0]
+        assertEquals(bean.getBooleanProperty(),
+                beans[0].getBooleanProperty());
+        assertEquals(bean.isBooleanSecond(),
+                beans[0].isBooleanSecond());
+        assertEquals(bean.getByteProperty(),
+                beans[0].getByteProperty());
+        assertEquals(bean.getDoubleProperty(),
+                beans[0].getDoubleProperty(), 0.005);
+        assertEquals(bean.getFloatProperty(),
+                beans[0].getFloatProperty(), (float) 0.005);
+        assertEquals(bean.getIntProperty(),
+                beans[0].getIntProperty());
+        assertEquals(bean.getLongProperty(),
+                beans[0].getLongProperty());
+        assertEquals(bean.getStringProperty(),
+                beans[0].getStringProperty());
+    }
+
+    // Test row index manipulations
+    @Test
+    void testRowIndex() throws Exception {
+        assertEquals(0, model.getRowIndex());
+
+        // Positive setRowIndex() tests
+        model.setRowIndex(0);
+        model.setRowIndex(-1);
+
+        // Negative setRowIndex() tests
+        try {
+            model.setRowIndex(-2);
+            fail("Should have thrown IllegalArgumentException");
+        } catch (IllegalArgumentException e) {
+            // Expected result
+        }
+    }
+
+    @Test
+    void testIterator() {
+        Iterator<?> iterator = model.iterator();
+        if (!(model instanceof ScalarDataModel)) {
+            for (int i = 0; i < 5; i++) {
+                assertTrue(iterator.hasNext());
+                assertNotNull(iterator.next());
+            }
+        } else {
+            assertTrue(iterator.hasNext());
+            assertNotNull(iterator.next());
+        }
+
+        assertTrue(!iterator.hasNext());
+        try {
+            iterator.next();
+            assertTrue(false);
+        } catch (NoSuchElementException nsee) {
+            // expected
+        }
+    }
+
+    // Test resetting the wrapped data to null
+    @Test
+    void testWrapped() throws Exception {
+        model.setWrappedData(null);
+        assertTrue(!model.isRowAvailable());
+        assertEquals(-1, model.getRowCount());
+        assertNull(model.getRowData());
+        assertEquals(-1, model.getRowIndex());
+        assertNull(model.getWrappedData());
+    }
+
+    // ------------------------------------------------------- Protected Methods
+    protected MockedJavaBean data() throws Exception {
+        Object data = model.getRowData();
+        assertNotNull(data);
+        assertTrue(data instanceof MockedJavaBean);
+        return ((MockedJavaBean) data);
+    }
+
+    protected void checkRow(int i) throws Exception {
+        model.setRowIndex(i);
+        String prompt = "Row " + i + " property ";
+        MockedJavaBean bean = data();
+        assertNotNull(bean, "Row " + i + " data");
+        assertEquals(
+                beans[i].getBooleanProperty(),
+                bean.getBooleanProperty(), prompt + "booleanProperty");
+        assertEquals(
+                beans[i].isBooleanSecond(),
+                bean.isBooleanSecond(), prompt + "booleanSecond");
+        assertEquals(
+                beans[i].getByteProperty(),
+                bean.getByteProperty(), prompt + "byteProperty");
+        assertEquals(
+                "" + beans[i].getDoubleProperty(),
+                "" + bean.getDoubleProperty(), prompt + "doubleProperty");
+        assertEquals(
+                "" + beans[i].getFloatProperty(),
+                "" + bean.getFloatProperty(), prompt + "floatProperty");
+        assertEquals(
+                beans[i].getIntProperty(),
+                bean.getIntProperty(), prompt + "intProperty");
+        assertEquals(
+                beans[i].getLongProperty(),
+                bean.getLongProperty(), prompt + "longProperty");
+        assertEquals(
+                beans[i].getNullProperty(),
+                bean.getNullProperty(), prompt + "nullProperty");
+        assertEquals(
+                beans[i].getReadOnlyProperty(),
+                bean.getReadOnlyProperty(), prompt + "readOnlyProperty");
+        assertEquals(
+                beans[i].getShortProperty(),
+                bean.getShortProperty(), prompt + "shortProperty");
+        assertEquals(
+                beans[i].getStringProperty(),
+                bean.getStringProperty(), prompt + "stringProperty");
+        assertEquals(
+                beans[i].getWriteOnlyPropertyValue(),
+                bean.getWriteOnlyPropertyValue(), prompt + "writeOnlyProperty");
+    }
+}

--- a/api/src/test/java/jakarta/faces/model/ListDataModelTestCase.java
+++ b/api/src/test/java/jakarta/faces/model/ListDataModelTestCase.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 1997, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.faces.model;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+
+/**
+ * <p>
+ * Unit tests for {@link ListDataModel}.</p>
+ */
+class ListDataModelTestCase extends DataModelTestCaseBase {
+
+    // ------------------------------------------------------ Instance Variables
+    // ---------------------------------------------------- Overall Test Methods
+    // Set up instance variables required by this test case.
+    @BeforeEach
+    void setUp() throws Exception {
+        List<MockedJavaBean> list = new ArrayList<MockedJavaBean>();
+        for (int i = 0; i < 5; i++) {
+            list.add(new MockedJavaBean());
+        }
+        beans = list.toArray(new MockedJavaBean[5]);
+        configure();
+        model = new ListDataModel<MockedJavaBean>(list);
+    }
+
+    // ------------------------------------------------- Individual Test Methods
+    // ------------------------------------------------------- Protected Methods
+}

--- a/api/src/test/java/jakarta/faces/model/ListenerTestImpl.java
+++ b/api/src/test/java/jakarta/faces/model/ListenerTestImpl.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 1997, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.faces.model;
+
+/**
+ * <p>
+ * Test implementation of DataModelListener.</p>
+ */
+class ListenerTestImpl implements DataModelListener {
+
+    // ----------------------------------------------- DataModelListener Methods
+    @Override
+    public void rowSelected(DataModelEvent event) {
+        Object rowData = event.getRowData();
+        int rowIndex = event.getRowIndex();
+        trace(String.valueOf(rowIndex));
+        if ((rowIndex >= 0) && (rowData == null)) {
+            throw new IllegalArgumentException("rowIndex=" + rowIndex
+                    + " but rowData is null");
+        } else if ((rowIndex == -1) && (rowData != null)) {
+            throw new IllegalArgumentException("rowIndex=" + rowIndex
+                    + " but rowData is not null");
+        } else if (rowIndex < -1) {
+            throw new IllegalArgumentException("rowIndex=" + rowIndex);
+        }
+
+    }
+
+    // ---------------------------------------------------------- Static Methods
+    private static StringBuffer trace = new StringBuffer();
+
+    public static String trace() {
+        return (trace.toString());
+    }
+
+    public static void trace(String value) {
+        if (value == null) {
+            trace = new StringBuffer();
+        } else {
+            trace.append('/');
+            trace.append(value);
+        }
+    }
+}

--- a/api/src/test/java/jakarta/faces/model/MockedJavaBean.java
+++ b/api/src/test/java/jakarta/faces/model/MockedJavaBean.java
@@ -1,0 +1,177 @@
+/*
+ * Copyright (c) 1997, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.faces.model;
+
+/**
+ * <p>
+ * JavaBean for data model tests.</p>
+ */
+class MockedJavaBean {
+
+    // -------------------------------------------------------------- Properties
+    /**
+     * A boolean property.
+     */
+    private boolean booleanProperty = true;
+
+    public boolean getBooleanProperty() {
+        return (booleanProperty);
+    }
+
+    public void setBooleanProperty(boolean booleanProperty) {
+        this.booleanProperty = booleanProperty;
+    }
+
+    /**
+     * A boolean property that uses an "is" method for the getter.
+     */
+    private boolean booleanSecond = true;
+
+    public boolean isBooleanSecond() {
+        return (booleanSecond);
+    }
+
+    public void setBooleanSecond(boolean booleanSecond) {
+        this.booleanSecond = booleanSecond;
+    }
+
+    /**
+     * A byte property.
+     */
+    private byte byteProperty = (byte) 121;
+
+    public byte getByteProperty() {
+        return (this.byteProperty);
+    }
+
+    public void setByteProperty(byte byteProperty) {
+        this.byteProperty = byteProperty;
+    }
+
+    /**
+     * A double property.
+     */
+    private double doubleProperty = 321.0;
+
+    public double getDoubleProperty() {
+        return (this.doubleProperty);
+    }
+
+    public void setDoubleProperty(double doubleProperty) {
+        this.doubleProperty = doubleProperty;
+    }
+
+    /**
+     * A float property.
+     */
+    private float floatProperty = (float) 123.0;
+
+    public float getFloatProperty() {
+        return (this.floatProperty);
+    }
+
+    public void setFloatProperty(float floatProperty) {
+        this.floatProperty = floatProperty;
+    }
+
+    /**
+     * An integer property.
+     */
+    private int intProperty = 123;
+
+    public int getIntProperty() {
+        return (this.intProperty);
+    }
+
+    public void setIntProperty(int intProperty) {
+        this.intProperty = intProperty;
+    }
+
+    /**
+     * A long property.
+     */
+    private long longProperty = 321;
+
+    public long getLongProperty() {
+        return (this.longProperty);
+    }
+
+    public void setLongProperty(long longProperty) {
+        this.longProperty = longProperty;
+    }
+
+    /**
+     * A String property with an initial value of null.
+     */
+    private String nullProperty = null;
+
+    public String getNullProperty() {
+        return (this.nullProperty);
+    }
+
+    public void setNullProperty(String nullProperty) {
+        this.nullProperty = nullProperty;
+    }
+
+    /**
+     * A read-only String property.
+     */
+    private String readOnlyProperty = "Read Only String Property";
+
+    public String getReadOnlyProperty() {
+        return (this.readOnlyProperty);
+    }
+
+    /**
+     * A short property.
+     */
+    private short shortProperty = (short) 987;
+
+    public short getShortProperty() {
+        return (this.shortProperty);
+    }
+
+    public void setShortProperty(short shortProperty) {
+        this.shortProperty = shortProperty;
+    }
+
+    /**
+     * A String property.
+     */
+    private String stringProperty = "This is a string";
+
+    public String getStringProperty() {
+        return (this.stringProperty);
+    }
+
+    public void setStringProperty(String stringProperty) {
+        this.stringProperty = stringProperty;
+    }
+
+    /**
+     * A write-only String property.
+     */
+    private String writeOnlyProperty = "Write Only String Property";
+
+    public String getWriteOnlyPropertyValue() {
+        return (this.writeOnlyProperty);
+    }
+
+    public void setWriteOnlyProperty(String writeOnlyProperty) {
+        this.writeOnlyProperty = writeOnlyProperty;
+    }
+}

--- a/api/src/test/java/jakarta/faces/model/MockedResultSet.java
+++ b/api/src/test/java/jakarta/faces/model/MockedResultSet.java
@@ -1,0 +1,1164 @@
+/*
+ * Copyright (c) 1997, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.faces.model;
+
+import java.beans.IntrospectionException;
+import java.beans.Introspector;
+import java.beans.PropertyDescriptor;
+import java.io.InputStream;
+import java.io.Reader;
+import java.math.BigDecimal;
+import java.net.URL;
+import java.sql.Array;
+import java.sql.Blob;
+import java.sql.Clob;
+import java.sql.Date;
+import java.sql.NClob;
+import java.sql.Ref;
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.sql.RowId;
+import java.sql.SQLException;
+import java.sql.SQLWarning;
+import java.sql.SQLXML;
+import java.sql.Statement;
+import java.sql.Time;
+import java.sql.Timestamp;
+import java.util.Arrays;
+import java.util.Calendar;
+import java.util.Map;
+
+/**
+ * <p>
+ * Mock object that implements enough of <code>java.sql.ResultSet</code> to
+ * exercise the <code>ResultSetDataModel</code> functionality. It wraps an array
+ * of JavaBeans objects that are passed to the constructor.</p>
+ */
+public class MockedResultSet implements ResultSet {
+
+    // ------------------------------------------------------------ Constructors
+    /**
+     * <p>
+     * Construct a new <code>MockResultSet</code> instance wrapping the
+     * specified array of beans.</p>
+     *
+     * @param beans Array of beans representing the content of the result set
+     */
+    public MockedResultSet(Object beans[]) {
+        if (beans == null) {
+            throw new NullPointerException();
+        }
+        this.beans = beans;
+        this.clazz = beans.getClass().getComponentType();
+    }
+
+    // ------------------------------------------------------ Instance Variables
+    // Array of beans representing our underlying data
+    private Object beans[] = null;
+
+    // Class representing the underlying data type we are wrapping
+    private Class<?> clazz = null;
+
+    // ResultSetMetaData for this ResultSet
+    private MockedResultSetMetaData metadata = null;
+
+    // Current row number (0 means "before the first row"
+    private int row = 0;
+
+    // ----------------------------------------------------- Implemented Methods
+    @Override
+    public boolean absolute(int row) throws SQLException {
+        if (row == 0) {
+            this.row = 0;
+            return (false);
+        } else if (row > 0) {
+            if (row > beans.length) {
+                this.row = beans.length + 1;
+                return (false);
+            } else {
+                this.row = row;
+                return (true);
+            }
+        } else {
+            this.row = (beans.length + 1) - row;
+            if (row < 1) {
+                row = 0;
+                return (false);
+            } else {
+                return (true);
+            }
+        }
+    }
+
+    @Override
+    public void beforeFirst() throws SQLException {
+        absolute(0);
+    }
+
+    @Override
+    public void close() throws SQLException {
+        // No action required
+    }
+
+    @Override
+    public int getConcurrency() throws SQLException {
+        return (ResultSet.CONCUR_UPDATABLE);
+    }
+
+    @Override
+    public ResultSetMetaData getMetaData() throws SQLException {
+        if (metadata == null) {
+            metadata = new MockedResultSetMetaData(clazz);
+        }
+        return (metadata);
+    }
+
+    @Override
+    public Object getObject(int columnIndex) throws SQLException {
+        return (getObject(getMetaData().getColumnName(columnIndex)));
+    }
+
+    @Override
+    public Object getObject(String columnName) throws SQLException {
+        if ((row <= 0) || (row > beans.length)) {
+            throw new SQLException("Invalid row number " + row);
+        }
+        try {
+            if (columnName.equals("writeOnlyProperty")
+                    && (beans[row - 1] instanceof MockedJavaBean)) {
+                return (((MockedJavaBean) beans[row - 1]).getWriteOnlyPropertyValue());
+            } else if("class".equals(columnName)) {
+                return null;
+            } else {
+                try {
+                    return getPropertyDescriptor(beans[row - 1], columnName).getReadMethod().invoke(beans[row - 1]);
+                } catch (Exception e) {
+                    throw new IllegalStateException(e);
+                }
+            }
+        } catch (Exception e) {
+            throw new SQLException(e.getMessage(), e);
+        }
+    }
+    
+    private static PropertyDescriptor getPropertyDescriptor(Object beanInstance, String propertyName) {
+        try {
+            return Arrays.stream(Introspector.getBeanInfo(beanInstance.getClass()).getPropertyDescriptors())
+                .filter(propertyDescriptor -> propertyName.equals(propertyDescriptor.getName()))
+                .findFirst().orElseThrow();
+        } catch (IntrospectionException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    @Override
+    public int getRow() throws SQLException {
+        return (this.row);
+    }
+
+    @Override
+    public int getType() throws SQLException {
+        return (ResultSet.TYPE_SCROLL_INSENSITIVE);
+    }
+
+    @Override
+    public boolean last() throws SQLException {
+        return (absolute(beans.length));
+    }
+
+    @Override
+    public void updateObject(int columnIndex, Object value)
+            throws SQLException {
+        updateObject(getMetaData().getColumnName(columnIndex), value);
+    }
+
+    @Override
+    public void updateObject(String columnName, Object value)
+            throws SQLException {
+        if ((row <= 0) || (row > beans.length)) {
+            throw new SQLException("Invalid row number " + row);
+        }
+        try {
+            getPropertyDescriptor(beans[row - 1], columnName).getWriteMethod().invoke(beans[row - 1], value);
+        } catch (Exception e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    // --------------------------------------------------- Unimplemented Methods
+    @Override
+    public void afterLast() throws SQLException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void cancelRowUpdates() throws SQLException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void clearWarnings() throws SQLException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void deleteRow() throws SQLException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public int findColumn(String columnName) throws SQLException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean first() throws SQLException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Array getArray(int columnIndex) throws SQLException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Array getArray(String columnName) throws SQLException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public InputStream getAsciiStream(int columnIndex) throws SQLException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public InputStream getAsciiStream(String columnName) throws SQLException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public BigDecimal getBigDecimal(int columnIndex) throws SQLException {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * @deprecated
+     */
+    @Deprecated
+    @Override
+    public BigDecimal getBigDecimal(int columnIndex, int scale)
+            throws SQLException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public BigDecimal getBigDecimal(String columnName) throws SQLException {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * @param columnName
+     * @deprecated
+     */
+    @Deprecated
+    @Override
+    public BigDecimal getBigDecimal(String columnName, int scale)
+            throws SQLException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public InputStream getBinaryStream(int columnIndex) throws SQLException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public InputStream getBinaryStream(String columnName) throws SQLException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Blob getBlob(int columnIndex) throws SQLException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Blob getBlob(String columnName) throws SQLException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean getBoolean(int columnIndex) throws SQLException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean getBoolean(String columnName) throws SQLException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public byte getByte(int columnIndex) throws SQLException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public byte getByte(String columnName) throws SQLException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public byte[] getBytes(int columnIndex) throws SQLException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public byte[] getBytes(String columnName) throws SQLException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Reader getCharacterStream(int columnIndex)
+            throws SQLException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Reader getCharacterStream(String columnName) throws SQLException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Clob getClob(int columnIndex) throws SQLException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Clob getClob(String columnName) throws SQLException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getCursorName() throws SQLException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Date getDate(int columnIndex) throws SQLException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Date getDate(int columnIndex, Calendar cal) throws SQLException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Date getDate(String columnName) throws SQLException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Date getDate(String columnName, Calendar cal) throws SQLException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public double getDouble(int columnIndex) throws SQLException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public double getDouble(String columnName) throws SQLException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public int getFetchDirection() throws SQLException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public int getFetchSize() throws SQLException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public float getFloat(int columnIndex) throws SQLException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public float getFloat(String columnName) throws SQLException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public int getInt(int columnIndex) throws SQLException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public int getInt(String columnName) throws SQLException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public long getLong(int columnIndex) throws SQLException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public long getLong(String columnName) throws SQLException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Object getObject(int columnIndex, Map<String, Class<?>> map) throws SQLException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Object getObject(String columnName, Map<String, Class<?>> map) throws SQLException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Ref getRef(int columnIndex) throws SQLException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Ref getRef(String columnName) throws SQLException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public short getShort(int columnIndex) throws SQLException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public short getShort(String columnName) throws SQLException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Statement getStatement() throws SQLException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getString(int columnIndex) throws SQLException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getString(String columnName) throws SQLException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Time getTime(int columnIndex) throws SQLException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Time getTime(int columnIndex, Calendar cal) throws SQLException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Time getTime(String columnName) throws SQLException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Time getTime(String columnName, Calendar cal) throws SQLException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Timestamp getTimestamp(int columnIndex) throws SQLException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Timestamp getTimestamp(int columnIndex, Calendar cal)
+            throws SQLException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Timestamp getTimestamp(String columnName) throws SQLException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Timestamp getTimestamp(String columnName, Calendar cal)
+            throws SQLException {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * @deprecated
+     */
+    @Deprecated
+    @Override
+    public InputStream getUnicodeStream(int columnIndex) throws SQLException {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * @param columnName
+     * @deprecated
+     */
+    @Deprecated
+    @Override
+    public InputStream getUnicodeStream(String columnName) throws SQLException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public URL getURL(int columnIndex) throws SQLException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public URL getURL(String columnName) throws SQLException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public SQLWarning getWarnings() throws SQLException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void insertRow() throws SQLException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isAfterLast() throws SQLException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isBeforeFirst() throws SQLException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isFirst() throws SQLException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isLast() throws SQLException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void moveToCurrentRow() throws SQLException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void moveToInsertRow() throws SQLException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean next() throws SQLException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean previous() throws SQLException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void refreshRow() throws SQLException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean relative(int rows) throws SQLException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean rowDeleted() throws SQLException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean rowInserted() throws SQLException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean rowUpdated() throws SQLException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setFetchDirection(int direction) throws SQLException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setFetchSize(int size) throws SQLException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void updateArray(int columnPosition, Array x)
+            throws SQLException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void updateArray(String columnName, Array x)
+            throws SQLException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void updateAsciiStream(int columnPosition, InputStream x, int len)
+            throws SQLException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void updateAsciiStream(String columnName, InputStream x, int len)
+            throws SQLException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void updateBigDecimal(int columnPosition, BigDecimal x)
+            throws SQLException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void updateBigDecimal(String columnName, BigDecimal x)
+            throws SQLException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void updateBinaryStream(int columnPosition, InputStream x, int len)
+            throws SQLException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void updateBinaryStream(String columnName, InputStream x, int len)
+            throws SQLException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void updateBlob(int columnPosition, Blob x)
+            throws SQLException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void updateBlob(String columnName, Blob x)
+            throws SQLException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void updateBoolean(int columnPosition, boolean x)
+            throws SQLException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void updateBoolean(String columnName, boolean x)
+            throws SQLException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void updateByte(int columnPosition, byte x)
+            throws SQLException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void updateByte(String columnName, byte x)
+            throws SQLException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void updateBytes(int columnPosition, byte x[])
+            throws SQLException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void updateBytes(String columnName, byte x[])
+            throws SQLException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void updateCharacterStream(int columnPosition, Reader x, int len)
+            throws SQLException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void updateCharacterStream(String columnName, Reader x, int len)
+            throws SQLException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void updateClob(int columnPosition, Clob x)
+            throws SQLException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void updateClob(String columnName, Clob x)
+            throws SQLException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void updateDate(int columnPosition, Date x)
+            throws SQLException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void updateDate(String columnName, Date x)
+            throws SQLException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void updateDouble(int columnPosition, double x)
+            throws SQLException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void updateDouble(String columnName, double x)
+            throws SQLException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void updateFloat(int columnPosition, float x)
+            throws SQLException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void updateFloat(String columnName, float x)
+            throws SQLException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void updateInt(int columnPosition, int x)
+            throws SQLException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void updateInt(String columnName, int x)
+            throws SQLException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void updateLong(int columnPosition, long x)
+            throws SQLException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void updateLong(String columnName, long x)
+            throws SQLException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void updateNull(int columnPosition)
+            throws SQLException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void updateNull(String columnName)
+            throws SQLException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void updateObject(int columnPosition, Object x, int scale)
+            throws SQLException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void updateObject(String columnName, Object x, int scale)
+            throws SQLException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void updateRef(int columnPosition, Ref x)
+            throws SQLException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void updateRef(String columnName, Ref x)
+            throws SQLException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void updateRow() throws SQLException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void updateShort(int columnPosition, short x)
+            throws SQLException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void updateShort(String columnName, short x)
+            throws SQLException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void updateString(int columnPosition, String x)
+            throws SQLException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void updateString(String columnName, String x)
+            throws SQLException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void updateTime(int columnPosition, Time x)
+            throws SQLException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void updateTime(String columnName, Time x)
+            throws SQLException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void updateTimestamp(int columnPosition, Timestamp x)
+            throws SQLException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void updateTimestamp(String columnName, Timestamp x)
+            throws SQLException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean wasNull() throws SQLException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public int getHoldability() throws SQLException {
+        throw new UnsupportedOperationException("Not supported yet.");
+    }
+
+    @Override
+    public Reader getNCharacterStream(int columnIndex) throws SQLException {
+        throw new UnsupportedOperationException("Not supported yet.");
+    }
+
+    @Override
+    public Reader getNCharacterStream(String columnLabel) throws SQLException {
+        throw new UnsupportedOperationException("Not supported yet.");
+    }
+
+    @Override
+    public NClob getNClob(int columnIndex) throws SQLException {
+        throw new UnsupportedOperationException("Not supported yet.");
+    }
+
+    @Override
+    public NClob getNClob(String columnLabel) throws SQLException {
+        throw new UnsupportedOperationException("Not supported yet.");
+    }
+
+    @Override
+    public String getNString(int columnIndex) throws SQLException {
+        throw new UnsupportedOperationException("Not supported yet.");
+    }
+
+    @Override
+    public String getNString(String columnLabel) throws SQLException {
+        throw new UnsupportedOperationException("Not supported yet.");
+    }
+
+    @Override
+    public RowId getRowId(int columnIndex) throws SQLException {
+        throw new UnsupportedOperationException("Not supported yet.");
+    }
+
+    @Override
+    public RowId getRowId(String columnLabel) throws SQLException {
+        throw new UnsupportedOperationException("Not supported yet.");
+    }
+
+    @Override
+    public SQLXML getSQLXML(int columnIndex) throws SQLException {
+        throw new UnsupportedOperationException("Not supported yet.");
+    }
+
+    @Override
+    public SQLXML getSQLXML(String columnLabel) throws SQLException {
+        throw new UnsupportedOperationException("Not supported yet.");
+    }
+
+    @Override
+    public boolean isClosed() throws SQLException {
+        throw new UnsupportedOperationException("Not supported yet.");
+    }
+
+    @Override
+    public void updateAsciiStream(int columnIndex, InputStream x, long length) throws SQLException {
+        throw new UnsupportedOperationException("Not supported yet.");
+    }
+
+    @Override
+    public void updateAsciiStream(String columnLabel, InputStream x, long length) throws SQLException {
+        throw new UnsupportedOperationException("Not supported yet.");
+    }
+
+    @Override
+    public void updateAsciiStream(int columnIndex, InputStream x) throws SQLException {
+        throw new UnsupportedOperationException("Not supported yet.");
+    }
+
+    @Override
+    public void updateAsciiStream(String columnLabel, InputStream x) throws SQLException {
+        throw new UnsupportedOperationException("Not supported yet.");
+    }
+
+    @Override
+    public void updateBinaryStream(int columnIndex, InputStream x, long length) throws SQLException {
+        throw new UnsupportedOperationException("Not supported yet.");
+    }
+
+    @Override
+    public void updateBinaryStream(String columnLabel, InputStream x, long length) throws SQLException {
+        throw new UnsupportedOperationException("Not supported yet.");
+    }
+
+    @Override
+    public void updateBinaryStream(int columnIndex, InputStream x) throws SQLException {
+        throw new UnsupportedOperationException("Not supported yet.");
+    }
+
+    @Override
+    public void updateBinaryStream(String columnLabel, InputStream x) throws SQLException {
+        throw new UnsupportedOperationException("Not supported yet.");
+    }
+
+    @Override
+    public void updateBlob(int columnIndex, InputStream inputStream, long length) throws SQLException {
+        throw new UnsupportedOperationException("Not supported yet.");
+    }
+
+    @Override
+    public void updateBlob(String columnLabel, InputStream inputStream, long length) throws SQLException {
+        throw new UnsupportedOperationException("Not supported yet.");
+    }
+
+    @Override
+    public void updateBlob(int columnIndex, InputStream inputStream) throws SQLException {
+        throw new UnsupportedOperationException("Not supported yet.");
+    }
+
+    @Override
+    public void updateBlob(String columnLabel, InputStream inputStream) throws SQLException {
+        throw new UnsupportedOperationException("Not supported yet.");
+    }
+
+    @Override
+    public void updateCharacterStream(int columnIndex, Reader x, long length) throws SQLException {
+        throw new UnsupportedOperationException("Not supported yet.");
+    }
+
+    @Override
+    public void updateCharacterStream(String columnLabel, Reader reader, long length) throws SQLException {
+        throw new UnsupportedOperationException("Not supported yet.");
+    }
+
+    @Override
+    public void updateCharacterStream(int columnIndex, Reader x) throws SQLException {
+        throw new UnsupportedOperationException("Not supported yet.");
+    }
+
+    @Override
+    public void updateCharacterStream(String columnLabel, Reader reader) throws SQLException {
+        throw new UnsupportedOperationException("Not supported yet.");
+    }
+
+    @Override
+    public void updateClob(int columnIndex, Reader reader, long length) throws SQLException {
+        throw new UnsupportedOperationException("Not supported yet.");
+    }
+
+    @Override
+    public void updateClob(String columnLabel, Reader reader, long length) throws SQLException {
+        throw new UnsupportedOperationException("Not supported yet.");
+    }
+
+    @Override
+    public void updateClob(int columnIndex, Reader reader) throws SQLException {
+        throw new UnsupportedOperationException("Not supported yet.");
+    }
+
+    @Override
+    public void updateClob(String columnLabel, Reader reader) throws SQLException {
+        throw new UnsupportedOperationException("Not supported yet.");
+    }
+
+    @Override
+    public void updateNCharacterStream(int columnIndex, Reader x, long length) throws SQLException {
+        throw new UnsupportedOperationException("Not supported yet.");
+    }
+
+    @Override
+    public void updateNCharacterStream(String columnLabel, Reader reader, long length) throws SQLException {
+        throw new UnsupportedOperationException("Not supported yet.");
+    }
+
+    @Override
+    public void updateNCharacterStream(int columnIndex, Reader x) throws SQLException {
+        throw new UnsupportedOperationException("Not supported yet.");
+    }
+
+    @Override
+    public void updateNCharacterStream(String columnLabel, Reader reader) throws SQLException {
+        throw new UnsupportedOperationException("Not supported yet.");
+    }
+
+    @Override
+    public void updateNClob(int columnIndex, NClob nClob) throws SQLException {
+        throw new UnsupportedOperationException("Not supported yet.");
+    }
+
+    @Override
+    public void updateNClob(String columnLabel, NClob nClob) throws SQLException {
+        throw new UnsupportedOperationException("Not supported yet.");
+    }
+
+    @Override
+    public void updateNClob(int columnIndex, Reader reader, long length) throws SQLException {
+        throw new UnsupportedOperationException("Not supported yet.");
+    }
+
+    @Override
+    public void updateNClob(String columnLabel, Reader reader, long length) throws SQLException {
+        throw new UnsupportedOperationException("Not supported yet.");
+    }
+
+    @Override
+    public void updateNClob(int columnIndex, Reader reader) throws SQLException {
+        throw new UnsupportedOperationException("Not supported yet.");
+    }
+
+    @Override
+    public void updateNClob(String columnLabel, Reader reader) throws SQLException {
+        throw new UnsupportedOperationException("Not supported yet.");
+    }
+
+    @Override
+    public void updateNString(int columnIndex, String nString) throws SQLException {
+        throw new UnsupportedOperationException("Not supported yet.");
+    }
+
+    @Override
+    public void updateNString(String columnLabel, String nString) throws SQLException {
+        throw new UnsupportedOperationException("Not supported yet.");
+    }
+
+    @Override
+    public void updateRowId(int columnIndex, RowId x) throws SQLException {
+        throw new UnsupportedOperationException("Not supported yet.");
+    }
+
+    @Override
+    public void updateRowId(String columnLabel, RowId x) throws SQLException {
+        throw new UnsupportedOperationException("Not supported yet.");
+    }
+
+    @Override
+    public void updateSQLXML(int columnIndex, SQLXML xmlObject) throws SQLException {
+        throw new UnsupportedOperationException("Not supported yet.");
+    }
+
+    @Override
+    public void updateSQLXML(String columnLabel, SQLXML xmlObject) throws SQLException {
+        throw new UnsupportedOperationException("Not supported yet.");
+    }
+
+    @Override
+    public boolean isWrapperFor(Class<?> iface) throws SQLException {
+        throw new UnsupportedOperationException("Not supported yet.");
+    }
+
+    @Override
+    public <T> T unwrap(Class<T> iface) throws SQLException {
+        throw new UnsupportedOperationException("Not supported yet.");
+    }
+
+    @Override
+    public <T> T getObject(int columnIndex, Class<T> type) throws SQLException {
+        throw new UnsupportedOperationException("Not supported yet.");
+    }
+
+    @Override
+    public <T> T getObject(String columnLabel, Class<T> type) throws SQLException {
+        throw new UnsupportedOperationException("Not supported yet.");
+    }
+}

--- a/api/src/test/java/jakarta/faces/model/MockedResultSetMetaData.java
+++ b/api/src/test/java/jakarta/faces/model/MockedResultSetMetaData.java
@@ -1,0 +1,179 @@
+/*
+ * Copyright (c) 1997, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.faces.model;
+
+import java.beans.Introspector;
+import java.beans.PropertyDescriptor;
+import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
+
+/**
+ * <p>
+ * Mock object that implements enough of <code>java.sql.ResultSetMetaData</code>
+ * to exercise the <code>ResultSetDataModel</code> functionality.</p>
+ */
+public class MockedResultSetMetaData implements ResultSetMetaData {
+
+    // ------------------------------------------------------------ Constructors
+    /**
+     * <p>
+     * Construct a new <code>ResultSetMetaData</code> object wrapping the
+     * properties of the specified Java class.</p>
+     *
+     * @param clazz Class whose properties we treat like columns
+     */
+    public MockedResultSetMetaData(Class<?> clazz) throws SQLException {
+        try {
+            descriptors
+                    = Introspector.getBeanInfo(clazz).getPropertyDescriptors();
+        } catch (Exception e) {
+            throw new SQLException(e.getMessage());
+        }
+    }
+
+    // ------------------------------------------------------ Instance Variables
+
+    // The PropertyDescriptors for the Class we are wrapping
+    private PropertyDescriptor descriptors[] = null;
+
+    // ---------------------------------------------------------- Public Methods
+    public PropertyDescriptor getDescriptor(int columnIndex)
+            throws SQLException {
+        try {
+            return (descriptors[columnIndex - 1]);
+        } catch (IndexOutOfBoundsException e) {
+            throw new SQLException("Invalid columnIndex " + columnIndex);
+        }
+    }
+
+    // ----------------------------------------------------- Implemented Methods
+    @Override
+    public String getColumnClassName(int columnIndex) throws SQLException {
+        return (getDescriptor(columnIndex).getPropertyType().getName());
+    }
+
+    @Override
+    public int getColumnCount() throws SQLException {
+        return (descriptors.length);
+    }
+
+    @Override
+    public String getColumnName(int columnIndex) throws SQLException {
+        return (getDescriptor(columnIndex).getName());
+    }
+
+    @Override
+    public boolean isReadOnly(int columnIndex) throws SQLException {
+        return (getDescriptor(columnIndex).getWriteMethod() == null);
+    }
+
+    // --------------------------------------------------- Unimplemented Methods
+    @Override
+    public String getCatalogName(int columnIndex) throws SQLException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public int getColumnDisplaySize(int columnIndex) throws SQLException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getColumnLabel(int columnIndex) throws SQLException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public int getColumnType(int columnIndex) throws SQLException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getColumnTypeName(int columnIndex) throws SQLException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public int getPrecision(int columnIndex) throws SQLException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public int getScale(int columnIndex) throws SQLException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getSchemaName(int columnIndex) throws SQLException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getTableName(int columnIndex) throws SQLException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isAutoIncrement(int columnIndex) throws SQLException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isCaseSensitive(int columnIndex) throws SQLException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isCurrency(int columnIndex) throws SQLException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isDefinitelyWritable(int columnIndex) throws SQLException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public int isNullable(int columnIndex) throws SQLException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isSearchable(int columnIndex) throws SQLException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isSigned(int columnIndex) throws SQLException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isWritable(int columnIndex) throws SQLException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public <T> T unwrap(Class<T> iface) throws SQLException {
+        throw new UnsupportedOperationException("Not supported yet.");
+    }
+
+    @Override
+    public boolean isWrapperFor(Class<?> iface) throws SQLException {
+        throw new UnsupportedOperationException("Not supported yet.");
+    }
+}

--- a/api/src/test/java/jakarta/faces/model/ResultSetDataModelTestCase.java
+++ b/api/src/test/java/jakarta/faces/model/ResultSetDataModelTestCase.java
@@ -1,0 +1,547 @@
+/*
+ * Copyright (c) 1997, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.faces.model;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.sql.ResultSet;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * <p>
+ * Unit tests for {@link ArrayDataModel}.</p>
+ */
+@SuppressWarnings({ "rawtypes", "unchecked" })
+class ResultSetDataModelTestCase extends DataModelTestCaseBase {
+
+    // ------------------------------------------------------ Instance Variables
+    // The ResultSet passed to our ResultSetDataModel
+    protected ResultSet result = null;
+
+    // ---------------------------------------------------- Overall Test Methods
+    // Set up instance variables required by this test case.
+    @BeforeEach
+    void setUp() throws Exception {
+        beans = new MockedJavaBean[5];
+        for (int i = 0; i < beans.length; i++) {
+            beans[i] = new MockedJavaBean();
+        }
+        configure();
+        result = new MockedResultSet(beans);
+        model = new ResultSetDataModel(result);
+    }
+
+    // ------------------------------------------------- Individual Test Methods
+    // Test ((Map) getRowData()).containsKey()
+    @Test
+    void testRowDataContainsKey() throws Exception {
+        // Position to row 1 and retrieve the corresponding Map
+        model.setRowIndex(1);
+        assertTrue(model.isRowAvailable());
+        Object data = model.getRowData();
+        assertNotNull(data);
+        assertTrue(data instanceof Map);
+        Map map = (Map) data;
+
+        // Test exact match on column names
+        assertTrue(map.containsKey("booleanProperty"));
+        assertTrue(map.containsKey("booleanSecond"));
+        assertTrue(map.containsKey("byteProperty"));
+        assertTrue(map.containsKey("doubleProperty"));
+        assertTrue(map.containsKey("floatProperty"));
+        assertTrue(map.containsKey("intProperty"));
+        assertTrue(map.containsKey("longProperty"));
+        assertTrue(map.containsKey("stringProperty"));
+
+        // Test inexact match on column names
+        assertTrue(map.containsKey("booleanPROPERTY"));
+        assertTrue(map.containsKey("booleanSECOND"));
+        assertTrue(map.containsKey("bytePROPERTY"));
+        assertTrue(map.containsKey("doublePROPERTY"));
+        assertTrue(map.containsKey("floatPROPERTY"));
+        assertTrue(map.containsKey("intPROPERTY"));
+        assertTrue(map.containsKey("longPROPERTY"));
+        assertTrue(map.containsKey("stringPROPERTY"));
+
+        // Test false return on invalid column names
+        assertTrue(!map.containsKey("foo"));
+        assertTrue(!map.containsKey("FOO"));
+        assertTrue(!map.containsKey("bar"));
+        assertTrue(!map.containsKey("BAR"));
+    }
+
+    // Test ((Map) getRowData()).containsValue()
+    @Test
+    void testRowDataContainsValue() throws Exception {
+        // Position to row 1 and retrieve the corresponding Map
+        model.setRowIndex(1);
+        assertTrue(model.isRowAvailable());
+        Object data = model.getRowData();
+        assertNotNull(data);
+        assertTrue(data instanceof Map);
+        Map map = (Map) data;
+
+        // Test positive results
+        assertTrue(map.containsValue(Boolean.TRUE));
+        assertTrue(map.containsValue(Boolean.FALSE));
+        assertTrue(map.containsValue(Byte.valueOf((byte) 1)));
+        assertTrue(map.containsValue(Double.valueOf(100.0)));
+        assertTrue(map.containsValue(Float.valueOf((float) 10.0)));
+        assertTrue(map.containsValue(Integer.valueOf(1000)));
+        assertTrue(map.containsValue(Long.valueOf(10000l)));
+        assertTrue(map.containsValue("This is string 1"));
+
+        // Test negative results
+        assertTrue(!map.containsValue("foo"));
+        assertTrue(!map.containsValue(Integer.valueOf(654321)));
+    }
+
+    // Test ((Map) getRowData()).entrySet()
+    @Test
+    void testRowDataEntrySet() throws Exception {
+        // Position to row 1 and retrieve the corresponding Map
+        model.setRowIndex(1);
+        assertTrue(model.isRowAvailable());
+        Object data = model.getRowData();
+        assertNotNull(data);
+        assertTrue(data instanceof Map);
+        Map map = (Map) data;
+        Set set = map.entrySet();
+
+        // Test exact match postive results
+        assertTrue(set.contains(new TestEntry("booleanProperty", Boolean.FALSE)));
+        assertTrue(set.contains(new TestEntry("booleanSecond", Boolean.TRUE)));
+        assertTrue(set.contains(new TestEntry("byteProperty", Byte.valueOf((byte) 1))));
+        assertTrue(set.contains(new TestEntry("doubleProperty", Double.valueOf(100.0))));
+        assertTrue(set.contains(new TestEntry("floatProperty", Float.valueOf((float) 10.0))));
+        assertTrue(set.contains(new TestEntry("intProperty", Integer.valueOf(1000))));
+        assertTrue(set.contains(new TestEntry("longProperty", Long.valueOf(10000l))));
+        assertTrue(set.contains(new TestEntry("stringProperty", "This is string 1")));
+
+        // Test exact match postive results
+        assertTrue(set.contains(new TestEntry("booleanPROPERTY", Boolean.FALSE)));
+        assertTrue(set.contains(new TestEntry("booleanSECOND", Boolean.TRUE)));
+        assertTrue(set.contains(new TestEntry("bytePROPERTY", Byte.valueOf((byte) 1))));
+        assertTrue(set.contains(new TestEntry("doublePROPERTY", Double.valueOf(100.0))));
+        assertTrue(set.contains(new TestEntry("floatPROPERTY", Float.valueOf((float) 10.0))));
+        assertTrue(set.contains(new TestEntry("intPROPERTY", Integer.valueOf(1000))));
+        assertTrue(set.contains(new TestEntry("longPROPERTY", Long.valueOf(10000l))));
+        assertTrue(set.contains(new TestEntry("stringPROPERTY", "This is string 1")));
+
+        // Test negative results
+        assertTrue(!set.contains(new TestEntry("foo", "bar")));
+        assertTrue(!set.contains(new TestEntry("FOO", "bar")));
+        assertTrue(!set.contains(new TestEntry("baz", "bop")));
+        assertTrue(!set.contains(new TestEntry("BAZ", "bop")));
+
+        // Test other methods
+        assertTrue(!set.isEmpty());
+
+        // Test updating through the entry set
+        Iterator entries = set.iterator();
+        while (entries.hasNext()) {
+            Map.Entry entry = (Map.Entry) entries.next();
+            if ("stringProperty".equalsIgnoreCase((String) entry.getKey())) {
+                entry.setValue("This is string 1 modified");
+            }
+        }
+        assertEquals("This is string 1 modified",
+                beans[1].getStringProperty());
+        assertEquals("This is string 1 modified",
+                map.get("stringProperty"));
+        assertEquals("This is string 1 modified",
+                map.get("stringPROPERTY"));
+        result.absolute(2); // ResultSet indexing is one-relative
+        assertEquals("This is string 1 modified",
+                result.getObject("stringProperty"));
+    }
+
+    // Test ((Map) getRowData()).get()
+    @Test
+    void testRowDataGet() throws Exception {
+        // Position to row 1 and retrieve the corresponding Map
+        model.setRowIndex(1);
+        assertTrue(model.isRowAvailable());
+        Object data = model.getRowData();
+        assertNotNull(data);
+        assertTrue(data instanceof Map);
+        Map map = (Map) data;
+
+        // Test exact match on column names
+        assertEquals(Boolean.FALSE, map.get("booleanProperty"));
+        assertEquals(Boolean.TRUE, map.get("booleanSecond"));
+        assertEquals(Byte.valueOf((byte) 1), map.get("byteProperty"));
+        assertEquals(Double.valueOf(100.0), map.get("doubleProperty"));
+        assertEquals(Float.valueOf((float) 10.0), map.get("floatProperty"));
+        assertEquals(Integer.valueOf(1000), map.get("intProperty"));
+        assertEquals(Long.valueOf(10000l), map.get("longProperty"));
+        assertEquals("This is string 1", map.get("stringProperty"));
+
+        // Test inexact match on column names
+        assertEquals(Boolean.FALSE, map.get("booleanPROPERTY"));
+        assertEquals(Boolean.TRUE, map.get("booleanSECOND"));
+        assertEquals(Byte.valueOf((byte) 1), map.get("bytePROPERTY"));
+        assertEquals(Double.valueOf(100.0), map.get("doublePROPERTY"));
+        assertEquals(Float.valueOf((float) 10.0), map.get("floatPROPERTY"));
+        assertEquals(Integer.valueOf(1000), map.get("intPROPERTY"));
+        assertEquals(Long.valueOf(10000l), map.get("longPROPERTY"));
+        assertEquals("This is string 1", map.get("stringPROPERTY"));
+
+        // Test null return on non-existent column names
+        assertNull(map.get("foo"));
+        assertNull(map.get("FOO"));
+        assertNull(map.get("bar"));
+        assertNull(map.get("bar"));
+    }
+
+    // Test ((Map) getRowData()).keySet()
+    @Test
+    void testRowDataKeySet() throws Exception {
+        // Position to row 1 and retrieve the corresponding Map
+        model.setRowIndex(1);
+        assertTrue(model.isRowAvailable());
+        Object data = model.getRowData();
+        assertNotNull(data);
+        assertTrue(data instanceof Map);
+        Map map = (Map) data;
+        Set set = map.keySet();
+
+        // Test exact match postive results
+        assertTrue(set.contains("booleanProperty"));
+        assertTrue(set.contains("booleanSecond"));
+        assertTrue(set.contains("byteProperty"));
+        assertTrue(set.contains("doubleProperty"));
+        assertTrue(set.contains("floatProperty"));
+        assertTrue(set.contains("intProperty"));
+        assertTrue(set.contains("longProperty"));
+        assertTrue(set.contains("stringProperty"));
+
+        // Test inexact match positive results
+        assertTrue(set.contains("booleanPROPERTY"));
+        assertTrue(set.contains("booleanSECOND"));
+        assertTrue(set.contains("bytePROPERTY"));
+        assertTrue(set.contains("doublePROPERTY"));
+        assertTrue(set.contains("floatPROPERTY"));
+        assertTrue(set.contains("intPROPERTY"));
+        assertTrue(set.contains("longPROPERTY"));
+        assertTrue(set.contains("stringPROPERTY"));
+
+        // Test negative results
+        assertTrue(!set.contains("foo"));
+        assertTrue(!set.contains("FOO"));
+        assertTrue(!set.contains("bar"));
+        assertTrue(!set.contains("BAR"));
+
+        // Test other methods
+        assertTrue(!set.isEmpty());
+    }
+
+    // Test ((Map) getRowData()).put()
+    @Test
+    void testRowDataPut() throws Exception {
+        // Position to row 1 and retrieve the corresponding Map
+        model.setRowIndex(1);
+        assertTrue(model.isRowAvailable());
+        Object data = model.getRowData();
+        assertNotNull(data);
+        assertTrue(data instanceof Map);
+    }
+
+    // Test unsupported operations on ((Map) getRowData())
+    @Test
+    void testRowDataUnsupported() throws Exception {
+        // Position to row 1 and retrieve the corresponding Map
+        model.setRowIndex(1);
+        assertTrue(model.isRowAvailable());
+        Object data = model.getRowData();
+        assertNotNull(data);
+        assertTrue(data instanceof Map);
+        Map map = (Map) data;
+
+        // clear()
+        try {
+            map.clear();
+            fail("Should have thrown UnsupportedOperationException");
+        } catch (UnsupportedOperationException e) {
+            // Expected result
+        }
+
+        // entrySet()
+        Set entrySet = map.entrySet();
+        try {
+            entrySet.add(new TestEntry("foo", "bar"));
+            fail("Should have thrown UnsupportedOperationException");
+        } catch (UnsupportedOperationException e) {
+            // Expected result
+        }
+        List mapEntries = new ArrayList();
+        mapEntries.add(new TestEntry("foo", "bar"));
+        mapEntries.add(new TestEntry("baz", "bop"));
+        try {
+            entrySet.addAll(mapEntries);
+            fail("Should have thrown UnsupportedOperationException");
+        } catch (UnsupportedOperationException e) {
+            // Expected result
+        }
+        try {
+            entrySet.clear();
+            fail("Should have thrown UnsupportedOperationException");
+        } catch (UnsupportedOperationException e) {
+            // Expected result
+        }
+        try {
+            Iterator iterator = entrySet.iterator();
+            iterator.next();
+            iterator.remove();
+            fail("Should have thrown UnsupportedOperationException");
+        } catch (UnsupportedOperationException e) {
+            // Expected result
+        }
+        try {
+            entrySet.remove(new TestEntry("foo", "bar"));
+            fail("Should have thrown UnsupportedOperationException");
+        } catch (UnsupportedOperationException e) {
+            // Expected result
+        }
+        try {
+            entrySet.removeAll(mapEntries);
+            fail("Should have thrown UnsupportedOperationException");
+        } catch (UnsupportedOperationException e) {
+            // Expected result
+        }
+        try {
+            entrySet.retainAll(mapEntries);
+            fail("Should have thrown UnsupportedOperationException");
+        } catch (UnsupportedOperationException e) {
+            // Expected result
+        }
+
+        // keySet()
+        Set keySet = map.keySet();
+        try {
+            keySet.add("foo");
+            fail("Should have thrown UnsupportedOperationException");
+        } catch (UnsupportedOperationException e) {
+            // Expected result
+        }
+        List mapKeys = new ArrayList();
+        mapKeys.add("foo");
+        mapKeys.add("bar");
+        try {
+            keySet.addAll(mapKeys);
+            fail("Should have thrown UnsupportedOperationException");
+        } catch (UnsupportedOperationException e) {
+            // Expected result
+        }
+        try {
+            keySet.clear();
+            fail("Should have thrown UnsupportedOperationException");
+        } catch (UnsupportedOperationException e) {
+            // Expected result
+        }
+        try {
+            Iterator iterator = keySet.iterator();
+            iterator.next();
+            iterator.remove();
+            fail("Should have thrown UnsupportedOperationException");
+        } catch (UnsupportedOperationException e) {
+            // Expected result
+        }
+        try {
+            keySet.remove(new TestEntry("foo", "bar"));
+            fail("Should have thrown UnsupportedOperationException");
+        } catch (UnsupportedOperationException e) {
+            // Expected result
+        }
+        try {
+            keySet.removeAll(mapKeys);
+            fail("Should have thrown UnsupportedOperationException");
+        } catch (UnsupportedOperationException e) {
+            // Expected result
+        }
+        try {
+            keySet.retainAll(mapKeys);
+            fail("Should have thrown UnsupportedOperationException");
+        } catch (UnsupportedOperationException e) {
+            // Expected result
+        }
+
+        // remove()
+        try {
+            map.remove("foo");
+            fail("Should have thrown UnsupportedOperationException");
+        } catch (UnsupportedOperationException e) {
+            // Expected result
+        }
+
+        // values()
+        Collection values = map.values();
+        try {
+            values.add("foo");
+            fail("Should have thrown UnsupportedOperationException");
+        } catch (UnsupportedOperationException e) {
+            // Expected result
+        }
+        List list = new ArrayList();
+        list.add("foo");
+        list.add("bar");
+        try {
+            values.addAll(list);
+            fail("Should have thrown UnsupportedOperationException");
+        } catch (UnsupportedOperationException e) {
+            // Expected result
+        }
+        try {
+            values.clear();
+            fail("Should have thrown UnsupportedOperationException");
+        } catch (UnsupportedOperationException e) {
+            // Expected result
+        }
+        try {
+            Iterator iterator = values.iterator();
+            iterator.next();
+            iterator.remove();
+            fail("Should have thrown UnsupportedOperationException");
+        } catch (UnsupportedOperationException e) {
+            // Expected result
+        }
+        try {
+            values.remove("foo");
+            fail("Should have thrown UnsupportedOperationException");
+        } catch (UnsupportedOperationException e) {
+            // Expected result
+        }
+        try {
+            values.removeAll(list);
+            fail("Should have thrown UnsupportedOperationException");
+        } catch (UnsupportedOperationException e) {
+            // Expected result
+        }
+        try {
+            values.retainAll(list);
+            fail("Should have thrown UnsupportedOperationException");
+        } catch (UnsupportedOperationException e) {
+            // Expected result
+        }
+
+    }
+
+    // Test ((Map) getRowData()).values()
+    @Test
+    void testRowDataValues() throws Exception {
+        // Position to row 1 and retrieve the corresponding Map
+        model.setRowIndex(1);
+        assertTrue(model.isRowAvailable());
+        Object data = model.getRowData();
+        assertNotNull(data);
+        assertTrue(data instanceof Map);
+        Map map = (Map) data;
+        Collection values = map.values();
+
+        // Test positive results
+        assertTrue(values.contains(Boolean.TRUE));
+        assertTrue(values.contains(Boolean.FALSE));
+        assertTrue(values.contains(Byte.valueOf((byte) 1)));
+        assertTrue(values.contains(Double.valueOf(100.0)));
+        assertTrue(values.contains(Float.valueOf((float) 10.0)));
+        assertTrue(values.contains(Integer.valueOf(1000)));
+        assertTrue(values.contains(Long.valueOf(10000l)));
+        assertTrue(values.contains("This is string 1"));
+
+        // Test negative results
+        assertTrue(!values.contains("foo"));
+        assertTrue(!values.contains(Integer.valueOf(654321)));
+
+        // Test other methods
+        assertTrue(!values.isEmpty());
+    }
+
+    // ------------------------------------------------------- Protected Methods
+    @Override
+    protected MockedJavaBean data() throws Exception {
+        Object data = model.getRowData();
+        assertTrue(data instanceof Map);
+        MockedJavaBean bean = new MockedJavaBean();
+        Map map = (Map) data;
+
+        bean.setBooleanProperty(((Boolean) map.get("booleanProperty")).booleanValue());
+        bean.setBooleanSecond(((Boolean) map.get("booleanSecond")).booleanValue());
+        bean.setByteProperty(((Byte) map.get("byteProperty")).byteValue());
+        bean.setDoubleProperty(((Double) map.get("doubleProperty")).doubleValue());
+        bean.setFloatProperty(((Float) map.get("floatProperty")).floatValue());
+        bean.setIntProperty(((Integer) map.get("intProperty")).intValue());
+        bean.setLongProperty(((Long) map.get("longProperty")).longValue());
+        bean.setNullProperty((String) map.get("nullProperty"));
+        bean.setShortProperty(((Short) map.get("shortProperty")).shortValue());
+        bean.setStringProperty((String) map.get("stringProperty"));
+        bean.setWriteOnlyProperty((String) map.get("writeOnlyPropertyValue"));
+
+        return (bean);
+    }
+
+    class TestEntry implements Map.Entry {
+
+        public TestEntry(Object key, Object value) {
+            this.key = key;
+            this.value = value;
+        }
+
+        private Object key;
+        private Object value;
+
+        @Override
+        public Object getKey() {
+            return key;
+        }
+
+        @Override
+        public Object getValue() {
+            return value;
+        }
+
+        @Override
+        public Object setValue(Object value) {
+            Object previous = this.value;
+            this.value = value;
+            return previous;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (!(o instanceof Map.Entry)) {
+                return (false);
+            }
+            Map.Entry e = (Map.Entry) o;
+            return (key == null
+                    ? e.getKey() == null : key.equals(e.getKey()))
+                    && (value == null
+                    ? e.getValue() == null : value.equals(e.getValue()));
+        }
+    }
+}

--- a/api/src/test/java/jakarta/faces/model/ScalarDataModelTestCase.java
+++ b/api/src/test/java/jakarta/faces/model/ScalarDataModelTestCase.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 1997, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.faces.model;
+
+import org.junit.jupiter.api.BeforeEach;
+
+/**
+ * <p>
+ * Unit tests for {@link ScalarDataModel}.</p>
+ */
+class ScalarDataModelTestCase extends DataModelTestCaseBase {
+
+    // ------------------------------------------------------ Instance Variables
+    // ---------------------------------------------------- Overall Test Methods
+    // Set up instance variables required by this test case.
+    @BeforeEach
+    void setUp() throws Exception {
+        beans = new MockedJavaBean[1];
+        beans[0] = new MockedJavaBean();
+        configure();
+        model = new ScalarDataModel<MockedJavaBean>(beans[0]);
+    }
+
+    // ------------------------------------------------- Individual Test Methods
+    // ------------------------------------------------------- Protected Methods
+}

--- a/api/src/test/java/jakarta/faces/validator/BeanValidatorTest.java
+++ b/api/src/test/java/jakarta/faces/validator/BeanValidatorTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2022, 2022 Contributors to Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.faces.validator;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+/**
+ * <p>Unit tests for {@link BeanValidator}.</p>
+ *
+ * @author rmartinc
+ */
+class BeanValidatorTest {
+
+    /**
+     * Test class for the bean validator.
+     */
+    public static class TestBean {
+
+        @NotNull
+        @Size(min = 1, max = 64)
+        private String message;
+
+        public String getMessage() {
+            return message;
+        }
+
+        void setMessage(String message) {
+            this.message = message;
+        }
+    }
+
+    // ------------------------------------------------- Individual Test Methods
+//    @Test
+//    void testMessageOK() {
+//        BeanValidator validator = new BeanValidator();
+//        Locale.setDefault(Locale.US);
+//        FacesContext facesContext = Mockito.mock(FacesContext.class);
+//        facesContext.getViewRoot().setLocale(Locale.US);
+//        UIInput component = new UIInput();
+//        request.setAttribute("test", new TestBean());
+//        component.setValueExpression("value", application.getExpressionFactory().createValueExpression(facesContext.getELContext(), "#{test.message}", String.class));
+//
+//        validator.validate(facesContext, component, "something");
+//    }
+//
+//    @Test
+//    void testMessageKO() {
+//        BeanValidator validator = new BeanValidator();
+//        Locale.setDefault(Locale.US);
+//        FacesContext facesContext = Mockito.mock(FacesContext.class);
+//        facesContext.getViewRoot().setLocale(Locale.US);
+//        UIInput component = new UIInput();
+//        request.setAttribute("test", new TestBean());
+//        component.setValueExpression("value", application.getExpressionFactory().createValueExpression(facesContext.getELContext(), "#{test.message}", String.class));
+//
+//        try {
+//            validator.validate(facesContext, component, "");
+//            Assertions.fail("ValidatorException expected");
+//        } catch (ValidatorException e) {
+//            Assertions.assertEquals("size must be between 1 and 64", e.getMessage());
+//        }
+//    }
+//
+//    @Test
+//    void testNoBase() {
+//        BeanValidator validator = new BeanValidator();
+//        Locale.setDefault(Locale.US);
+//        FacesContext facesContext = Mockito.mock(FacesContext.class);
+//        facesContext.getViewRoot().setLocale(Locale.US);
+//        UIInput component = new UIInput();
+//        component.setValueExpression("value", application.getExpressionFactory().createValueExpression(facesContext.getELContext(), "#{something}", String.class));
+//
+//        validator.validate(facesContext, component, "something");
+//    }
+}

--- a/api/src/test/java/jakarta/faces/validator/CastingValidatorTest.java
+++ b/api/src/test/java/jakarta/faces/validator/CastingValidatorTest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 1997, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.faces.validator;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * <p>
+ * Unit tests for JLS casting rules</p>
+ */
+class CastingValidatorTest {
+
+    @Test
+    @SuppressWarnings("rawtypes")
+    void testWithGenericCanCastToRaw() {
+        Validator<?> validatorWithGeneric = (context, component, value) -> {};
+        Validator validatorRaw = validatorWithGeneric;
+        assertNotNull(validatorRaw);
+    }
+
+}

--- a/api/src/test/java/jakarta/faces/validator/DoubleRangeValidatorTest.java
+++ b/api/src/test/java/jakarta/faces/validator/DoubleRangeValidatorTest.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 1997, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.faces.validator;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.util.Locale;
+
+import jakarta.faces.component.UIInput;
+import jakarta.faces.context.FacesContext;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * <p>
+ * Unit tests for {@link DoubleRangeValidator}.</p>
+ */
+class DoubleRangeValidatorTest extends ValidatorTestBase {
+
+    // ------------------------------------------------- Individual Test Methods
+    @Test
+    void testLocaleHonored() {
+        DoubleRangeValidator validator = new DoubleRangeValidator();
+        validator.setMinimum(10.1);
+        validator.setMaximum(20.1);
+        boolean exceptionThrown = false;
+        UIInput component = new UIInput();
+        String message;
+        FacesContext facesContext = mockFacesContextWithLocale(Locale.US);
+
+        try {
+            validator.validate(facesContext, component, "5.1");
+            fail("Exception not thrown");
+        } catch (ValidatorException e) {
+            exceptionThrown = true;
+            message = e.getMessage();
+            assertTrue(
+                    -1 != message.indexOf("10.1"), "message: \"" + message + "\" missing localized chars.");
+            assertTrue(
+                    -1 != message.indexOf("20.1"), "message: \"" + message + "\" missing localized chars.");
+        }
+        assertTrue(exceptionThrown);
+
+        exceptionThrown = false;
+        facesContext = mockFacesContextWithLocale(Locale.GERMAN);
+
+        try {
+            validator.validate(facesContext, component, "5");
+            fail("Exception not thrown");
+        } catch (ValidatorException e) {
+            exceptionThrown = true;
+            message = e.getMessage();
+            assertTrue(
+                    -1 != message.indexOf("10,1"), "message: \"" + message + "\" missing localized chars.");
+            assertTrue(
+                    -1 != message.indexOf("20,1"), "message: \"" + message + "\" missing localized chars.");
+        }
+        assertTrue(exceptionThrown);
+    }
+
+    @Test
+    void testHashCode() {
+        DoubleRangeValidator validator1 = new DoubleRangeValidator();
+        DoubleRangeValidator validator2 = new DoubleRangeValidator();
+
+        validator1.setMinimum(10.0d);
+        validator1.setMaximum(15.1d);
+        validator2.setMinimum(10.0d);
+        validator2.setMaximum(15.1d);
+
+        assertTrue(validator1.hashCode() == validator2.hashCode());
+        assertTrue(validator1.hashCode() == validator2.hashCode());
+
+        validator2.setMaximum(15.2d);
+
+        assertTrue(validator1.hashCode() != validator2.hashCode());
+
+        validator1 = new DoubleRangeValidator();
+        validator2 = new DoubleRangeValidator();
+
+        validator1.setMinimum(10.0d);
+        validator2.setMinimum(10.0d);
+
+        assertTrue(validator1.hashCode() == validator2.hashCode());
+        assertTrue(validator1.hashCode() == validator2.hashCode());
+
+        validator1.setMinimum(11.0d);
+
+        assertTrue(validator1.hashCode() != validator2.hashCode());
+
+        validator1.setMinimum(10.0d);
+        validator1.setMaximum(10.1d);
+
+        assertTrue(validator1.hashCode() != validator2.hashCode());
+    }
+}

--- a/api/src/test/java/jakarta/faces/validator/LengthValidatorTest.java
+++ b/api/src/test/java/jakarta/faces/validator/LengthValidatorTest.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 1997, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.faces.validator;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.util.Locale;
+
+import jakarta.faces.component.UIInput;
+import jakarta.faces.context.FacesContext;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * <p>
+ * Unit tests for {@link LengthValidator}.</p>
+ */
+class LengthValidatorTest extends ValidatorTestBase {
+
+    // ------------------------------------------------- Individual Test Methods
+    @Test
+    void testLocaleHonored() {
+        LengthValidator validator = new LengthValidator();
+        validator.setMinimum(1000);
+        validator.setMaximum(2000);
+        boolean exceptionThrown = false;
+        UIInput component = new UIInput();
+        String message;
+        FacesContext facesContext = mockFacesContextWithLocale(Locale.US);
+
+        try {
+            validator.validate(facesContext, component,
+                    "Not at all long enough");
+            fail("Exception not thrown");
+        } catch (ValidatorException e) {
+            exceptionThrown = true;
+            message = e.getMessage();
+            assertTrue(
+                    -1 != message.indexOf("1,000"), "message: \"" + message + "\" missing localized chars.");
+        }
+        assertTrue(exceptionThrown);
+
+        exceptionThrown = false;
+        facesContext = mockFacesContextWithLocale(Locale.GERMAN);
+
+        try {
+            validator.validate(facesContext, component,
+                    "Still not long enough");
+            fail("Exception not thrown");
+        } catch (ValidatorException e) {
+            exceptionThrown = true;
+            message = e.getMessage();
+            assertTrue(
+                    -1 != message.indexOf("1.000"), "message: \"" + message + "\" missing localized chars.");
+        }
+        assertTrue(exceptionThrown);
+    }
+
+    @Test
+    void testHashCode() {
+        LengthValidator validator1 = new LengthValidator();
+        LengthValidator validator2 = new LengthValidator();
+
+        validator1.setMinimum(10);
+        validator1.setMaximum(15);
+        validator2.setMinimum(10);
+        validator2.setMaximum(15);
+
+        assertTrue(validator1.hashCode() == validator2.hashCode());
+        assertTrue(validator1.hashCode() == validator2.hashCode());
+
+        validator2.setMaximum(16);
+
+        assertTrue(validator1.hashCode() != validator2.hashCode());
+
+        validator1 = new LengthValidator();
+        validator2 = new LengthValidator();
+
+        validator1.setMinimum(10);
+        validator2.setMinimum(10);
+
+        assertTrue(validator1.hashCode() == validator2.hashCode());
+        assertTrue(validator1.hashCode() == validator2.hashCode());
+
+        validator1.setMinimum(11);
+
+        assertTrue(validator1.hashCode() != validator2.hashCode());
+
+        validator1.setMinimum(10);
+        validator1.setMaximum(10);
+
+        assertTrue(validator1.hashCode() != validator2.hashCode());
+    }
+}

--- a/api/src/test/java/jakarta/faces/validator/LongRangeValidatorTest.java
+++ b/api/src/test/java/jakarta/faces/validator/LongRangeValidatorTest.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 1997, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.faces.validator;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.util.Locale;
+
+import jakarta.faces.component.UIInput;
+import jakarta.faces.context.FacesContext;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * <p>
+ * Unit tests for {@link LongRangeValidator}.</p>
+ */
+class LongRangeValidatorTest extends ValidatorTestBase {
+
+    // ------------------------------------------------- Individual Test Methods
+    @Test
+    void testLocaleHonored() {
+        LongRangeValidator validator = new LongRangeValidator();
+        validator.setMinimum(10100);
+        validator.setMaximum(20100);
+        boolean exceptionThrown = false;
+        UIInput component = new UIInput();
+        String message;
+        FacesContext facesContext = mockFacesContextWithLocale(Locale.US);
+
+        try {
+            validator.validate(facesContext, component, "5100");
+            fail("Exception not thrown");
+        } catch (ValidatorException e) {
+            exceptionThrown = true;
+            message = e.getMessage();
+            assertTrue(
+                    -1 != message.indexOf("10,100"), "message: \"" + message + "\" missing localized chars.");
+            assertTrue(
+                    -1 != message.indexOf("20,100"), "message: \"" + message + "\" missing localized chars.");
+        }
+        assertTrue(exceptionThrown);
+
+        exceptionThrown = false;
+        facesContext = mockFacesContextWithLocale(Locale.GERMAN);
+
+        try {
+            validator.validate(facesContext, component, "5100");
+            fail("Exception not thrown");
+        } catch (ValidatorException e) {
+            exceptionThrown = true;
+            message = e.getMessage();
+            assertTrue(
+                    -1 != message.indexOf("10.100"), "message: \"" + message + "\" missing localized chars.");
+            assertTrue(
+                    -1 != message.indexOf("20.100"), "message: \"" + message + "\" missing localized chars.");
+        }
+        assertTrue(exceptionThrown);
+    }
+
+    @Test
+    void testHashCode() {
+        LongRangeValidator validator1 = new LongRangeValidator();
+        LongRangeValidator validator2 = new LongRangeValidator();
+
+        validator1.setMinimum(10l);
+        validator1.setMaximum(15l);
+        validator2.setMinimum(10l);
+        validator2.setMaximum(15l);
+
+        assertTrue(validator1.hashCode() == validator2.hashCode());
+        assertTrue(validator1.hashCode() == validator2.hashCode());
+
+        validator2.setMaximum(16l);
+
+        assertTrue(validator1.hashCode() != validator2.hashCode());
+
+        validator1 = new LongRangeValidator();
+        validator2 = new LongRangeValidator();
+
+        validator1.setMinimum(10l);
+        validator2.setMinimum(10l);
+
+        assertTrue(validator1.hashCode() == validator2.hashCode());
+        assertTrue(validator1.hashCode() == validator2.hashCode());
+
+        validator1.setMinimum(11l);
+
+        assertTrue(validator1.hashCode() != validator2.hashCode());
+
+        validator1.setMinimum(10l);
+        validator1.setMaximum(11l);
+
+        assertTrue(validator1.hashCode() != validator2.hashCode());
+    }
+}

--- a/api/src/test/java/jakarta/faces/validator/RegexValidatorTest.java
+++ b/api/src/test/java/jakarta/faces/validator/RegexValidatorTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 1997, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.faces.validator;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.util.Locale;
+
+import jakarta.faces.component.UIInput;
+import jakarta.faces.context.FacesContext;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * <p>
+ * Unit tests for {@link RegexValidator}.</p>
+ */
+class RegexValidatorTest extends ValidatorTestBase {
+
+    // ------------------------------------------------- Individual Test Methods
+    @Test
+    void testPatternMatch() {
+        String patternStr = "t.*";
+        RegexValidator validator = new RegexValidator();
+        validator.setPattern(patternStr);
+        UIInput component = new UIInput();
+        String checkme = "test";
+        FacesContext facesContext = mockFacesContext();
+        try {
+            validator.validate(facesContext, component, checkme);
+            assertTrue(true);
+        } catch (ValidatorException ve) {
+            fail("Exception thrown " + ve.getMessage());
+        }
+    }
+
+    @Test
+    void testPatterMismatch() {
+        String patternStr = "t.*";
+        FacesContext facesContext = mockFacesContextWithLocale(Locale.US);
+        RegexValidator validator = new RegexValidator();
+        validator.setPattern(patternStr);
+        UIInput component = new UIInput();
+        String checkme = "jest";
+        try {
+            validator.validate(facesContext, component, checkme);
+            fail("Exception not thrown when tested " + checkme + " against " + patternStr);
+        } catch (ValidatorException ve) {
+            String detail = ve.getFacesMessage().getDetail();
+            assertTrue(detail.equalsIgnoreCase("Regex pattern of 't.*' not matched"));
+        }
+    }
+}

--- a/api/src/test/java/jakarta/faces/validator/RequiredValidatorTest.java
+++ b/api/src/test/java/jakarta/faces/validator/RequiredValidatorTest.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 1997, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.faces.validator;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * The JUnit tests for the RequiredValidator class.
+ */
+class RequiredValidatorTest {
+
+    /**
+     * Test validate method.
+     */
+    @Test
+    void testValidate() {
+        RequiredValidator validator = new RequiredValidator();
+        validator.validate(null, null, "notempty");
+    }
+}

--- a/api/src/test/java/jakarta/faces/validator/ValidatorTestBase.java
+++ b/api/src/test/java/jakarta/faces/validator/ValidatorTestBase.java
@@ -1,0 +1,57 @@
+package jakarta.faces.validator;
+
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+import java.util.Locale;
+
+import jakarta.faces.application.Application;
+import jakarta.faces.component.UIViewRoot;
+import jakarta.faces.context.FacesContext;
+import jakarta.faces.convert.NumberConverter;
+import jakarta.faces.render.RenderKit;
+
+import org.junit.jupiter.api.AfterEach;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+abstract class ValidatorTestBase {
+
+    private MockedStatic<FacesContext> mockStaticFacesContext;
+
+    FacesContext mockFacesContext() {
+        return mockFacesContextWithLocale(Locale.getDefault());
+    }
+
+    FacesContext mockFacesContextWithLocale(Locale locale) {
+        Locale.setDefault(locale);
+
+        UIViewRoot mockedViewRoot = Mockito.mock(UIViewRoot.class);
+        when(mockedViewRoot.getLocale()).thenReturn(locale);
+        when(mockedViewRoot.getViewId()).thenReturn("/viewId");
+
+        Application mockedApplication = Mockito.mock(Application.class);
+        when(mockedApplication.createConverter(NumberConverter.CONVERTER_ID)).thenReturn(new NumberConverter());
+
+        RenderKit mockedRenderKit = Mockito.mock(RenderKit.class);
+
+        FacesContext mockedFacesContext = Mockito.mock(FacesContext.class);
+        when(mockedFacesContext.getViewRoot()).thenReturn(mockedViewRoot);
+        when(mockedFacesContext.getApplication()).thenReturn(mockedApplication);
+        when(mockedFacesContext.getRenderKit()).thenReturn(mockedRenderKit);
+
+        closeMockStaticFacesContextIfNecessary();
+        mockStaticFacesContext = mockStatic(FacesContext.class);
+        mockStaticFacesContext.when(FacesContext::getCurrentInstance).thenReturn(mockedFacesContext);
+
+        return mockedFacesContext;
+    }
+
+    @AfterEach
+    void closeMockStaticFacesContextIfNecessary() {
+        if (mockStaticFacesContext != null) {
+            mockStaticFacesContext.close();
+            mockStaticFacesContext = null;
+        }
+    }
+}


### PR DESCRIPTION
so there are at least unit tests for standard converters, validators and models
also fixed the FacesWrapperTestCase which broke after removal of powermock in 4.0/4.1

PR in Mojarra side: https://github.com/eclipse-ee4j/mojarra/pull/5470