### PR TITLE
Fix failing tests since changes in rendering behavior scripts

### DIFF
--- a/tck/faces22/ajax/src/main/java/ee/jakarta/tck/faces/test/servlet30/ajax/GreetBehavior.java
+++ b/tck/faces22/ajax/src/main/java/ee/jakarta/tck/faces/test/servlet30/ajax/GreetBehavior.java
@@ -42,12 +42,12 @@ public class GreetBehavior extends ClientBehaviorBase {
 
     public String getScript(ClientBehaviorContext behaviorContext) {
 
-        String name = (this.name == null) ? "World" : this.name;
+        String name = (this.name == null) ? behaviorContext.getComponent().getClientId() : this.name;
 
-        StringBuilder builder = new StringBuilder(19 + name.length());
-        builder.append("alert('Hello, ");
+        StringBuilder builder = new StringBuilder();
+        builder.append("document.getElementById('output').innerHTML+=' Hello, ");
         builder.append(name);
-        builder.append("!');");
+        builder.append("';");
 
         return builder.toString();
     }

--- a/tck/faces22/ajax/src/main/webapp/disabledBehaviors.xhtml
+++ b/tck/faces22/ajax/src/main/webapp/disabledBehaviors.xhtml
@@ -29,23 +29,44 @@
     <title>Ajax</title>
 </h:head>
 <h:body>
+    <div id="output" />
+    <script>
+        faces.ajax.addOnEvent(function(data) {
+            if (data.status === "success") {
+                document.getElementById("output").innerHTML += " " + data.source.id;
+            }
+        });
+    </script>
+
     <h:form id="form1">    <!-- Note that unlike previous examples, prependid='true' -->
 <!-- Test one: No behaviors rendered -->
        <h:inputText id="input1">
-	  <f:ajax execute="@all" render="@all" disabled="true"/>
-          <f:ajax execute="@this" render="@all" disabled="true"/>
+	      <f:ajax execute="@form" render="@form" disabled="true" />
+          <f:ajax execute="@this" render="@form" disabled="true" />
        </h:inputText>
        <br/>
-<!-- Test two: Second behavior rendered -->
+<!-- Test two: One ajax behavior rendered -->
        <h:inputText id="input2">
-	  <f:ajax execute="@all" render="@all" disabled="true"/>
-          <f:ajax execute="@this" render="@all"/>
+	      <f:ajax execute="@form" render="@form" disabled="true" />
+          <f:ajax execute="@this" render="@form" />
        </h:inputText>
        <br/>
-<!-- Test three: First behavior rendered -->
+<!-- Test three: Custom (non-ajax) behavior and disabled ajax behavior rendered -->
        <h:inputText id="input3">
           <be:greet/>
-	  <f:ajax execute="@all" render="@all" disabled="true"/>
+          <f:ajax execute="@form" render="@form" disabled="true" />
+       </h:inputText>
+       <br/>
+<!-- Test four: Two ajax behaviors rendered -->
+       <h:inputText id="input4">
+          <f:ajax execute="@form" render="@form" />
+          <f:ajax execute="@this" render="@form" />
+       </h:inputText>
+       <br/>
+<!-- Test five: Ajax behavior and custom (non-ajax) behavior rendered -->
+       <h:inputText id="input5">
+          <f:ajax execute="@this" render="@form" />
+          <be:greet/>
        </h:inputText>
     </h:form>
 


### PR DESCRIPTION
#1590 for https://github.com/eclipse-ee4j/mojarra/pull/5601

Ran entire TCK. Only one test failed and the particular test explicitly checked presence of onchange attribute instead of actual outcome of the behavior. So improved it and added two more use cases.

Rest of TCK all green for https://github.com/eclipse-ee4j/mojarra/pull/5601