### PR TITLE
Update Chrome devtools version in TCK

### DIFF
--- a/tck/util/pom.xml
+++ b/tck/util/pom.xml
@@ -54,13 +54,13 @@
         </dependency>
         <dependency>
             <groupId>org.seleniumhq.selenium</groupId>
-            <artifactId>selenium-devtools-v124</artifactId>
-            <version>4.22.0</version>
+            <artifactId>selenium-devtools-v138</artifactId>
+            <version>4.34.0</version>
         </dependency>
         <dependency>
             <groupId>io.github.bonigarcia</groupId>
             <artifactId>webdrivermanager</artifactId>
-            <version>5.9.2</version>
+            <version>6.2.0</version>
         </dependency>
         <dependency>
             <groupId>commons-lang</groupId>

--- a/tck/util/src/main/java/ee/jakarta/tck/faces/test/util/selenium/ChromeDevtoolsDriver.java
+++ b/tck/util/src/main/java/ee/jakarta/tck/faces/test/util/selenium/ChromeDevtoolsDriver.java
@@ -51,12 +51,12 @@ import org.openqa.selenium.chrome.ChromeDriverService;
 import org.openqa.selenium.chrome.ChromeOptions;
 import org.openqa.selenium.chromium.ChromiumNetworkConditions;
 import org.openqa.selenium.devtools.DevTools;
-import org.openqa.selenium.devtools.v124.network.Network;
-import org.openqa.selenium.devtools.v124.network.model.Headers;
-import org.openqa.selenium.devtools.v124.network.model.Request;
-import org.openqa.selenium.devtools.v124.network.model.RequestId;
-import org.openqa.selenium.devtools.v124.network.model.ResponseReceived;
-import org.openqa.selenium.devtools.v124.network.model.TimeSinceEpoch;
+import org.openqa.selenium.devtools.v138.network.Network;
+import org.openqa.selenium.devtools.v138.network.model.Headers;
+import org.openqa.selenium.devtools.v138.network.model.Request;
+import org.openqa.selenium.devtools.v138.network.model.RequestId;
+import org.openqa.selenium.devtools.v138.network.model.ResponseReceived;
+import org.openqa.selenium.devtools.v138.network.model.TimeSinceEpoch;
 import org.openqa.selenium.html5.LocalStorage;
 import org.openqa.selenium.html5.Location;
 import org.openqa.selenium.html5.SessionStorage;
@@ -184,7 +184,7 @@ public class ChromeDevtoolsDriver implements ExtendedWebDriver {
             Logger log = Logger.getLogger(ChromeDevtoolsDriver.class.getName());
             log.warning("Init timeout error, can happen, " + "if the driver already has been used, can be safely ignore");
         }
-        devTools.send(Network.enable(Optional.empty(), Optional.empty(), Optional.empty()));
+        devTools.send(Network.enable(Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty()));
     }
 
     private void initNetworkListeners(DevTools devTools) {


### PR DESCRIPTION
TCK is pegged to Chrome 124 and doesn't anymore run when your machine actually has Chrome 138 or newer installed. So bumped devtools dependency from 124 to 138.

While at it also bumped webdrivermanager version as 5.x had a CVE violation.