### PR TITLE
#1935 Choose local and month not impacted by JDK 17/21 formatting changes

### DIFF
--- a/tck/faces22/ajax/pom.xml
+++ b/tck/faces22/ajax/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.eclipse.ee4j.tck.faces.faces22</groupId>
         <artifactId>pom</artifactId>
-        <version>4.0.3-SNAPSHOT</version>
+        <version>4.0.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>ajax</artifactId>

--- a/tck/faces22/cdiBeanValidator/pom.xml
+++ b/tck/faces22/cdiBeanValidator/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.eclipse.ee4j.tck.faces.faces22</groupId>
         <artifactId>pom</artifactId>
-        <version>4.0.3-SNAPSHOT</version>
+        <version>4.0.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>cdiBeanValidator</artifactId>

--- a/tck/faces22/cdiInitDestroyEvent/pom.xml
+++ b/tck/faces22/cdiInitDestroyEvent/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.eclipse.ee4j.tck.faces.faces22</groupId>
         <artifactId>pom</artifactId>
-        <version>4.0.3-SNAPSHOT</version>
+        <version>4.0.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>cdiInitDestroyEvent</artifactId>

--- a/tck/faces22/cdiMethodValidation/pom.xml
+++ b/tck/faces22/cdiMethodValidation/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.eclipse.ee4j.tck.faces.faces22</groupId>
         <artifactId>pom</artifactId>
-        <version>4.0.3-SNAPSHOT</version>
+        <version>4.0.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>cdiMethodValidation</artifactId>

--- a/tck/faces22/cdiMultiTenantSetsTccl/pom.xml
+++ b/tck/faces22/cdiMultiTenantSetsTccl/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.eclipse.ee4j.tck.faces.faces22</groupId>
         <artifactId>pom</artifactId>
-        <version>4.0.3-SNAPSHOT</version>
+        <version>4.0.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>cdiMultiTenantSetsTccl</artifactId>

--- a/tck/faces22/cdiNoBeansXml/pom.xml
+++ b/tck/faces22/cdiNoBeansXml/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.eclipse.ee4j.tck.faces.faces22</groupId>
         <artifactId>pom</artifactId>
-        <version>4.0.3-SNAPSHOT</version>
+        <version>4.0.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>cdiNoBeansXml</artifactId>

--- a/tck/faces22/childCountTest/pom.xml
+++ b/tck/faces22/childCountTest/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.eclipse.ee4j.tck.faces.faces22</groupId>
         <artifactId>pom</artifactId>
-        <version>4.0.3-SNAPSHOT</version>
+        <version>4.0.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>childCountTest</artifactId>

--- a/tck/faces22/compositeComponent/pom.xml
+++ b/tck/faces22/compositeComponent/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.eclipse.ee4j.tck.faces.faces22</groupId>
         <artifactId>pom</artifactId>
-        <version>4.0.3-SNAPSHOT</version>
+        <version>4.0.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>compositeComponent</artifactId>

--- a/tck/faces22/expressionLanguageLambda/pom.xml
+++ b/tck/faces22/expressionLanguageLambda/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.eclipse.ee4j.tck.faces.faces22</groupId>
         <artifactId>pom</artifactId>
-        <version>4.0.3-SNAPSHOT</version>
+        <version>4.0.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>expressionLanguageLambda</artifactId>

--- a/tck/faces22/faceletsTemplate/pom.xml
+++ b/tck/faces22/faceletsTemplate/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.eclipse.ee4j.tck.faces.faces22</groupId>
         <artifactId>pom</artifactId>
-        <version>4.0.3-SNAPSHOT</version>
+        <version>4.0.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>faceletsTemplate</artifactId>

--- a/tck/faces22/multiFieldValidation/pom.xml
+++ b/tck/faces22/multiFieldValidation/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.eclipse.ee4j.tck.faces.faces22</groupId>
         <artifactId>pom</artifactId>
-        <version>4.0.3-SNAPSHOT</version>
+        <version>4.0.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>multiFieldValidation</artifactId>

--- a/tck/faces22/pom.xml
+++ b/tck/faces22/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.eclipse.ee4j.faces.tck</groupId>
         <artifactId>jakarta-faces-tck</artifactId>
-        <version>4.0.3-SNAPSHOT</version>
+        <version>4.0.4-SNAPSHOT</version>
     </parent>
 
     <groupId>org.eclipse.ee4j.tck.faces.faces22</groupId>

