### PR TITLE
Updates and improving integration flexibility

### DIFF
--- a/tck/faces-signaturetest/pom.xml
+++ b/tck/faces-signaturetest/pom.xml
@@ -84,7 +84,7 @@
                     </execution>
                 </executions>
             </plugin>
-            
+
             <plugin>
                 <artifactId>maven-dependency-plugin</artifactId>
                 <executions>
@@ -106,7 +106,7 @@
                                     <outputDirectory>${project.build.directory}/</outputDirectory>
                                     <destFileName>jakarta.faces-vendor-api.jar</destFileName>
                                 </artifactItem>
-                                
+
                                 <artifactItem>
                                     <groupId>jakarta.el</groupId>
                                     <artifactId>jakarta.el-api</artifactId>
@@ -115,7 +115,7 @@
                                     <outputDirectory>${project.build.directory}/</outputDirectory>
                                     <destFileName>jakarta.el-api.jar</destFileName>
                                 </artifactItem>
-                                
+
                                 <artifactItem>
                                     <groupId>jakarta.enterprise</groupId>
                                     <artifactId>jakarta.enterprise.cdi-api</artifactId>
@@ -132,7 +132,7 @@
                                     <outputDirectory>${project.build.directory}/</outputDirectory>
                                     <destFileName>jakarta.inject-api.jar</destFileName>
                                 </artifactItem>
-                                
+
                                 <artifactItem>
                                     <groupId>jakarta.servlet</groupId>
                                     <artifactId>jakarta.servlet-api</artifactId>
@@ -141,7 +141,7 @@
                                     <outputDirectory>${project.build.directory}/</outputDirectory>
                                     <destFileName>jakarta.servlet-api.jar</destFileName>
                                 </artifactItem>
-                                
+
                                 <artifactItem>
                                     <groupId>jakarta.websocket</groupId>
                                     <artifactId>jakarta.websocket-api</artifactId>
@@ -166,22 +166,14 @@
 
             <plugin>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>integration-test</goal>
-                            <goal>verify</goal>
-                        </goals>
-                        <configuration>
-                            <dependenciesToScan>jakarta.faces.tck:facestck-sigtest-${project.version}</dependenciesToScan>
-                            <systemPropertyVariables>
-                                <jimage.dir>${project.build.directory}/jdk-bundle</jimage.dir>
-                                <optional.tech.packages.to.ignore>jakarta.xml.bind</optional.tech.packages.to.ignore>
-                                <signature.sigTestClasspath>${project.build.directory}/jakarta.faces-vendor-api.jar:${project.build.directory}/jakarta.el-api.jar:${project.build.directory}/jakarta.enterprise.cdi-api.jar:${project.build.directory}/jakarta.servlet-api.jar:${project.build.directory}/jakarta.websocket-client-api.jar:${project.build.directory}/jakarta.websocket-api.jar:${project.build.directory}/jakarta.inject-api.jar:${project.build.directory}/jdk-bundle/java.base:${project.build.directory}/jdk-bundle/java.rmi:${project.build.directory}/jdk-bundle/java.sql:${project.build.directory}/jdk-bundle/java.naming</signature.sigTestClasspath>
-                            </systemPropertyVariables>
-                        </configuration>
-                    </execution>
-                </executions>
+                <configuration>
+                    <dependenciesToScan>jakarta.faces.tck:facestck-sigtest-${project.version}</dependenciesToScan>
+                    <systemPropertyVariables>
+                        <jimage.dir>${project.build.directory}/jdk-bundle</jimage.dir>
+                        <optional.tech.packages.to.ignore>jakarta.xml.bind</optional.tech.packages.to.ignore>
+                        <signature.sigTestClasspath>${project.build.directory}/jakarta.faces-vendor-api.jar:${project.build.directory}/jakarta.el-api.jar:${project.build.directory}/jakarta.enterprise.cdi-api.jar:${project.build.directory}/jakarta.servlet-api.jar:${project.build.directory}/jakarta.websocket-client-api.jar:${project.build.directory}/jakarta.websocket-api.jar:${project.build.directory}/jakarta.inject-api.jar:${project.build.directory}/jdk-bundle/java.base:${project.build.directory}/jdk-bundle/java.rmi:${project.build.directory}/jdk-bundle/java.sql:${project.build.directory}/jdk-bundle/java.naming</signature.sigTestClasspath>
+                    </systemPropertyVariables>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/tck/old-tck/build/pom.xml
+++ b/tck/old-tck/build/pom.xml
@@ -37,7 +37,7 @@
         <ant.version>1.10.2</ant.version>
         <ant.home>${project.build.directory}/apache-ant-${ant.version}</ant.home>
         <ant.zip.url>https://archive.apache.org/dist/ant/binaries/apache-ant-${ant.version}-bin.zip</ant.zip.url>
-        
+
         <tck.old.skip>${skipITs}</tck.old.skip>
     </properties>
 
@@ -85,10 +85,10 @@
             </plugin>
 
             <plugin>
