### PR TITLE
Add new tck for #1443

### DIFF
--- a/api/src/main/java/jakarta/faces/event/AfterPhase.java
+++ b/api/src/main/java/jakarta/faces/event/AfterPhase.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package jakarta.faces.event;
+
+import static jakarta.faces.event.PhaseId.ANY_PHASE;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import jakarta.enterprise.util.AnnotationLiteral;
+import jakarta.inject.Qualifier;
+
+/**
+ * <p class="changed_added_5_0">
+ * This qualifier allows you to observe after phase events via CDI.
+ * This event must be fired synchronously after all phase listeners have been invoked.
+ * </p>
+ * @since 5.0
+ * @see BeforePhase
+ */
+@Qualifier
+@Target(PARAMETER)
+@Retention(RUNTIME)
+@Documented
+public @interface AfterPhase {
+
+    /**
+     * <p>
+     * The phase ID on which the after phase event needs to be observed. Defaults to {@link PhaseId#ANY_PHASE}.
+     * </p>
+     */
+    PhaseId value() default ANY_PHASE;
+
+    /**
+     * <p>
+     * Supports inline instantiation of the {@link AfterPhase} qualifier.
+     * </p>
+     */
+    public static final class Literal extends AnnotationLiteral<AfterPhase> implements AfterPhase {
+
+        private static final long serialVersionUID = 1L;
+
+        /**
+         * Default instance of the {@link AfterPhase} qualifier.
+         */
+        public static final Literal INSTANCE = of(ANY_PHASE);
+
+        private final PhaseId value;
+
+        public static Literal of(PhaseId value) {
+            return new Literal(value);
+        }
+
+        private Literal(PhaseId value) {
+            this.value = value;
+        }
+
+        @Override
+        public PhaseId value() {
+            return value;
+        }
+    }
+}

--- a/api/src/main/java/jakarta/faces/event/BeforePhase.java
+++ b/api/src/main/java/jakarta/faces/event/BeforePhase.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package jakarta.faces.event;
+
+import static jakarta.faces.event.PhaseId.ANY_PHASE;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import jakarta.enterprise.util.AnnotationLiteral;
+import jakarta.inject.Qualifier;
+
+/**
+ * <p class="changed_added_5_0">
+ * This qualifier allows you to observe before phase events via CDI.
+ * This event must be fired synchronously before any phase listener has been invoked.
+ * </p>
+ * @since 5.0
+ * @see AfterPhase
+ */
+@Qualifier
+@Target(PARAMETER)
+@Retention(RUNTIME)
+@Documented
+public @interface BeforePhase {
+
+    /**
+     * <p>
+     * The phase ID on which the before phase event needs to be observed. Defaults to {@link PhaseId#ANY_PHASE}.
+     * </p>
+     */
+    PhaseId value() default ANY_PHASE;
+
+    /**
+     * <p>
+     * Supports inline instantiation of the {@link BeforePhase} qualifier.
+     * </p>
+     */
+    public static final class Literal extends AnnotationLiteral<BeforePhase> implements BeforePhase {
+
+        private static final long serialVersionUID = 1L;
+
+        /**
+         * Default instance of the {@link BeforePhase} qualifier.
+         */
+        public static final Literal INSTANCE = of(ANY_PHASE);
+
+        private final PhaseId value;
+
+        public static Literal of(PhaseId value) {
+            return new Literal(value);
+        }
+
+        private Literal(PhaseId value) {
+            this.value = value;
+        }
+
+        @Override
+        public PhaseId value() {
+            return value;
+        }
+    }
+}

--- a/tck/faces50/phaseEvents/pom.xml
+++ b/tck/faces50/phaseEvents/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) Contributors to Eclipse Foundation.
+    Copyright (c) 2024 Contributors to Eclipse Foundation.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -20,27 +20,17 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>org.eclipse.ee4j.faces.tck</groupId>
-        <artifactId>jakarta-faces-tck</artifactId>
+        <groupId>org.eclipse.ee4j.tck.faces.faces50</groupId>
+        <artifactId>pom</artifactId>
         <version>5.0.0-SNAPSHOT</version>
     </parent>
 
-    <groupId>org.eclipse.ee4j.tck.faces.faces50</groupId>
-    <artifactId>pom</artifactId>
-    <packaging>pom</packaging>
+    <artifactId>phaseEvents</artifactId>
+    <packaging>war</packaging>
 