--- a/tck/faces22/protectedView/pom.xml
+++ b/tck/faces22/protectedView/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.eclipse.ee4j.tck.faces.faces22</groupId>
         <artifactId>pom</artifactId>
-        <version>4.0.3-SNAPSHOT</version>
+        <version>4.0.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>protectedView</artifactId>

--- a/tck/faces22/viewActionCdiViewScoped/pom.xml
+++ b/tck/faces22/viewActionCdiViewScoped/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.eclipse.ee4j.tck.faces.faces22</groupId>
         <artifactId>pom</artifactId>
-        <version>4.0.3-SNAPSHOT</version>
+        <version>4.0.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>viewActionCdiViewScoped</artifactId>

--- a/tck/faces22/viewExpired/pom.xml
+++ b/tck/faces22/viewExpired/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.eclipse.ee4j.tck.faces.faces22</groupId>
         <artifactId>pom</artifactId>
-        <version>4.0.3-SNAPSHOT</version>
+        <version>4.0.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>viewExpired</artifactId>

--- a/tck/faces22/viewParamNullValueAjax/pom.xml
+++ b/tck/faces22/viewParamNullValueAjax/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.eclipse.ee4j.tck.faces.faces22</groupId>
         <artifactId>pom</artifactId>
-        <version>4.0.3-SNAPSHOT</version>
+        <version>4.0.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>viewParamNullValueAjax</artifactId>

--- a/tck/faces22/viewScope/pom.xml
+++ b/tck/faces22/viewScope/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.eclipse.ee4j.tck.faces.faces22</groupId>
         <artifactId>pom</artifactId>
-        <version>4.0.3-SNAPSHOT</version>
+        <version>4.0.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>viewScope</artifactId>

--- a/tck/faces23/ajax/pom.xml
+++ b/tck/faces23/ajax/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.eclipse.ee4j.tck.faces.faces23</groupId>
         <artifactId>pom</artifactId>
-        <version>4.0.3-SNAPSHOT</version>
+        <version>4.0.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>ajax</artifactId>

--- a/tck/faces23/cdi/pom.xml
+++ b/tck/faces23/cdi/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.eclipse.ee4j.tck.faces.faces23</groupId>
         <artifactId>pom</artifactId>
-        <version>4.0.3-SNAPSHOT</version>
+        <version>4.0.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>cdi</artifactId>

--- a/tck/faces23/commandScript/pom.xml
+++ b/tck/faces23/commandScript/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.eclipse.ee4j.tck.faces.faces23</groupId>
         <artifactId>pom</artifactId>
-        <version>4.0.3-SNAPSHOT</version>
+        <version>4.0.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>commandScript</artifactId>

--- a/tck/faces23/converter/pom.xml
+++ b/tck/faces23/converter/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.eclipse.ee4j.tck.faces.faces23</groupId>
         <artifactId>pom</artifactId>
-        <version>4.0.3-SNAPSHOT</version>
+        <version>4.0.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>converter</artifactId>