-                <groupId>com.googlecode.maven-download-plugin</groupId>
+                <groupId>io.github.download-maven-plugin</groupId>
                 <artifactId>download-maven-plugin</artifactId>
                 <inherited>false</inherited>
-                <version>1.9.0</version>
+                <version>2.0.0</version>
                 <executions>
                     <execution>
                         <id>download-ant</id>

--- a/tck/old-tck/run/pom.xml
+++ b/tck/old-tck/run/pom.xml
@@ -35,16 +35,16 @@
         <ant.version>1.10.2</ant.version>
         <ant.home>${project.build.directory}/apache-ant-${ant.version}</ant.home>
         <ant.zip.url>https://archive.apache.org/dist/ant/binaries/apache-ant-${ant.version}-bin.zip</ant.zip.url>
-        
+
         <tck.home>${project.build.directory}/faces-tck</tck.home>
         <tck.tests.home>${tck.home}/src/com/sun/ts/tests</tck.tests.home>
         <tck.mode>standalone</tck.mode>
         <tck.old.skip>${skipITs}</tck.old.skip>
-         
+
         <glassfish.asadmin>${glassfish.home}/glassfish/bin/asadmin</glassfish.asadmin>
-       
+
         <jacoco.includes>org/glassfish/**\:com/sun/enterprise/**</jacoco.includes>
-        
+
         <port.admin>14848</port.admin>
         <port.derby>11527</port.derby>
         <port.http>18080</port.http>
@@ -76,9 +76,9 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>com.googlecode.maven-download-plugin</groupId>
+                <groupId>io.github.download-maven-plugin</groupId>
                 <artifactId>download-maven-plugin</artifactId>
-                <version>1.6.7</version>
+                <version>2.0.0</version>
                 <executions>
                     <execution>
                         <id>download-ant</id>
@@ -147,7 +147,7 @@
                         <configuration>
                             <target xmlns:if="ant:if" xmlns:unless="ant:unless">
                                 <taskdef resource="net/sf/antcontrib/antcontrib.properties" classpathref="maven.plugin.classpath" />
-                                         
+
                                 <macrodef name="tck-setting">
                                     <attribute name="key" /> <attribute name="value" />
                                     <sequential>
@@ -155,7 +155,7 @@
                                         match="@{key}=.*" replace="@{key}=@{value}" />
                                     </sequential>
                                 </macrodef>
-                                
+
                                 <if>
                                     <equals arg1="${tck.mode}" arg2="platform" />
                                     <then>
@@ -172,33 +172,33 @@
                                         <fail/>
                                     </else>
                                 </if>
-                                
-                                
-                                <!-- 
-                                    Set exclude file 
-                                    
+
+
+                                <!--
+                                    Set exclude file
+
                                     This will exclude everything except for lines matching a pattern, which will not be excluded.
                                     In effect, it works as the reverse and only these tests will be executed.
-                                    
+
                                 -->
                                 <sequential if:set="run.test.pattern">
-                                    <echo message="Running test pattern ${run.test.pattern}" /> 
-                            
+                                    <echo message="Running test pattern ${run.test.pattern}" />
+
                                     <copy file="${project.basedir}/src/test/etc/ts-all-${tck.mode}.jtx"
                                         tofile="${tck.home}/bin/ts.jtx.tmp" overwrite="true" verbose="true"/>
-                            
+
                                     <replaceregexp file="${tck.home}/bin/ts.jtx.tmp"
                                         match="${run.test.pattern}" replace="" byline="true" />
-                                        
-                                    <copy file="${tck.home}/bin/ts.jtx.tmp" 
+
+                                    <copy file="${tck.home}/bin/ts.jtx.tmp"
                                         toFile="${tck.home}/bin/ts.jtx" overwrite="true" verbose="true">
                                         <filterchain>
                                             <ignoreblank/>
                                         </filterchain>
                                     </copy>
-                                    
+
                                     <delete file="${tck.home}/bin/ts.jtx.tmp"/>
-                                    
+
                                     <if>
                                         <equals arg1="${tck.mode}" arg2="platform" />
                                     <then>
@@ -213,32 +213,32 @@
                                             </then>
                                     </elseif>
                                     </if>
-                                    
+
                                 </sequential>
-                                
-                                
+
+
 
                                 <!-- Change configuration -->
-                                
+
                                 <tck-setting key="web.home" value="${glassfish.home}/glassfish"/>
                                 <tck-setting key="webServerHome" value="${glassfish.home}/glassfish"/>
                                 <tck-setting key="webServerHost" value="localhost"/>
                                 <tck-setting key="webServerPort" value="${port.http}"/>
-                                
+
                                 <tck-setting key="securedWebServicePort" value="${port.https}"/>
                                 <tck-setting key="s1as.admin.port" value="${port.admin}"/>
                                 <tck-setting key="glassfish.admin.port" value="${port.admin}"/>
                                 <tck-setting key="orb.port" value="${port.orb}"/>
                                 <tck-setting key="database.port" value="${port.derby}"/>
                                 <tck-setting key="harness.log.port" value="${port.harness.log}"/>
-                                
+
                                 <tck-setting key="report.dir" value="${tck.home}/facesreport/faces"/>
                                 <tck-setting key="work.dir" value="${tck.home}/faceswork/faces"/>
 
                                 <tck-setting key="impl.vi" value="glassfish"/>
                                 <tck-setting key="impl.vi.deploy.dir" value="${webServerHome}/domains/domain1/autodeploy"/>
                                 <tck-setting key="impl.deploy.timeout.multiplier" value="960"/>
-                                
+
                                 <tck-setting key="jsf.classes" value="${webServerHome}/modules/cdi-api.jar;${webServerHome}/modules/jakarta.servlet.jsp.jstl-api.jar;${webServerHome}/modules/jakarta.inject.jar;${webServerHome}/modules/jakarta.faces.jar;${webServerHome}/modules/jakarta.servlet.jsp-api.jar;${webServerHome}/modules/jakarta.servlet-api.jar;${webServerHome}/modules/expressly.jar"/>
 
                                 <limit maxwait="60">
@@ -272,10 +272,10 @@
                                         <arg value="domain1"/>
                                     </exec>
                                 </limit>
-                                
+
                                 <mkdir dir="${tck.home}/facesreport"/>
                                 <mkdir dir="${tck.home}/facesreport/faces"/>
-                                
+
                                 <replace file="${tck.home}/bin/xml/ts.top.import.xml" if:set="suspend-tck" >
                                   <replacetoken><![CDATA[<jvmarg value="-Xmx512m"/>]]></replacetoken>
                                   <replacevalue><![CDATA[<jvmarg value="-Xmx512m"/>
@@ -299,24 +299,24 @@
                                 <replace file="${glassfish.home}/glassfish/domains/domain1/config/domain.xml" 
                                     token="-Xmx512m" value="-Xmx1024m" />
                                 <taskdef resource="net/sf/antcontrib/antcontrib.properties" classpathref="maven.plugin.classpath" />
-                                
+
                                 <limit maxwait="300">
                                     <exec executable="${glassfish.asadmin}" dir="${glassfish.home}/glassfish/bin" failonerror="true">
                                         <arg value="start-domain"/>
                                         <arg value="--suspend" if:set="glassfish.suspend"/>
                                     </exec>
                                 </limit>
-                                
+
                                 <!-- Deploy single test -->
                                 <sequential if:set="run.test" >
                                     <dirname property="test.dir" file="${tck.home}/src/${run.test}"/>
                                     <echo>Deploying from ${test.dir}</echo>
-                                    
+
                                     <exec executable="${ant.home}/bin/ant" dir="${test.dir}" failonerror="true">
                                         <arg value="deploy"  />
                                     </exec>
                                 </sequential>
-                                
+
                                 <!-- Deploy all tests -->
                                 <sequential unless:set="run.test" >
                                     <echo>Deploying all archives</echo>
@@ -362,7 +362,7 @@
                                 <exec executable="${glassfish.asadmin}" dir="${glassfish.home}/glassfish/bin">
                                     <arg value="stop-domain" />
                                 </exec>
-                                
+
                                 <if>
                                     <not>
                                         <equals arg1="${testResult}" arg2="0" />

--- a/tck/old-tck/run/pom.xml
+++ b/tck/old-tck/run/pom.xml
@@ -296,8 +296,8 @@
                         </goals>
                         <configuration>
                             <target xmlns:if="ant:if" xmlns:unless="ant:unless">
-                                <replace file="${glassfish.home}/glassfish/domains/domain1/config/domain.xml" 
-                                    token="-Xmx512m" value="-Xmx1024m" />
+                                <replace file="${glassfish.home}/glassfish/domains/domain1/config/domain.xml"
+                                    token="-Xmx512m" value="-Xmx4g" />
                                 <taskdef resource="net/sf/antcontrib/antcontrib.properties" classpathref="maven.plugin.classpath" />
 
                                 <limit maxwait="300">

--- a/tck/pom.xml
+++ b/tck/pom.xml
@@ -41,7 +41,7 @@ mvn clean install -Dmojarra.noupdate
 
 Build old TCK once from the root (NOT from the /old-tck folder)
 
-mvn clean install -pl :old-tck-build  
+mvn clean install -pl :old-tck-build
 
 
 
@@ -95,19 +95,25 @@ mvn clean install -pl :old-tck-run -Dglassfish.suspend
         <maven.compiler.release>17</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        
+
         <maven.test.skip>false</maven.test.skip>
         <skipTests>false</skipTests>
         <test.selenium>true</test.selenium>
-        <chromedriver.version>124</chromedriver.version>
-        
-        <faces.version>4.1.0-SNAPSHOT</faces.version>
-        
-        <!-- 
+
+        <arquillian.version>1.10.0.Final</arquillian.version>
+        <arquillian-suite-extension.version>1.2.2</arquillian-suite-extension.version>
+        <chromedriver.version>139</chromedriver.version>
+        <faces.version>4.1.3-SNAPSHOT</faces.version>
+        <htmlunit.version>4.13.0</htmlunit.version>
+        <selenium.version>4.35.0</selenium.version>
+        <shrinkwrap-resolver.version>3.3.4</shrinkwrap-resolver.version>
+        <webdrivermanager.version>6.2.0</webdrivermanager.version>
+
+        <!--
             Set to the actual Faces API the implementation being tested is using.
-            
+
             This can best be done in a profile specific to the implementation.
-            See the standard profiles for examples. 
+            See the standard profiles for examples.
         -->
         <sigtest.api.groupId></sigtest.api.groupId>
         <sigtest.api.artifactId></sigtest.api.artifactId>
@@ -122,19 +128,19 @@ mvn clean install -pl :old-tck-run -Dglassfish.suspend
             <dependency>
                 <groupId>org.jboss.arquillian</groupId>
                 <artifactId>arquillian-bom</artifactId>
-                <version>1.9.5.Final</version>
+                <version>${arquillian.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>org.jboss.arquillian.container</groupId>
                 <artifactId>arquillian-container-test-api</artifactId>
-                <version>1.9.5.Final</version>
+                <version>${arquillian.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.omnifaces.arquillian</groupId>
-                <artifactId>glassfish-client-ee10</artifactId>
-                <version>1.8</version>
+                <groupId>junit</groupId>
+                <artifactId>junit</artifactId>
+                <version>4.13.2</version>
                 <scope>test</scope>
             </dependency>
 
@@ -144,7 +150,7 @@ mvn clean install -pl :old-tck-run -Dglassfish.suspend
                 <version>${faces.version}</version>
                 <scope>provided</scope>
             </dependency>
-            
+
             <dependency>
                 <groupId>jakarta.el</groupId>
                 <artifactId>jakarta.el-api</artifactId>
@@ -186,37 +192,43 @@ mvn clean install -pl :old-tck-run -Dglassfish.suspend
             </dependency>
             <dependency>
                 <groupId>org.htmlunit</groupId>
+                <artifactId>htmlunit</artifactId>
+                <version>${htmlunit.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.htmlunit</groupId>
                 <artifactId>htmlunit-core-js</artifactId>
-                <version>4.13.0</version>
+                <version>${htmlunit.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.htmlunit</groupId>
                 <artifactId>neko-htmlunit</artifactId>
-                <version>4.13.0</version>
+                <version>${htmlunit.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.htmlunit</groupId>
                 <artifactId>htmlunit-cssparser</artifactId>
-                <version>4.13.0</version>
+                <version>${htmlunit.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.htmlunit</groupId>
                 <artifactId>htmlunit-xpath</artifactId>
-                <version>4.13.0</version>
+                <version>${htmlunit.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.htmlunit</groupId>
                 <artifactId>htmlunit-csp</artifactId>
-                <version>4.13.0</version>
+                <version>${htmlunit.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.htmlunit</groupId>
                 <artifactId>htmlunit-websocket-client</artifactId>
-                <version>4.13.0</version>
+                <version>${htmlunit.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>
-    
+
     <dependencies>
         <dependency>
             <groupId>jakarta.faces</groupId>
@@ -252,7 +264,7 @@ mvn clean install -pl :old-tck-run -Dglassfish.suspend
             <artifactId>jakarta.enterprise.cdi-api</artifactId>
             <scope>provided</scope>
         </dependency>
-        
+
         <dependency>
             <groupId>jakarta.inject</groupId>
             <artifactId>jakarta.inject-api</artifactId>
@@ -265,7 +277,7 @@ mvn clean install -pl :old-tck-run -Dglassfish.suspend
             <version>3.1.1</version>
             <scope>provided</scope>
         </dependency>
-        
+
         <dependency>
             <groupId>jakarta.ejb</groupId>
             <artifactId>jakarta.ejb-api</artifactId>
@@ -298,7 +310,6 @@ mvn clean install -pl :old-tck-run -Dglassfish.suspend
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.13.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -314,14 +325,14 @@ mvn clean install -pl :old-tck-run -Dglassfish.suspend
         <dependency>
             <groupId>org.jboss.shrinkwrap.resolver</groupId>
             <artifactId>shrinkwrap-resolver-impl-maven</artifactId>
-            <version>3.3.4</version>
+            <version>${shrinkwrap-resolver.version}</version>
             <type>jar</type>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jboss.shrinkwrap.resolver</groupId>
             <artifactId>shrinkwrap-resolver-impl-maven-archive</artifactId>
-            <version>3.3.4</version>
+            <version>${shrinkwrap-resolver.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -339,7 +350,6 @@ mvn clean install -pl :old-tck-run -Dglassfish.suspend
         <dependency>
             <groupId>org.htmlunit</groupId>
             <artifactId>htmlunit</artifactId>
-            <version>4.13.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -419,7 +429,7 @@ mvn clean install -pl :old-tck-run -Dglassfish.suspend
                     </execution>
                 </executions>
             </plugin>
-            
+
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>
@@ -429,7 +439,7 @@ mvn clean install -pl :old-tck-run -Dglassfish.suspend
                     <failOnMissingWebXml>false</failOnMissingWebXml>
                 </configuration>
             </plugin>
-            
+
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
@@ -450,7 +460,7 @@ mvn clean install -pl :old-tck-run -Dglassfish.suspend
                     </systemPropertyVariables>
                 </configuration>
             </plugin>
-            
+
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-report-plugin</artifactId>
@@ -490,7 +500,7 @@ mvn clean install -pl :old-tck-run -Dglassfish.suspend
     </reporting>
 
     <profiles>
-    
+
         <profile>
             <id>build-epl-tck</id>
             <activation>
@@ -501,7 +511,7 @@ mvn clean install -pl :old-tck-run -Dglassfish.suspend
                 <licenseFile>${project.basedir}/LICENSE.md</licenseFile>
             </properties>
         </profile>
-    
+
         <profile>
             <id>custom</id>
         </profile>
@@ -521,19 +531,20 @@ mvn clean install -pl :old-tck-run -Dglassfish.suspend
             </activation>
 
             <properties>
+                <arquillian.glassfish.version>2.1.0</arquillian.glassfish.version>
                 <!-- Explicit version of Mojarra to test -->
                 <mojarra.version>4.1.0</mojarra.version>
-                
-                <!-- 
+
+                <!--
                     By default this profile will copy the Mojarra version to test to GlassFish.
-                    Set this to "true"" to skip copying and therefor use GlassFish as is. That is 
-                    useful to test GlassFish itself instead of just a specific Mojarra version.   
+                    Set this to "true"" to skip copying and therefor use GlassFish as is. That is
+                    useful to test GlassFish itself instead of just a specific Mojarra version.
                 -->
                 <mojarra.noupdate>false</mojarra.noupdate>
 
-                <!-- 
+                <!--
                     Exact artefact used by GlassFish that holds the API classes.
-                    This is used by the signature test in module /faces-signaturetest 
+                    This is used by the signature test in module /faces-signaturetest
                 -->
                 <sigtest.api.groupId>org.glassfish</sigtest.api.groupId>
                 <sigtest.api.artifactId>jakarta.faces</sigtest.api.artifactId>
@@ -541,16 +552,22 @@ mvn clean install -pl :old-tck-run -Dglassfish.suspend
 
                 <!-- Verhicle used for testing the Mojarra version -->
                 <glassfish.version>8.0.0-M12</glassfish.version>
+                <glassfish.dirName>glassfish8</glassfish.dirName>
                 <glassfish.root>${maven.multiModuleProjectDirectory}/target</glassfish.root>
-                <glassfish.home>${glassfish.root}/glassfish8</glassfish.home>
+                <glassfish.home>${glassfish.root}/${glassfish.dirName}</glassfish.home>
             </properties>
 
             <dependencies>
-                <!-- The actual Arquillian connector -->
                 <dependency>
-                    <groupId>org.omnifaces.arquillian</groupId>
+                    <groupId>ee.omnifish.arquillian</groupId>
                     <artifactId>arquillian-glassfish-server-managed</artifactId>
-                    <version>1.8</version>
+                    <version>${arquillian.glassfish.version}</version>
+                    <scope>test</scope>
+                </dependency>
+                <dependency>
+                    <groupId>ee.omnifish.arquillian</groupId>
+                    <artifactId>glassfish-client-ee11</artifactId>
+                    <version>${arquillian.glassfish.version}</version>
                     <scope>test</scope>
                 </dependency>
             </dependencies>
@@ -643,11 +660,13 @@ mvn clean install -pl :old-tck-run -Dglassfish.suspend
 
         <profile>
             <id>piranha-embedded-micro</id>
-
+      <properties>
+        <arquillian.piranha.version>21.6.0-SNAPSHOT</arquillian.piranha.version>
+      </properties>
             <dependencies>
                 <!-- Jakarta EE based client dependencies to contact a server via WebSocket or REST -->
                 <dependency>
-                    <groupId>org.omnifaces.arquillian</groupId>
+                    <groupId>ee.omnifish.arquillian</groupId>
                     <artifactId>glassfish-client-ee10</artifactId>
                     <scope>test</scope>
                 </dependency>
@@ -655,7 +674,7 @@ mvn clean install -pl :old-tck-run -Dglassfish.suspend
                 <dependency>
                     <groupId>cloud.piranha.arquillian</groupId>
                     <artifactId>piranha-arquillian-server</artifactId>
-                    <version>21.6.0-SNAPSHOT</version>
+                    <version>${arquillian.piranha.version}</version>
                     <scope>test</scope>
                 </dependency>
             </dependencies>
@@ -684,6 +703,7 @@ mvn clean install -pl :old-tck-run -Dglassfish.suspend
             <id>tomcat-remote</id>
 
             <properties>
+                <arquillian.tomcat.version>1.1.0.Final</arquillian.tomcat.version>
                 <skipEJB>true</skipEJB>
                 <skipCDI>true</skipCDI>
                 <skipJSF>true</skipJSF>
@@ -694,7 +714,7 @@ mvn clean install -pl :old-tck-run -Dglassfish.suspend
                 <dependency>
                     <groupId>org.jboss.arquillian.container</groupId>
                     <artifactId>arquillian-tomcat-remote-7</artifactId>
-                    <version>1.1.0.Final</version>
+                    <version>${arquillian.tomcat.version}</version>
                     <scope>test</scope>
                 </dependency>
             </dependencies>
@@ -718,7 +738,8 @@ mvn clean install -pl :old-tck-run -Dglassfish.suspend
             <id>tomcat-ci-managed</id>
 
             <properties>
-                <skipEJB>true</skipEJB>
+                <arquillian.tomcat.version>1.1.0.Final</arquillian.tomcat.version>
+        <skipEJB>true</skipEJB>
                 <skipCDI>true</skipCDI>
                 <skipJSF>true</skipJSF>
                 <skipJACC>true</skipJACC>
@@ -754,7 +775,7 @@ mvn clean install -pl :old-tck-run -Dglassfish.suspend
                 <dependency>
                     <groupId>org.jboss.arquillian.container</groupId>
                     <artifactId>arquillian-tomcat-managed-7</artifactId>
-                    <version>1.1.0.Final</version>
+                    <version>${arquillian.tomcat.version}</version>
                     <scope>test</scope>
                 </dependency>
             </dependencies>
@@ -822,11 +843,14 @@ mvn clean install -pl :old-tck-run -Dglassfish.suspend
 
         <profile>
             <id>wildfly-ci-managed</id>
+            <properties>
+              <arquillian.wildfly.version>5.0.0.Alpha1</arquillian.wildfly.version>
+            </properties>
             <dependencies>
                 <dependency>
                     <groupId>org.wildfly.arquillian</groupId>
                     <artifactId>wildfly-arquillian-container-managed</artifactId>
-                    <version>5.0.0.Alpha1</version>
+                    <version>${arquillian.wildfly.version}</version>
                     <exclusions>
                         <exclusion>
                             <groupId>org.jboss.sasl</groupId>
@@ -863,25 +887,24 @@ mvn clean install -pl :old-tck-run -Dglassfish.suspend
             </activation>
 
             <properties>
-                <!-- Arquillian Dependencies -->
-                <payara.arquillian.container.version>3.0.alpha8</payara.arquillian.container.version>
+                <arquillian.payara.version>3.0.alpha8</arquillian.payara.version>
             </properties>
 
             <dependencies>
                 <dependency>
                     <groupId>fish.payara.arquillian</groupId>
                     <artifactId>arquillian-payara-server-remote</artifactId>
-                    <version>${payara.arquillian.container.version}</version>
+                    <version>${arquillian.payara.version}</version>
                     <scope>test</scope>
                 </dependency>
                 <dependency>
                     <groupId>fish.payara.arquillian</groupId>
                     <artifactId>payara-client-ee9</artifactId>
                     <scope>test</scope>
-                    <version>${payara.arquillian.container.version}</version>
+                    <version>${arquillian.payara.version}</version>
                 </dependency>
-                <!-- 
-                Solution for 
+                <!--
+                Solution for
                 WARNING: A class jakarta.activation.DataSource for a default provider MessageBodyWriter<jakarta.activation.DataSource> was not found. The provider is not available.
                 fish.payara.arquillian.shaded.glassfish.jersey.message.internal.MessagingBinders$EnabledProvidersBinder bindToBinder
                 -->

--- a/tck/pom.xml
+++ b/tck/pom.xml
@@ -454,14 +454,6 @@ mvn clean install -pl :old-tck-run -Dglassfish.suspend
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>integration-test</goal>
-                            <goal>verify</goal>
-                        </goals>
-                    </execution>
-                </executions>
                 <configuration>
                     <systemPropertyVariables>
                         <finalName>${project.build.finalName}</finalName>
@@ -469,11 +461,30 @@ mvn clean install -pl :old-tck-run -Dglassfish.suspend
                         <chromedriver.version>${chromedriver.version}</chromedriver.version>
                     </systemPropertyVariables>
                 </configuration>
+                <executions>
+                    <execution>
+                        <id>integration-test</id>
+                        <goals>
+                            <goal>integration-test</goal>
+                        </goals>
+                        <phase>integration-test</phase>
+                    </execution>
+                    <execution>
+                        <id>veify</id>
+                        <goals>
+                            <goal>verify</goal>
+                        </goals>
+                        <phase>verify</phase>
+                    </execution>
+                </executions>
             </plugin>
 
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-report-plugin</artifactId>
+                <configuration>
+                    <aggregate>true</aggregate>
+                </configuration>
                 <executions>
                     <execution>
                         <phase>post-integration-test</phase>
@@ -482,9 +493,6 @@ mvn clean install -pl :old-tck-run -Dglassfish.suspend
                         </goals>
                     </execution>
                 </executions>
-                <configuration>
-                    <aggregate>true</aggregate>
-                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/tck/pom.xml
+++ b/tck/pom.xml
@@ -99,6 +99,8 @@ mvn clean install -pl :old-tck-run -Dglassfish.suspend
         <maven.test.skip>false</maven.test.skip>
         <skipTests>false</skipTests>
         <test.selenium>true</test.selenium>
+        <failsafe.rerunFailingTestsCount>3</failsafe.rerunFailingTestsCount>
+        <failsafe.failOnFlakeCount>0</failsafe.failOnFlakeCount>
 
         <arquillian.version>1.10.0.Final</arquillian.version>
         <arquillian-suite-extension.version>1.2.2</arquillian-suite-extension.version>
@@ -392,22 +394,32 @@ mvn clean install -pl :old-tck-run -Dglassfish.suspend
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.13.0</version>
+                    <version>3.14.0</version>
                     </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-dependency-plugin</artifactId>
-                    <version>3.6.1</version>
+                    <version>3.8.1</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>3.2.5</version>
+                    <version>3.5.3</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-failsafe-plugin</artifactId>
-                    <version>3.2.5</version>
+                    <version>3.5.3</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-surefire-report-plugin</artifactId>
+                    <version>3.5.3</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-war-plugin</artifactId>
+                    <version>3.4.0</version>
                 </plugin>
             </plugins>
         </pluginManagement>
@@ -433,7 +445,6 @@ mvn clean install -pl :old-tck-run -Dglassfish.suspend
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>
-                <version>3.4.0</version>
                 <configuration>
                     <attachClasses>true</attachClasses>
                     <failOnMissingWebXml>false</failOnMissingWebXml>
@@ -452,7 +463,6 @@ mvn clean install -pl :old-tck-run -Dglassfish.suspend
                     </execution>
                 </executions>
                 <configuration>
-                    <rerunFailingTestsCount>3</rerunFailingTestsCount>
                     <systemPropertyVariables>
                         <finalName>${project.build.finalName}</finalName>
                         <test.selenium>${test.selenium}</test.selenium>
@@ -464,7 +474,6 @@ mvn clean install -pl :old-tck-run -Dglassfish.suspend
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-report-plugin</artifactId>
-                <version>3.2.5</version>
                 <executions>
                     <execution>
                         <phase>post-integration-test</phase>
@@ -485,7 +494,6 @@ mvn clean install -pl :old-tck-run -Dglassfish.suspend
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-report-plugin</artifactId>
-                <version>3.2.5</version>
                 <configuration>
                     <skipSurefireReport>${skipSurefireReport}</skipSurefireReport>
                     <aggregate>true</aggregate>
@@ -660,9 +668,9 @@ mvn clean install -pl :old-tck-run -Dglassfish.suspend
 
         <profile>
             <id>piranha-embedded-micro</id>
-      <properties>
-        <arquillian.piranha.version>21.6.0-SNAPSHOT</arquillian.piranha.version>
-      </properties>
+            <properties>
+                <arquillian.piranha.version>21.6.0-SNAPSHOT</arquillian.piranha.version>
+            </properties>
             <dependencies>
                 <!-- Jakarta EE based client dependencies to contact a server via WebSocket or REST -->
                 <dependency>
@@ -739,7 +747,7 @@ mvn clean install -pl :old-tck-run -Dglassfish.suspend
 
             <properties>
                 <arquillian.tomcat.version>1.1.0.Final</arquillian.tomcat.version>
-        <skipEJB>true</skipEJB>
+                <skipEJB>true</skipEJB>
                 <skipCDI>true</skipCDI>
                 <skipJSF>true</skipJSF>
                 <skipJACC>true</skipJACC>
@@ -844,7 +852,7 @@ mvn clean install -pl :old-tck-run -Dglassfish.suspend
         <profile>
             <id>wildfly-ci-managed</id>
             <properties>
-              <arquillian.wildfly.version>5.0.0.Alpha1</arquillian.wildfly.version>
+                <arquillian.wildfly.version>5.0.0.Alpha1</arquillian.wildfly.version>
             </properties>
             <dependencies>
                 <dependency>

--- a/tck/util/pom.xml
+++ b/tck/util/pom.xml
@@ -36,7 +36,6 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.13.2</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
@@ -46,48 +45,43 @@
         <dependency>
             <groupId>org.seleniumhq.selenium</groupId>
             <artifactId>selenium-java</artifactId>
-            <version>4.22.0</version>
+            <version>${selenium.version}</version>
         </dependency>
         <dependency>
             <groupId>org.seleniumhq.selenium</groupId>
             <artifactId>selenium-chrome-driver</artifactId>
-            <version>4.22.0</version>
+            <version>${selenium.version}</version>
         </dependency>
         <dependency>
             <groupId>org.seleniumhq.selenium</groupId>
-            <artifactId>selenium-devtools-v124</artifactId>
-            <version>4.22.0</version>
-        </dependency>
-        <dependency>
-            <groupId>commons-lang</groupId>
-            <artifactId>commons-lang</artifactId>
-            <version>2.6</version>
+            <artifactId>selenium-devtools-v${chromedriver.version}</artifactId>
+            <version>${selenium.version}</version>
         </dependency>
         <dependency>
             <groupId>io.github.bonigarcia</groupId>
             <artifactId>webdrivermanager</artifactId>
-            <version>6.1.0</version>
+            <version>${webdrivermanager.version}</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.shrinkwrap.resolver</groupId>
             <artifactId>shrinkwrap-resolver-impl-maven</artifactId>
-            <version>3.3.4</version>
+            <version>${shrinkwrap-resolver.version}</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.shrinkwrap.resolver</groupId>
             <artifactId>shrinkwrap-resolver-impl-maven-archive</artifactId>
-            <version>3.3.4</version>
+            <version>${shrinkwrap-resolver.version}</version>
         </dependency>
         <dependency>
             <groupId>org.eu.ingwar.tools</groupId>
             <artifactId>arquillian-suite-extension</artifactId>
-            <version>1.2.2</version>
+            <version>${arquillian-suite-extension.version}</version>
         </dependency>
 
         <dependency>
             <groupId>org.htmlunit</groupId>
             <artifactId>htmlunit</artifactId>
-            <version>4.13.0</version>
+			<scope>compile</scope>
         </dependency>
     </dependencies>
 </project>

--- a/tck/util/src/main/java/ee/jakarta/tck/faces/test/util/selenium/ChromeDevtoolsDriver.java
+++ b/tck/util/src/main/java/ee/jakarta/tck/faces/test/util/selenium/ChromeDevtoolsDriver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Contributors to the Eclipse Foundation.
+ * Copyright (c) 2023, 2025 Contributors to the Eclipse Foundation.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -15,6 +15,7 @@
  */
 package ee.jakarta.tck.faces.test.util.selenium;
 
