### PR TITLE
Fix failing tests after adding generics to converters

### DIFF
--- a/api/src/test/java/jakarta/faces/convert/BigIntegerConverterTest.java
+++ b/api/src/test/java/jakarta/faces/convert/BigIntegerConverterTest.java
@@ -98,7 +98,7 @@ class BigIntegerConverterTest {
     void testGetAsString3() {
         BigIntegerConverter converter = new BigIntegerConverter();
         FacesContext facesContext = Mockito.mock(FacesContext.class);
-        assertEquals("123", converter.getAsString(facesContext, new UIPanel(), "123"));
+        assertEquals("123", converter.getAsString(facesContext, new UIPanel(), new BigInteger("123")));
     }
 
     /**

--- a/api/src/test/java/jakarta/faces/convert/DoubleConverterTest.java
+++ b/api/src/test/java/jakarta/faces/convert/DoubleConverterTest.java
@@ -96,7 +96,7 @@ class DoubleConverterTest {
     void testGetAsString3() {
         DoubleConverter converter = new DoubleConverter();
         FacesContext facesContext = Mockito.mock(FacesContext.class);
-        assertEquals("12.3", converter.getAsString(facesContext, new UIPanel(), "12.3"));
+        assertEquals("12.3", converter.getAsString(facesContext, new UIPanel(), (double) 12.3));
     }
 
     /**

--- a/api/src/test/java/jakarta/faces/convert/FloatConverterTest.java
+++ b/api/src/test/java/jakarta/faces/convert/FloatConverterTest.java
@@ -96,7 +96,7 @@ class FloatConverterTest {
     void testGetAsString3() {
         FloatConverter converter = new FloatConverter();
         FacesContext facesContext = Mockito.mock(FacesContext.class);
-        assertEquals("12.3", converter.getAsString(facesContext, new UIPanel(), "12.3"));
+        assertEquals("12.3", converter.getAsString(facesContext, new UIPanel(), (float) 12.3));
     }
 
     /**

--- a/api/src/test/java/jakarta/faces/convert/IntegerConverterTest.java
+++ b/api/src/test/java/jakarta/faces/convert/IntegerConverterTest.java
@@ -96,7 +96,7 @@ class IntegerConverterTest {
     void testGetAsString3() {
         IntegerConverter converter = new IntegerConverter();
         FacesContext facesContext = Mockito.mock(FacesContext.class);
-        assertEquals("123", converter.getAsString(facesContext, new UIPanel(), "123"));
+        assertEquals("123", converter.getAsString(facesContext, new UIPanel(), 123));
     }
 
     /**

--- a/api/src/test/java/jakarta/faces/convert/LongConverterTest.java
+++ b/api/src/test/java/jakarta/faces/convert/LongConverterTest.java
@@ -96,7 +96,7 @@ class LongConverterTest {
     void testGetAsString3() {
         LongConverter converter = new LongConverter();
         FacesContext facesContext = Mockito.mock(FacesContext.class);
-        assertEquals("123", converter.getAsString(facesContext, new UIPanel(), "123"));
+        assertEquals("123", converter.getAsString(facesContext, new UIPanel(), (long) 123));
     }
 
     /**

--- a/api/src/test/java/jakarta/faces/convert/ShortConverterTest.java
+++ b/api/src/test/java/jakarta/faces/convert/ShortConverterTest.java
@@ -96,7 +96,7 @@ class ShortConverterTest {
     void testGetAsString3() {
         ShortConverter converter = new ShortConverter();
         FacesContext facesContext = Mockito.mock(FacesContext.class);
-        assertEquals("123", converter.getAsString(facesContext, new UIPanel(), "123"));
+        assertEquals("123", converter.getAsString(facesContext, new UIPanel(), (short) 123));
     }
 
     /**


### PR DESCRIPTION
Update #1822: converter unit tests were as per https://github.com/jakartaee/faces/pull/1941 migrated from Mojarra project at same moment as original #1822 was fixed. But these caused compilation errors after changes in #1822 and still need to catch up