-    <name>Jakarta Faces TCK ${project.version} - Test - Faces 5.0</name>
+    <name>Jakarta Faces TCK ${project.version} - Test - Faces 5.0 - phaseEvents</name>
 
-    <modules>
-        <module>facelets</module>
-        <module>phaseEvents</module>
-    </modules>
-
-    <dependencies>
-        <dependency>
-            <groupId>org.eclipse.ee4j.tck.faces.test</groupId>
-            <artifactId>util</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-    </dependencies>
+    <build>
+        <finalName>test-faces50-phaseEvents</finalName>
+    </build>
 </project>

--- a/tck/faces50/phaseEvents/src/main/java/org/eclipse/ee4j/tck/faces/faces50/phaseEvents/Spec1443Bean.java
+++ b/tck/faces50/phaseEvents/src/main/java/org/eclipse/ee4j/tck/faces/faces50/phaseEvents/Spec1443Bean.java
@@ -85,11 +85,11 @@ public class Spec1443Bean {
     }
 
     public void observeAfterPhaseUpdateModelValues(@Observes @AfterPhase(PhaseId.UPDATE_MODEL_VALUES) PhaseEvent event) {
-        observedPhases.add("afterPhaseUpdateModelValuesL " + event.getPhaseId());
+        observedPhases.add("afterPhaseUpdateModelValues: " + event.getPhaseId());
     }
 
     public void observeAfterPhaseRenderResponse(@Observes @AfterPhase(PhaseId.RENDER_RESPONSE) PhaseEvent event) {
-        observedPhases.add("afterPhaseRenderResponseL " + event.getPhaseId());
+        observedPhases.add("afterPhaseRenderResponse: " + event.getPhaseId());
     }
 
     public void observeAfterPhaseAny(@Observes @AfterPhase(PhaseId.ANY_PHASE) PhaseEvent event) {

--- a/tck/faces50/phaseEvents/src/main/java/org/eclipse/ee4j/tck/faces/faces50/phaseEvents/Spec1443Bean.java
+++ b/tck/faces50/phaseEvents/src/main/java/org/eclipse/ee4j/tck/faces/faces50/phaseEvents/Spec1443Bean.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2024 Contributors to Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package org.eclipse.ee4j.tck.faces.faces50.phaseEvents;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import jakarta.enterprise.context.RequestScoped;
+import jakarta.enterprise.event.Observes;
+import jakarta.faces.event.AfterPhase;
+import jakarta.faces.event.BeforePhase;
+import jakarta.faces.event.PhaseEvent;
+import jakarta.faces.event.PhaseId;
+import jakarta.inject.Named;
+
+@Named
+@RequestScoped
+public class Spec1443Bean {
+
+    private List<String> observedPhases = new ArrayList<>();
+
+    public void observeBeforePhaseDefault(@Observes @BeforePhase PhaseEvent event) {
+        observedPhases.add("beforePhaseDefault: " + event.getPhaseId());
+    }
+
+    public void observeBeforePhaseRestoreView(@Observes @BeforePhase(PhaseId.RESTORE_VIEW) PhaseEvent event) {
+        observedPhases.add("beforePhaseRestoreView: " + event.getPhaseId());
+    }
+
+    public void observeBeforePhaseApplyRequestValues(@Observes @BeforePhase(PhaseId.APPLY_REQUEST_VALUES) PhaseEvent event) {
+        observedPhases.add("beforePhaseApplyRequestValues: " + event.getPhaseId());
+    }
+
+    public void observeBeforePhaseProcessValidations(@Observes @BeforePhase(PhaseId.PROCESS_VALIDATIONS) PhaseEvent event) {
+        observedPhases.add("beforePhaseProcessValidations: " + event.getPhaseId());
+    }
+
+    public void observeBeforePhaseInvokeApplication(@Observes @BeforePhase(PhaseId.INVOKE_APPLICATION) PhaseEvent event) {
+        observedPhases.add("beforePhaseInvokeApplication: " + event.getPhaseId());
+    }
+
+    public void observeBeforePhaseUpdateModelValues(@Observes @BeforePhase(PhaseId.UPDATE_MODEL_VALUES) PhaseEvent event) {
+        observedPhases.add("beforePhaseUpdateModelValues: " + event.getPhaseId());
+    }
+
+    public void observeBeforePhaseRenderResponse(@Observes @BeforePhase(PhaseId.RENDER_RESPONSE) PhaseEvent event) {
+        observedPhases.add("beforePhaseRenderResponse: " + event.getPhaseId());
+    }
+
+    public void observeBeforePhaseAny(@Observes @BeforePhase(PhaseId.ANY_PHASE) PhaseEvent event) {
+        observedPhases.add("beforeBeforePhaseAny: " + event.getPhaseId());
+    }
+
+    public void observeAfterPhaseDefault(@Observes @AfterPhase PhaseEvent event) {
+        observedPhases.add("afterPhaseDefault: " + event.getPhaseId());
+    }
+
+    public void observeAfterPhaseRestoreView(@Observes @AfterPhase(PhaseId.RESTORE_VIEW) PhaseEvent event) {
+        observedPhases.add("afterPhaseRestoreView: " + event.getPhaseId());
+    }
+
+    public void observeAfterPhaseApplyRequestValues(@Observes @AfterPhase(PhaseId.APPLY_REQUEST_VALUES) PhaseEvent event) {
+        observedPhases.add("afterPhaseApplyRequestValues: " + event.getPhaseId());
+    }
+
+    public void observeAfterPhaseProcessValidations(@Observes @AfterPhase(PhaseId.PROCESS_VALIDATIONS) PhaseEvent event) {
+        observedPhases.add("afterPhaseProcessValidations: " + event.getPhaseId());
+    }
+
+    public void observeAfterPhaseInvokeApplication(@Observes @AfterPhase(PhaseId.INVOKE_APPLICATION) PhaseEvent event) {
+        observedPhases.add("afterPhaseInvokeApplication: " + event.getPhaseId());
+    }
+
+    public void observeAfterPhaseUpdateModelValues(@Observes @AfterPhase(PhaseId.UPDATE_MODEL_VALUES) PhaseEvent event) {
+        observedPhases.add("afterPhaseUpdateModelValuesL " + event.getPhaseId());
+    }
+
+    public void observeAfterPhaseRenderResponse(@Observes @AfterPhase(PhaseId.RENDER_RESPONSE) PhaseEvent event) {
+        observedPhases.add("afterPhaseRenderResponseL " + event.getPhaseId());
+    }
+
+    public void observeAfterPhaseAny(@Observes @AfterPhase(PhaseId.ANY_PHASE) PhaseEvent event) {
+        observedPhases.add("afterPhaseAny: " + event.getPhaseId());
+    }
+
+    public List<String> getObservedPhases() {
+        return observedPhases;
+    }
+}

--- a/tck/faces50/phaseEvents/src/main/webapp/WEB-INF/beans.xml
+++ b/tck/faces50/phaseEvents/src/main/webapp/WEB-INF/beans.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2024 Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+<beans
+    xmlns="https://jakarta.ee/xml/ns/jakartaee"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_4_1.xsd"
+    version="4.1" bean-discovery-mode="annotated">
+</beans>

--- a/tck/faces50/phaseEvents/src/main/webapp/WEB-INF/faces-config.xml
+++ b/tck/faces50/phaseEvents/src/main/webapp/WEB-INF/faces-config.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2024 Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+<faces-config 
+    xmlns="https://jakarta.ee/xml/ns/jakartaee"
+    xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance" 
+    xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-facesconfig_4_0.xsd"
+    version="4.0">
+    <faces-config-extension>
+        <facelets-processing>
+            <file-extension>.xhtmlAsXml</file-extension>
+            <process-as>xml</process-as>
+        </facelets-processing>
+        <facelets-processing>
+            <file-extension>.xhtmlAsXhtml</file-extension>
+            <process-as>xhtml</process-as>
+        </facelets-processing>
+    </faces-config-extension>
+</faces-config>

--- a/tck/faces50/phaseEvents/src/main/webapp/WEB-INF/web.xml
+++ b/tck/faces50/phaseEvents/src/main/webapp/WEB-INF/web.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2024 Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+<web-app
+    xmlns="https://jakarta.ee/xml/ns/jakartaee" 
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+    xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-app_6_0.xsd"
+    version="6.0"
+>
+    <context-param>
+        <param-name>jakarta.faces.PROJECT_STAGE</param-name>
+        <param-value>${webapp.projectStage}</param-value>
+    </context-param>
+    <context-param>
+        <param-name>jakarta.faces.STATE_SAVING_METHOD</param-name>
+        <param-value>${webapp.stateSavingMethod}</param-value>
+    </context-param>    
+    <context-param>
+        <param-name>jakarta.faces.SERIALIZE_SERVER_STATE</param-name>
+        <param-value>${webapp.serializeServerState}</param-value>
+    </context-param>
+
+    <servlet>
+        <servlet-name>facesServlet</servlet-name>
+        <servlet-class>jakarta.faces.webapp.FacesServlet</servlet-class>
+    </servlet>
+    <servlet-mapping>
+        <servlet-name>facesServlet</servlet-name>
+        <url-pattern>*.xhtml</url-pattern>
+        <url-pattern>*.xhtmlAsXhtml</url-pattern>
+        <url-pattern>*.xhtmlAsXml</url-pattern>
+    </servlet-mapping>
+</web-app>

--- a/tck/faces50/phaseEvents/src/main/webapp/spec1443.xhtml
+++ b/tck/faces50/phaseEvents/src/main/webapp/spec1443.xhtml
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<!--
+
+    Copyright (c) 2024 Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+<html xmlns:h="jakarta.faces.html">
+    <h:head>
+        <title>Spec1443: observe phase events via CDI</title>
+    </h:head>
+    <h:body>
+        <h:outputText id="observedPhases" value="#{spec1443Bean.observedPhases}" />
+        <h:form id="form">
+            <h:commandButton id="postback" value="postback" />
+        </h:form>
+    </h:body>
+</html>

--- a/tck/faces50/phaseEvents/src/test/java/org/eclipse/ee4j/tck/faces/faces50/phaseEvents/Deployments.java
+++ b/tck/faces50/phaseEvents/src/test/java/org/eclipse/ee4j/tck/faces/faces50/phaseEvents/Deployments.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2024 Contributors to Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package org.eclipse.ee4j.tck.faces.faces50.phaseEvents;
+
+import org.eu.ingwar.tools.arquillian.extension.suite.annotations.ArquillianSuiteDeployment;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+
+import ee.jakarta.tck.faces.test.util.selenium.BaseITNG;
+
+/**
+ * Given Arquilian has no single deployment testsuite
+ * mechanism we have to rely on a third party library.
+ * This improves the performance in a major area, namely
+ * we are only deploying once and then run all tests
+ * on the same deployment (cuts down by 95% the test time)
+ */
+@ArquillianSuiteDeployment
+public class Deployments {
+    @Deployment(testable = false)
+    public static WebArchive createDeployment() {
+        return BaseITNG.createDeployment();
+    }
+}
+

--- a/tck/faces50/phaseEvents/src/test/java/org/eclipse/ee4j/tck/faces/faces50/phaseEvents/Spec1443IT.java
+++ b/tck/faces50/phaseEvents/src/test/java/org/eclipse/ee4j/tck/faces/faces50/phaseEvents/Spec1443IT.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2024 Contributors to Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package org.eclipse.ee4j.tck.faces.faces50.phaseEvents;
+
+import static org.junit.Assert.assertEquals;
+
+import jakarta.faces.event.AfterPhase;
+import jakarta.faces.event.BeforePhase;
+
+import org.junit.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+
+import ee.jakarta.tck.faces.test.util.selenium.BaseITNG;
+import ee.jakarta.tck.faces.test.util.selenium.WebPage;
+
+public class Spec1443IT extends BaseITNG {
+
+    /**
+     * @see AfterPhase
+     * @see BeforePhase
+     * @see https://github.com/jakartaee/faces/issues/1443
+     */
+    @Test
+    public void testObservedPhases() {
+        WebPage page = getPage("spec1443.xhtml");
+        WebElement observedPhasesOnInitialRequest = page.findElement(By.id("observedPhases"));
+        assertEquals("""
+            [
+                beforePhaseDefault: RESTORE_VIEW 1,
+                beforeBeforePhaseAny: RESTORE_VIEW 1,
+                beforePhaseRestoreView: RESTORE_VIEW 1,
+                afterPhaseRestoreView: RESTORE_VIEW 1,
+                afterPhaseAny: RESTORE_VIEW 1,
+                afterPhaseDefault: RESTORE_VIEW 1,
+                beforePhaseDefault: RENDER_RESPONSE 6,
+                beforeBeforePhaseAny: RENDER_RESPONSE 6,
+                beforePhaseRenderResponse: RENDER_RESPONSE 6
+            ] 
+        """.trim().replaceAll("\s+", " "), observedPhasesOnInitialRequest.getText());
+        
+        WebElement postback = page.findElement(By.id("form:postback"));
+        postback.click();
+
+        WebElement observedPhasesAfterPostback = page.findElement(By.id("observedPhases"));
+        assertEquals("""
+            [
+                beforePhaseDefault: RESTORE_VIEW 1,
+                beforeBeforePhaseAny: RESTORE_VIEW 1,
+                beforePhaseRestoreView: RESTORE_VIEW 1,
+                afterPhaseRestoreView: RESTORE_VIEW 1,
+                afterPhaseAny: RESTORE_VIEW 1,
+                afterPhaseDefault: RESTORE_VIEW 1,
+                beforePhaseDefault: APPLY_REQUEST_VALUES 2,
+                beforeBeforePhaseAny: APPLY_REQUEST_VALUES 2,
+                beforePhaseApplyRequestValues: APPLY_REQUEST_VALUES 2,
+                afterPhaseApplyRequestValues: APPLY_REQUEST_VALUES 2,
+                afterPhaseAny: APPLY_REQUEST_VALUES 2,
+                afterPhaseDefault: APPLY_REQUEST_VALUES 2,
+                beforePhaseDefault: PROCESS_VALIDATIONS 3,
+                beforeBeforePhaseAny: PROCESS_VALIDATIONS 3,
+                beforePhaseProcessValidations: PROCESS_VALIDATIONS 3,
+                afterPhaseProcessValidations: PROCESS_VALIDATIONS 3,
+                afterPhaseAny: PROCESS_VALIDATIONS 3,
+                afterPhaseDefault: PROCESS_VALIDATIONS 3,
+                beforePhaseDefault: UPDATE_MODEL_VALUES 4,
+                beforeBeforePhaseAny: UPDATE_MODEL_VALUES 4,
+                beforePhaseUpdateModelValues: UPDATE_MODEL_VALUES 4,
+                afterPhaseUpdateModelValuesL UPDATE_MODEL_VALUES 4,
+                afterPhaseAny: UPDATE_MODEL_VALUES 4,
+                afterPhaseDefault: UPDATE_MODEL_VALUES 4,
+                beforePhaseDefault: INVOKE_APPLICATION 5,
+                beforeBeforePhaseAny: INVOKE_APPLICATION 5,
+                beforePhaseInvokeApplication: INVOKE_APPLICATION 5,
+                afterPhaseInvokeApplication: INVOKE_APPLICATION 5,
+                afterPhaseAny: INVOKE_APPLICATION 5,
+                afterPhaseDefault: INVOKE_APPLICATION 5,
+                beforePhaseDefault: RENDER_RESPONSE 6,
+                beforeBeforePhaseAny: RENDER_RESPONSE 6,
+                beforePhaseRenderResponse: RENDER_RESPONSE 6
+            ]
+        """.trim().replaceAll("\s+", " "), observedPhasesAfterPostback.getText());
+        
+    }
+}

--- a/tck/faces50/phaseEvents/src/test/java/org/eclipse/ee4j/tck/faces/faces50/phaseEvents/Spec1443IT.java
+++ b/tck/faces50/phaseEvents/src/test/java/org/eclipse/ee4j/tck/faces/faces50/phaseEvents/Spec1443IT.java
@@ -79,7 +79,7 @@ public class Spec1443IT extends BaseITNG {
                 beforePhaseDefault: UPDATE_MODEL_VALUES 4,
                 beforeBeforePhaseAny: UPDATE_MODEL_VALUES 4,
                 beforePhaseUpdateModelValues: UPDATE_MODEL_VALUES 4,
-                afterPhaseUpdateModelValuesL UPDATE_MODEL_VALUES 4,
+                afterPhaseUpdateModelValues: UPDATE_MODEL_VALUES 4,
                 afterPhaseAny: UPDATE_MODEL_VALUES 4,
                 afterPhaseDefault: UPDATE_MODEL_VALUES 4,
                 beforePhaseDefault: INVOKE_APPLICATION 5,


### PR DESCRIPTION
TCK for https://github.com/jakartaee/faces/pull/1965 + https://github.com/eclipse-ee4j/mojarra/pull/5492

NOTE: PR extends https://github.com/jakartaee/faces/pull/1852 which had the first TCK for 5.0 but which cannot be merged due to GlassFish 8 not accepting Faces 5.0.

NOTE: the @AfterPhase of RENDER_RESPONSE can indeed not be asserted because of it being fired after render response ... if we also want to assert it then we need to adjust the test with some robust async update in current view scope retriving the events fired in previous request