--- a/tck/faces23/converter/src/main/java/ee/jakarta/tck/faces/test/javaee8/converter/BackingBean.java
+++ b/tck/faces23/converter/src/main/java/ee/jakarta/tck/faces/test/javaee8/converter/BackingBean.java
@@ -33,7 +33,7 @@ import jakarta.inject.Named;
 public class BackingBean implements Serializable {
     private static final long serialVersionUID = 1544275452223321526L;
 
-    private Locale locale = new Locale("en", "US");
+    private Locale locale = new Locale("nl", "NL");
 
     public Locale getLocale() {
        return locale;

--- a/tck/faces23/converter/src/main/webapp/WEB-INF/faces-config.xml
+++ b/tck/faces23/converter/src/main/webapp/WEB-INF/faces-config.xml
@@ -24,8 +24,8 @@
 
     <application>
         <locale-config>
-            <default-locale>en_US</default-locale>
-            <supported-locale>en_US</supported-locale>
+            <default-locale>nl_NL</default-locale>
+            <supported-locale>nl_NL</supported-locale>
         </locale-config>
     </application>
 

--- a/tck/faces23/converter/src/test/java/ee/jakarta/tck/faces/test/javaee8/converter/Issue4070IT.java
+++ b/tck/faces23/converter/src/test/java/ee/jakarta/tck/faces/test/javaee8/converter/Issue4070IT.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2024, 2025 Contributors to Eclipse Foundation.
  * Copyright (c) 1997, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -17,17 +18,12 @@
 package ee.jakarta.tck.faces.test.javaee8.converter;
 
 import static java.lang.System.getProperty;
-import static java.time.ZonedDateTime.now;
-import static java.time.format.FormatStyle.MEDIUM;
 import static org.jboss.shrinkwrap.api.ShrinkWrap.create;
 import static org.junit.Assert.assertEquals;
 
 import java.io.File;
 import java.net.URL;
-import java.time.ZoneId;
-import java.time.format.DateTimeFormatter;
 import java.time.temporal.Temporal;
-import java.util.Locale;
 
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
@@ -66,7 +62,7 @@ public class Issue4070IT {
     public void setUp() {
         webClient = new WebClient();
         webClient.getOptions().setTimeout(900_000);
-        webClient.addRequestHeader("Accept-Language", "en-US");
+        webClient.addRequestHeader("Accept-Language", "nl-NL");
     }
 
     @After
@@ -80,29 +76,32 @@ public class Issue4070IT {
      * @see https://github.com/eclipse-ee4j/mojarra/issues/4074
      */
     @Test
-    public void testJavaTimeTypes() throws Exception {
-        Locale.setDefault(Locale.US);
+    public void testLocalDateTime() throws Exception {
+        doTestJavaTimeTypes("30 mei 2015 16:14:43", "localDateTime", "2015-05-30T16:14:43");
+    }
 
-        DateTimeFormatter formatter = DateTimeFormatter
-            .ofLocalizedDateTime(
-                MEDIUM, MEDIUM)
-            .withLocale(
-                Locale.US);
+    @Test
+    public void testLocalDate() throws Exception {
+        doTestJavaTimeTypes("30 mei 2015", "localDate", "2015-05-30");
+    }
 
-        String expectedFormat = formatter.format(now(ZoneId.of("America/New_York")));
-        System.out.println("Expected format " + expectedFormat);
+    @Test
+    public void testLocalTime() throws Exception {
+        doTestJavaTimeTypes("16:52:56", "localTime", "16:52:56");
+    }
 
-
-        doTestJavaTimeTypes("Sep 30, 2015, 4:14:43 PM", "localDateTime", "2015-09-30T16:14:43");
-
-        doTestJavaTimeTypes("Sep 30, 2015", "localDate", "2015-09-30");
-
-        doTestJavaTimeTypes("4:52:56 PM", "localTime", "16:52:56");
-
+    @Test
+    public void testOffsetTime() throws Exception {
         doTestJavaTimeTypes("17:07:19.358-04:00", "offsetTime", "17:07:19.358-04:00");
+    }
 
+    @Test
+    public void testOffsetDateTime() throws Exception {
         doTestJavaTimeTypes("2015-09-30T17:24:36.529-04:00", "offsetDateTime", "2015-09-30T17:24:36.529-04:00");
+    }
 
+    @Test
+    public void testZonedDateTime() throws Exception {
         doTestJavaTimeTypes("2015-09-30T17:31:42.09-04:00[America/New_York]", "zonedDateTime", "2015-09-30T17:31:42.090-04:00[America/New_York]");
     }
 
@@ -118,7 +117,7 @@ public class Issue4070IT {
             HtmlSpan output = page.getHtmlElementById(inputId + "Value");
             assertEquals(expected, output.getTextContent());
         } catch (AssertionError e) {
-            System.out.println(page.asXml());
+            System.out.println(page.getHtmlElementById("messages").asXml());
 
             throw e;
         }

--- a/tck/faces23/converter/src/test/java/ee/jakarta/tck/faces/test/javaee8/converter/Issue4087IT.java
+++ b/tck/faces23/converter/src/test/java/ee/jakarta/tck/faces/test/javaee8/converter/Issue4087IT.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2024, 2025 Contributors to Eclipse Foundation.
  * Copyright (c) 1997, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -23,7 +24,6 @@ import static org.junit.Assert.assertTrue;
 import java.io.File;
 import java.net.URL;
 import java.time.temporal.Temporal;
-import java.util.Locale;
 
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
@@ -61,7 +61,7 @@ public class Issue4087IT {
     @Before
     public void setUp() {
         webClient = new WebClient();
-        webClient.addRequestHeader("Accept-Language", "en-US");
+        webClient.addRequestHeader("Accept-Language", "nl-NL");
     }
 
     @After
@@ -76,38 +76,37 @@ public class Issue4087IT {
      */
     @Test
     public void testJavaTimeTypes() throws Exception {
-        Locale.setDefault(Locale.US);
         HtmlPage page = webClient.getPage(webUrl + "faces/issue4087.xhtml");
         HtmlPage page1 = null;
 
         try {
 
             HtmlTextInput input1 = (HtmlTextInput)page.getHtmlElementById("localDateTime1");
-            input1.setValueAttribute("Sep 30, 2015, 4:14:43 PM");
+            input1.setValueAttribute("30 mei 2015 16:14:43");
 
             HtmlTextInput input2 = (HtmlTextInput)page.getHtmlElementById("localDateTime2");
-            input2.setValueAttribute("Sep 30, 2015, 4:14:43 PM");
+            input2.setValueAttribute("30 mei 2015 16:14:43");
 
             HtmlTextInput input3 = (HtmlTextInput)page.getHtmlElementById("localTime1");
-            input3.setValueAttribute("4:14:43 PM");
+            input3.setValueAttribute("16:14:43");
 
             HtmlTextInput input4 = (HtmlTextInput)page.getHtmlElementById("localTime2");
-            input4.setValueAttribute("4:14:43 PM");
+            input4.setValueAttribute("16:14:43");
 
             HtmlSubmitInput submit = (HtmlSubmitInput)page.getHtmlElementById("submit");
             page1 = submit.click();
 
             HtmlSpan time1Output = (HtmlSpan)page1.getHtmlElementById("localDateTimeValue1");
-            assertTrue(time1Output.getTextContent().contains("Sep 30, 2015, 4:14 PM"));
+            assertTrue(time1Output.getTextContent().contains("30 mei 2015 16:14"));
 
             HtmlSpan time2Output = (HtmlSpan)page1.getHtmlElementById("localDateTimeValue2");
-            assertTrue(time2Output.getTextContent().contains("Sep 30, 2015, 4:14 PM"));
+            assertTrue(time2Output.getTextContent().contains("30 mei 2015 16:14"));
 
             HtmlSpan time3Output = (HtmlSpan)page1.getHtmlElementById("localTimeValue1");
-            assertTrue(time3Output.getTextContent().contains("4:14:43 PM"));
+            assertTrue(time3Output.getTextContent().contains("16:14:43"));
 
             HtmlSpan time4Output = (HtmlSpan)page1.getHtmlElementById("localTimeValue2");
-            assertTrue(time4Output.getTextContent().contains("4:14 PM"));
+            assertTrue(time4Output.getTextContent().contains("16:14"));
         } catch (AssertionError w) {
             System.out.println(page.asXml());
             if (page1 != null) {

--- a/tck/faces23/converter/src/test/java/ee/jakarta/tck/faces/test/javaee8/converter/Issue4110IT.java
+++ b/tck/faces23/converter/src/test/java/ee/jakarta/tck/faces/test/javaee8/converter/Issue4110IT.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2024, 2025 Contributors to Eclipse Foundation.
  * Copyright (c) 1997, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -61,7 +62,7 @@ public class Issue4110IT {
     @Before
     public void setUp() {
         webClient = new WebClient();
-        webClient.addRequestHeader("Accept-Language", "en-US");
+        webClient.addRequestHeader("Accept-Language", "nl-NL");
     }
 
     @After
@@ -75,10 +76,18 @@ public class Issue4110IT {
      * @see https://github.com/eclipse-ee4j/mojarra/issues/4114
      */
     @Test
-    public void testJavaTimeTypes() throws Exception {
-        doTestJavaTimeTypes("30 sep. 2015", "localDate", "2015-09-30");
+    public void testLocalDate() throws Exception {
+        doTestJavaTimeTypes("30 mei 2015", "localDate", "2015-05-30");
+    }
+
+    @Test
+    public void testLocalTime() throws Exception {
         doTestJavaTimeTypes("16:52:56", "localTime", "16:52:56");
-        doTestJavaTimeTypes("30 sep. 2015 16:14:43", "localDateTime", "2015-09-30T16:14:43");
+    }
+
+    @Test
+    public void testLocalDateTime() throws Exception {
+        doTestJavaTimeTypes("30 mei 2015 16:14:43", "localDateTime", "2015-05-30T16:14:43");
     }
 
     private void doTestJavaTimeTypes(String value, String type, String expected) throws Exception {

--- a/tck/faces23/disableFaceletToXhtmlMapping/pom.xml
+++ b/tck/faces23/disableFaceletToXhtmlMapping/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.eclipse.ee4j.tck.faces.faces23</groupId>
         <artifactId>pom</artifactId>
-        <version>4.0.3-SNAPSHOT</version>
+        <version>4.0.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>disableFaceletToXhtmlMapping</artifactId>

--- a/tck/faces23/el/pom.xml
+++ b/tck/faces23/el/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.eclipse.ee4j.tck.faces.faces23</groupId>
         <artifactId>pom</artifactId>
-        <version>4.0.3-SNAPSHOT</version>
+        <version>4.0.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>el</artifactId>

--- a/tck/faces23/exactMapping/pom.xml
+++ b/tck/faces23/exactMapping/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.eclipse.ee4j.tck.faces.faces23</groupId>
         <artifactId>pom</artifactId>
-        <version>4.0.3-SNAPSHOT</version>
+        <version>4.0.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>exactMapping</artifactId>

--- a/tck/faces23/faceletCacheFactory/pom.xml
+++ b/tck/faces23/faceletCacheFactory/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.eclipse.ee4j.tck.faces.faces23</groupId>
         <artifactId>pom</artifactId>
-        <version>4.0.3-SNAPSHOT</version>
+        <version>4.0.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>faceletCacheFactory</artifactId>

--- a/tck/faces23/facelets/pom.xml
+++ b/tck/faces23/facelets/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.eclipse.ee4j.tck.faces.faces23</groupId>
         <artifactId>pom</artifactId>
-        <version>4.0.3-SNAPSHOT</version>
+        <version>4.0.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>facelets</artifactId>

--- a/tck/faces23/facesConverter/pom.xml
+++ b/tck/faces23/facesConverter/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.eclipse.ee4j.tck.faces.faces23</groupId>
         <artifactId>pom</artifactId>
-        <version>4.0.3-SNAPSHOT</version>
+        <version>4.0.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>facesConverter</artifactId>

--- a/tck/faces23/facesDataModel/pom.xml
+++ b/tck/faces23/facesDataModel/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.eclipse.ee4j.tck.faces.faces23</groupId>
         <artifactId>pom</artifactId>
-        <version>4.0.3-SNAPSHOT</version>
+        <version>4.0.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>facesDataModel</artifactId>

--- a/tck/faces23/flash/pom.xml
+++ b/tck/faces23/flash/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.eclipse.ee4j.tck.faces.faces23</groupId>
         <artifactId>pom</artifactId>
-        <version>4.0.3-SNAPSHOT</version>
+        <version>4.0.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>flash</artifactId>

--- a/tck/faces23/getViews/pom.xml
+++ b/tck/faces23/getViews/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.eclipse.ee4j.tck.faces.faces23</groupId>
         <artifactId>pom</artifactId>
-        <version>4.0.3-SNAPSHOT</version>
+        <version>4.0.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>getViews</artifactId>

--- a/tck/faces23/importConstants/pom.xml
+++ b/tck/faces23/importConstants/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.eclipse.ee4j.tck.faces.faces23</groupId>
         <artifactId>pom</artifactId>
-        <version>4.0.3-SNAPSHOT</version>
+        <version>4.0.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>importConstants</artifactId>

--- a/tck/faces23/namespacedView/pom.xml
+++ b/tck/faces23/namespacedView/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.eclipse.ee4j.tck.faces.faces23</groupId>
         <artifactId>pom</artifactId>
-        <version>4.0.3-SNAPSHOT</version>
+        <version>4.0.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>namespacedView</artifactId>

--- a/tck/faces23/passthrough/pom.xml
+++ b/tck/faces23/passthrough/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.eclipse.ee4j.tck.faces.faces23</groupId>
         <artifactId>pom</artifactId>
-        <version>4.0.3-SNAPSHOT</version>
+        <version>4.0.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>passthrough</artifactId>

--- a/tck/faces23/pom.xml
+++ b/tck/faces23/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.eclipse.ee4j.faces.tck</groupId>
         <artifactId>jakarta-faces-tck</artifactId>
-        <version>4.0.3-SNAPSHOT</version>
+        <version>4.0.4-SNAPSHOT</version>
     </parent>
 
     <groupId>org.eclipse.ee4j.tck.faces.faces23</groupId>

--- a/tck/faces23/refreshPeriodExplicit/pom.xml
+++ b/tck/faces23/refreshPeriodExplicit/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.eclipse.ee4j.tck.faces.faces23</groupId>
         <artifactId>pom</artifactId>
-        <version>4.0.3-SNAPSHOT</version>
+        <version>4.0.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>refreshPeriodExplicit</artifactId>

--- a/tck/faces23/refreshPeriodProduction/pom.xml
+++ b/tck/faces23/refreshPeriodProduction/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.eclipse.ee4j.tck.faces.faces23</groupId>
         <artifactId>pom</artifactId>
-        <version>4.0.3-SNAPSHOT</version>
+        <version>4.0.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>refreshPeriodProduction</artifactId>

--- a/tck/faces23/searchExpression/pom.xml
+++ b/tck/faces23/searchExpression/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.eclipse.ee4j.tck.faces.faces23</groupId>
         <artifactId>pom</artifactId>
-        <version>4.0.3-SNAPSHOT</version>
+        <version>4.0.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>searchExpression</artifactId>

--- a/tck/faces23/systemEvent/pom.xml
+++ b/tck/faces23/systemEvent/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.eclipse.ee4j.tck.faces.faces23</groupId>
         <artifactId>pom</artifactId>
-        <version>4.0.3-SNAPSHOT</version>
+        <version>4.0.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>systemEvent</artifactId>

--- a/tck/faces23/uiinput-required-true/pom.xml
+++ b/tck/faces23/uiinput-required-true/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.eclipse.ee4j.tck.faces.faces23</groupId>
         <artifactId>pom</artifactId>
-        <version>4.0.3-SNAPSHOT</version>
+        <version>4.0.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>uiinput-required-true</artifactId>

--- a/tck/faces23/uiinput/pom.xml
+++ b/tck/faces23/uiinput/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.eclipse.ee4j.tck.faces.faces23</groupId>
         <artifactId>pom</artifactId>
-        <version>4.0.3-SNAPSHOT</version>
+        <version>4.0.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>uiinput</artifactId>

--- a/tck/faces23/validateWholeBean/pom.xml
+++ b/tck/faces23/validateWholeBean/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.eclipse.ee4j.tck.faces.faces23</groupId>
         <artifactId>pom</artifactId>
-        <version>4.0.3-SNAPSHOT</version>
+        <version>4.0.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>validateWholeBean</artifactId>

--- a/tck/faces23/websocket/pom.xml
+++ b/tck/faces23/websocket/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.eclipse.ee4j.tck.faces.faces23</groupId>
         <artifactId>pom</artifactId>
-        <version>4.0.3-SNAPSHOT</version>
+        <version>4.0.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>websocket</artifactId>

--- a/tck/faces23/xhtmlMappingToFaceletByDefault/pom.xml
+++ b/tck/faces23/xhtmlMappingToFaceletByDefault/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.eclipse.ee4j.tck.faces.faces23</groupId>
         <artifactId>pom</artifactId>
-        <version>4.0.3-SNAPSHOT</version>
+        <version>4.0.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>xhtmlMappingToFaceletByDefault</artifactId>

--- a/tck/faces40/ajax/pom.xml
+++ b/tck/faces40/ajax/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.eclipse.ee4j.tck.faces.faces40</groupId>
         <artifactId>pom</artifactId>
-        <version>4.0.3-SNAPSHOT</version>
+        <version>4.0.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>ajax</artifactId>

--- a/tck/faces40/beanValidation/pom.xml
+++ b/tck/faces40/beanValidation/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.eclipse.ee4j.tck.faces.faces40</groupId>
         <artifactId>pom</artifactId>
-        <version>4.0.3-SNAPSHOT</version>
+        <version>4.0.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>beanValidation</artifactId>

--- a/tck/faces40/cdi/pom.xml
+++ b/tck/faces40/cdi/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.eclipse.ee4j.tck.faces.faces40</groupId>
         <artifactId>pom</artifactId>
-        <version>4.0.3-SNAPSHOT</version>
+        <version>4.0.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>cdi</artifactId>

--- a/tck/faces40/doctype/pom.xml
+++ b/tck/faces40/doctype/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.eclipse.ee4j.tck.faces.faces40</groupId>
         <artifactId>pom</artifactId>
-        <version>4.0.3-SNAPSHOT</version>
+        <version>4.0.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>doctype</artifactId>

--- a/tck/faces40/extensionless-mapping/pom.xml
+++ b/tck/faces40/extensionless-mapping/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.eclipse.ee4j.tck.faces.faces40</groupId>
         <artifactId>pom</artifactId>
-        <version>4.0.3-SNAPSHOT</version>
+        <version>4.0.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>extensionless-mapping</artifactId>

--- a/tck/faces40/inputFile/pom.xml
+++ b/tck/faces40/inputFile/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.eclipse.ee4j.tck.faces.faces40</groupId>
         <artifactId>pom</artifactId>
-        <version>4.0.3-SNAPSHOT</version>
+        <version>4.0.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>inputFile</artifactId>

--- a/tck/faces40/inputText/pom.xml
+++ b/tck/faces40/inputText/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.eclipse.ee4j.tck.faces.faces40</groupId>
         <artifactId>pom</artifactId>
-        <version>4.0.3-SNAPSHOT</version>
+        <version>4.0.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>inputText</artifactId>

--- a/tck/faces40/javaPage/pom.xml
+++ b/tck/faces40/javaPage/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.eclipse.ee4j.tck.faces.faces40</groupId>
         <artifactId>pom</artifactId>
-        <version>4.0.3-SNAPSHOT</version>
+        <version>4.0.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>javaPage</artifactId>

--- a/tck/faces40/javaPageWithMetadata/pom.xml
+++ b/tck/faces40/javaPageWithMetadata/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.eclipse.ee4j.tck.faces.faces40</groupId>
         <artifactId>pom</artifactId>
-        <version>4.0.3-SNAPSHOT</version>
+        <version>4.0.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>javaPageWithMetadata</artifactId>

--- a/tck/faces40/namespaces/pom.xml
+++ b/tck/faces40/namespaces/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.eclipse.ee4j.tck.faces.faces40</groupId>
         <artifactId>pom</artifactId>
-        <version>4.0.3-SNAPSHOT</version>
+        <version>4.0.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>namespaces</artifactId>

--- a/tck/faces40/pom.xml
+++ b/tck/faces40/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.eclipse.ee4j.faces.tck</groupId>
         <artifactId>jakarta-faces-tck</artifactId>
-        <version>4.0.3-SNAPSHOT</version>
+        <version>4.0.4-SNAPSHOT</version>
     </parent>
 
     <groupId>org.eclipse.ee4j.tck.faces.faces40</groupId>

--- a/tck/faces40/resources/pom.xml
+++ b/tck/faces40/resources/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.eclipse.ee4j.tck.faces.faces40</groupId>
         <artifactId>pom</artifactId>
-        <version>4.0.3-SNAPSHOT</version>
+        <version>4.0.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>resources</artifactId>

--- a/tck/faces40/selectItemGroup/pom.xml
+++ b/tck/faces40/selectItemGroup/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.eclipse.ee4j.tck.faces.faces40</groupId>
         <artifactId>pom</artifactId>
-        <version>4.0.3-SNAPSHOT</version>
+        <version>4.0.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>selectItemGroup</artifactId>

--- a/tck/faces40/selectItemGroups/pom.xml
+++ b/tck/faces40/selectItemGroups/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.eclipse.ee4j.tck.faces.faces40</groupId>
         <artifactId>pom</artifactId>
-        <version>4.0.3-SNAPSHOT</version>
+        <version>4.0.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>selectItemGroups</artifactId>

--- a/tck/faces40/selectManyCheckbox/pom.xml
+++ b/tck/faces40/selectManyCheckbox/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.eclipse.ee4j.tck.faces.faces40</groupId>
         <artifactId>pom</artifactId>
-        <version>4.0.3-SNAPSHOT</version>
+        <version>4.0.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>selectManyCheckbox</artifactId>

--- a/tck/old-tck-selenium/ajax/pom.xml
+++ b/tck/old-tck-selenium/ajax/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.eclipse.ee4j.tck.faces.old-tck-selenium</groupId>
         <artifactId>pom</artifactId>
-        <version>4.0.3-SNAPSHOT</version>
+        <version>4.0.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>ajax</artifactId>

--- a/tck/old-tck-selenium/commandLink/pom.xml
+++ b/tck/old-tck-selenium/commandLink/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.eclipse.ee4j.tck.faces.old-tck-selenium</groupId>
         <artifactId>pom</artifactId>
-        <version>4.0.3-SNAPSHOT</version>
+        <version>4.0.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>commandLink</artifactId>

--- a/tck/old-tck-selenium/pom.xml
+++ b/tck/old-tck-selenium/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.eclipse.ee4j.faces.tck</groupId>
         <artifactId>jakarta-faces-tck</artifactId>
-        <version>4.0.3-SNAPSHOT</version>
+        <version>4.0.4-SNAPSHOT</version>
     </parent>
 
     <groupId>org.eclipse.ee4j.tck.faces.old-tck-selenium</groupId>

--- a/tck/old-tck-selenium/protectedViews/pom.xml
+++ b/tck/old-tck-selenium/protectedViews/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.eclipse.ee4j.tck.faces.old-tck-selenium</groupId>
         <artifactId>pom</artifactId>
-        <version>4.0.3-SNAPSHOT</version>
+        <version>4.0.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>protectedViews</artifactId>

--- a/tck/old-tck/build/pom.xml
+++ b/tck/old-tck/build/pom.xml
@@ -28,7 +28,7 @@
 
     <groupId>org.eclipse.ee4j.faces.tck</groupId>
     <artifactId>old-tck-build</artifactId>
-    <version>4.0.3-SNAPSHOT</version>
+    <version>4.0.4-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Old Jakarta Faces TCK - build</name>

--- a/tck/old-tck/pom.xml
+++ b/tck/old-tck/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.eclipse.ee4j.faces.tck</groupId>
         <artifactId>jakarta-faces-tck</artifactId>
-        <version>4.0.3-SNAPSHOT</version>
+        <version>4.0.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>old-faces-tck-parent</artifactId>

--- a/tck/old-tck/run/pom.xml
+++ b/tck/old-tck/run/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.eclipse.ee4j.faces.tck</groupId>
         <artifactId>old-faces-tck-parent</artifactId>
-        <version>4.0.3-SNAPSHOT</version>
+        <version>4.0.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>old-tck-run</artifactId>

--- a/tck/pom.xml
+++ b/tck/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.eclipse.ee4j</groupId>
         <artifactId>project</artifactId>
-        <version>1.0.7</version>
+        <version>1.0.9</version>
         <relativePath />
     </parent>
 
@@ -51,7 +51,7 @@
         <maven.test.skip>false</maven.test.skip>
         <skipTests>false</skipTests>
         
-        <faces.version>4.0.0</faces.version>
+        <faces.version>4.0.1</faces.version>
 
         <!-- Application Server versions (these are downloaded and installed in these versions by Maven for the CI profiles) -->
         <tomcat.version>9.0.12</tomcat.version>
@@ -372,10 +372,10 @@
             <properties>
                 <!-- Explicit version of Mojarra to test -->
                 <mojarra.noupdate>false</mojarra.noupdate>
-                <mojarra.version>4.0.8-SNAPSHOT</mojarra.version>
+                <mojarra.version>4.0.11</mojarra.version>
                 
                 <!-- Verhicle used for testing the Mojarra version -->
-                <glassfish.version>7.0.14</glassfish.version>
+                <glassfish.version>7.0.25</glassfish.version>
                 <glassfish.root>${maven.multiModuleProjectDirectory}/target</glassfish.root>
                 <glassfish.home>${glassfish.root}/glassfish7</glassfish.home>
             </properties>

--- a/tck/pom.xml
+++ b/tck/pom.xml
@@ -28,7 +28,7 @@
 
     <groupId>org.eclipse.ee4j.faces.tck</groupId>
     <artifactId>jakarta-faces-tck</artifactId>
-    <version>4.0.3-SNAPSHOT</version>
+    <version>4.0.4-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Jakarta Faces ${project.version} TCK</name>

--- a/tck/util/pom.xml
+++ b/tck/util/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.eclipse.ee4j.faces.tck</groupId>
         <artifactId>jakarta-faces-tck</artifactId>
-        <version>4.0.3-SNAPSHOT</version>
+        <version>4.0.4-SNAPSHOT</version>
     </parent>
 
     <groupId>org.eclipse.ee4j.tck.faces.test</groupId>


### PR DESCRIPTION
Fixes #1935 Choose a month and a locale for the converter tests that happens not to differ between JDK 17 and JDK 21.