+import java.io.OutputStream;
 import java.net.URI;
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
@@ -33,7 +34,6 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Stream;
 
-import org.apache.commons.io.output.NullOutputStream;
 import org.openqa.selenium.By;
 import org.openqa.selenium.Capabilities;
 import org.openqa.selenium.Credentials;
@@ -50,17 +50,13 @@ import org.openqa.selenium.chrome.ChromeDriverService;
 import org.openqa.selenium.chrome.ChromeOptions;
 import org.openqa.selenium.chromium.ChromiumNetworkConditions;
 import org.openqa.selenium.devtools.DevTools;
-import org.openqa.selenium.devtools.v124.network.Network;
-import org.openqa.selenium.devtools.v124.network.model.Request;
-import org.openqa.selenium.devtools.v124.network.model.RequestId;
-import org.openqa.selenium.devtools.v124.network.model.ResponseReceived;
-import org.openqa.selenium.devtools.v124.network.model.TimeSinceEpoch;
-import org.openqa.selenium.html5.LocalStorage;
-import org.openqa.selenium.html5.Location;
-import org.openqa.selenium.html5.SessionStorage;
+import org.openqa.selenium.devtools.v139.network.Network;
+import org.openqa.selenium.devtools.v139.network.model.Request;
+import org.openqa.selenium.devtools.v139.network.model.RequestId;
+import org.openqa.selenium.devtools.v139.network.model.ResponseReceived;
+import org.openqa.selenium.devtools.v139.network.model.TimeSinceEpoch;
 import org.openqa.selenium.interactions.Sequence;
 import org.openqa.selenium.logging.EventType;
