### PR TITLE
Fix #1229: ByteConverter: incorrect error message

### DIFF
--- a/api/src/main/java/jakarta/faces/convert/ByteConverter.java
+++ b/api/src/main/java/jakarta/faces/convert/ByteConverter.java
@@ -88,7 +88,7 @@ public class ByteConverter implements Converter<Byte> {
         try {
             return Byte.valueOf(value);
         } catch (NumberFormatException nfe) {
-            throw new ConverterException(MessageFactory.getMessage(context, BYTE_ID, value, "254", MessageFactory.getLabel(context, component)), nfe);
+            throw new ConverterException(MessageFactory.getMessage(context, BYTE_ID, value, "106", MessageFactory.getLabel(context, component)), nfe);
         } catch (Exception e) {
             throw new ConverterException(e);
         }


### PR DESCRIPTION
Closes #2029: replaces 254 with 106 (included into range -128..127)