-import org.openqa.selenium.mobile.NetworkConnection;
 import org.openqa.selenium.print.PrintOptions;
 import org.openqa.selenium.remote.CommandExecutor;
 import org.openqa.selenium.remote.CommandPayload;
@@ -86,7 +82,6 @@ import static java.util.Optional.empty;
  *
  * @see also https://medium.com/codex/selenium4-a-peek-into-chrome-devtools-92bca6de55e0
  */
-@SuppressWarnings("unused")
 public class ChromeDevtoolsDriver implements ExtendedWebDriver {
 
     /*
@@ -156,7 +151,7 @@ public class ChromeDevtoolsDriver implements ExtendedWebDriver {
     public ChromeDevtoolsDriver(ChromeOptions options) {
         ChromeDriverService chromeDriverService = new ChromeDriverService.Builder().build();
 
-        chromeDriverService.sendOutputTo(NullOutputStream.INSTANCE);
+        chromeDriverService.sendOutputTo(OutputStream.nullOutputStream());
         delegate = new ChromeDriver(chromeDriverService, options);
     }
 
@@ -185,7 +180,7 @@ public class ChromeDevtoolsDriver implements ExtendedWebDriver {
             Logger.getLogger(ChromeDevtoolsDriver.class.getName())
                   .warning("Init timeout error, can happen, " + "if the driver already has been used, can be safely ignore");
         }
-        devTools.send(Network.enable(empty(), empty(), empty()));
+        devTools.send(Network.enable(empty(), empty(), empty(), empty()));
     }
 
     private void initNetworkListeners(DevTools devTools) {


### PR DESCRIPTION
* This PR is from master; after the merge of this and #2047 I will create another PR for 5.0
* Updated test dependencies
  * Selenium + chromedriver
  * GlassFish Arquillian Container
  * Arquillian
* Updated maven plugins
  * download plugin changed the group id
* Removed commons-lang 2.6 dependency (used just for nullOutputStream which is in Java too since 11)
* Many version ids moved o properties, so we can use compatible updates
* GlassFish Xmx in old TCK was too low
