### PR TITLE
Stabilized tests - tests were flaky for several reasons

### DIFF
--- a/tck/faces-signaturetest/pom.xml
+++ b/tck/faces-signaturetest/pom.xml
@@ -84,7 +84,7 @@
                     </execution>
                 </executions>
             </plugin>
-            
+
             <plugin>
                 <artifactId>maven-dependency-plugin</artifactId>
                 <executions>
@@ -106,7 +106,7 @@
                                     <outputDirectory>${project.build.directory}/</outputDirectory>
                                     <destFileName>jakarta.faces-vendor-api.jar</destFileName>
                                 </artifactItem>
-                                
+
                                 <artifactItem>
                                     <groupId>jakarta.el</groupId>
                                     <artifactId>jakarta.el-api</artifactId>
@@ -115,7 +115,7 @@
                                     <outputDirectory>${project.build.directory}/</outputDirectory>
                                     <destFileName>jakarta.el-api.jar</destFileName>
                                 </artifactItem>
-                                
+
                                 <artifactItem>
                                     <groupId>jakarta.enterprise</groupId>
                                     <artifactId>jakarta.enterprise.cdi-api</artifactId>
@@ -132,7 +132,7 @@
                                     <outputDirectory>${project.build.directory}/</outputDirectory>
                                     <destFileName>jakarta.inject-api.jar</destFileName>
                                 </artifactItem>
-                                
+
                                 <artifactItem>
                                     <groupId>jakarta.servlet</groupId>
                                     <artifactId>jakarta.servlet-api</artifactId>
@@ -141,7 +141,7 @@
                                     <outputDirectory>${project.build.directory}/</outputDirectory>
                                     <destFileName>jakarta.servlet-api.jar</destFileName>
                                 </artifactItem>
-                                
+
                                 <artifactItem>
                                     <groupId>jakarta.websocket</groupId>
                                     <artifactId>jakarta.websocket-api</artifactId>
@@ -166,22 +166,14 @@
 
             <plugin>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>integration-test</goal>
-                            <goal>verify</goal>
-                        </goals>
-                        <configuration>
-                            <dependenciesToScan>jakarta.faces.tck:facestck-sigtest-${project.version}</dependenciesToScan>
-                            <systemPropertyVariables>
-                                <jimage.dir>${project.build.directory}/jdk-bundle</jimage.dir>
-                                <optional.tech.packages.to.ignore>jakarta.xml.bind</optional.tech.packages.to.ignore>
-                                <signature.sigTestClasspath>${project.build.directory}/jakarta.faces-vendor-api.jar:${project.build.directory}/jakarta.el-api.jar:${project.build.directory}/jakarta.enterprise.cdi-api.jar:${project.build.directory}/jakarta.servlet-api.jar:${project.build.directory}/jakarta.websocket-client-api.jar:${project.build.directory}/jakarta.websocket-api.jar:${project.build.directory}/jakarta.inject-api.jar:${project.build.directory}/jdk-bundle/java.base:${project.build.directory}/jdk-bundle/java.rmi:${project.build.directory}/jdk-bundle/java.sql:${project.build.directory}/jdk-bundle/java.naming</signature.sigTestClasspath>
-                            </systemPropertyVariables>
-                        </configuration>
-                    </execution>
-                </executions>
+                <configuration>
+                    <dependenciesToScan>jakarta.faces.tck:facestck-sigtest-${project.version}</dependenciesToScan>
+                    <systemPropertyVariables>
+                        <jimage.dir>${project.build.directory}/jdk-bundle</jimage.dir>
+                        <optional.tech.packages.to.ignore>jakarta.xml.bind</optional.tech.packages.to.ignore>
+                        <signature.sigTestClasspath>${project.build.directory}/jakarta.faces-vendor-api.jar:${project.build.directory}/jakarta.el-api.jar:${project.build.directory}/jakarta.enterprise.cdi-api.jar:${project.build.directory}/jakarta.servlet-api.jar:${project.build.directory}/jakarta.websocket-client-api.jar:${project.build.directory}/jakarta.websocket-api.jar:${project.build.directory}/jakarta.inject-api.jar:${project.build.directory}/jdk-bundle/java.base:${project.build.directory}/jdk-bundle/java.rmi:${project.build.directory}/jdk-bundle/java.sql:${project.build.directory}/jdk-bundle/java.naming</signature.sigTestClasspath>
+                    </systemPropertyVariables>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/tck/old-tck/build/pom.xml
+++ b/tck/old-tck/build/pom.xml
@@ -37,7 +37,7 @@
         <ant.version>1.10.2</ant.version>
         <ant.home>${project.build.directory}/apache-ant-${ant.version}</ant.home>
         <ant.zip.url>https://archive.apache.org/dist/ant/binaries/apache-ant-${ant.version}-bin.zip</ant.zip.url>
-        
+
         <tck.old.skip>${skipITs}</tck.old.skip>
     </properties>
 
@@ -85,10 +85,10 @@
             </plugin>
 
             <plugin>
-                <groupId>com.googlecode.maven-download-plugin</groupId>
+                <groupId>io.github.download-maven-plugin</groupId>
                 <artifactId>download-maven-plugin</artifactId>
                 <inherited>false</inherited>
-                <version>1.9.0</version>
+                <version>2.0.0</version>
                 <executions>
                     <execution>
                         <id>download-ant</id>

--- a/tck/old-tck/run/pom.xml
+++ b/tck/old-tck/run/pom.xml
@@ -35,16 +35,16 @@
         <ant.version>1.10.2</ant.version>
         <ant.home>${project.build.directory}/apache-ant-${ant.version}</ant.home>
         <ant.zip.url>https://archive.apache.org/dist/ant/binaries/apache-ant-${ant.version}-bin.zip</ant.zip.url>
-        
+
         <tck.home>${project.build.directory}/faces-tck</tck.home>
         <tck.tests.home>${tck.home}/src/com/sun/ts/tests</tck.tests.home>
         <tck.mode>standalone</tck.mode>
         <tck.old.skip>${skipITs}</tck.old.skip>
-         
+
         <glassfish.asadmin>${glassfish.home}/glassfish/bin/asadmin</glassfish.asadmin>
-       
+
         <jacoco.includes>org/glassfish/**\:com/sun/enterprise/**</jacoco.includes>
-        
+
         <port.admin>14848</port.admin>
         <port.derby>11527</port.derby>
         <port.http>18080</port.http>
@@ -76,9 +76,9 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>com.googlecode.maven-download-plugin</groupId>
+                <groupId>io.github.download-maven-plugin</groupId>
                 <artifactId>download-maven-plugin</artifactId>
-                <version>1.6.7</version>
+                <version>2.0.0</version>
                 <executions>
                     <execution>
                         <id>download-ant</id>
@@ -147,7 +147,7 @@
                         <configuration>
                             <target xmlns:if="ant:if" xmlns:unless="ant:unless">
                                 <taskdef resource="net/sf/antcontrib/antcontrib.properties" classpathref="maven.plugin.classpath" />
-                                         
+
                                 <macrodef name="tck-setting">
                                     <attribute name="key" /> <attribute name="value" />
                                     <sequential>
@@ -155,7 +155,7 @@
                                         match="@{key}=.*" replace="@{key}=@{value}" />
                                     </sequential>
                                 </macrodef>
-                                
+
                                 <if>
                                     <equals arg1="${tck.mode}" arg2="platform" />
                                     <then>
@@ -172,33 +172,33 @@
                                         <fail/>
                                     </else>
                                 </if>
-                                
-                                
-                                <!-- 
-                                    Set exclude file 
-                                    
+
+
+                                <!--
+                                    Set exclude file
+
                                     This will exclude everything except for lines matching a pattern, which will not be excluded.
                                     In effect, it works as the reverse and only these tests will be executed.
-                                    
+
                                 -->
                                 <sequential if:set="run.test.pattern">
-                                    <echo message="Running test pattern ${run.test.pattern}" /> 
-                            
+                                    <echo message="Running test pattern ${run.test.pattern}" />
+
                                     <copy file="${project.basedir}/src/test/etc/ts-all-${tck.mode}.jtx"
                                         tofile="${tck.home}/bin/ts.jtx.tmp" overwrite="true" verbose="true"/>
-                            
+
                                     <replaceregexp file="${tck.home}/bin/ts.jtx.tmp"
                                         match="${run.test.pattern}" replace="" byline="true" />
-                                        
-                                    <copy file="${tck.home}/bin/ts.jtx.tmp" 
+
+                                    <copy file="${tck.home}/bin/ts.jtx.tmp"
                                         toFile="${tck.home}/bin/ts.jtx" overwrite="true" verbose="true">
                                         <filterchain>
                                             <ignoreblank/>
                                         </filterchain>
                                     </copy>
-                                    
+
                                     <delete file="${tck.home}/bin/ts.jtx.tmp"/>
-                                    
+
                                     <if>
                                         <equals arg1="${tck.mode}" arg2="platform" />
                                     <then>
@@ -213,32 +213,32 @@
                                             </then>
                                     </elseif>
                                     </if>
-                                    
+
                                 </sequential>
-                                
-                                
+
+
 
                                 <!-- Change configuration -->
-                                
+
                                 <tck-setting key="web.home" value="${glassfish.home}/glassfish"/>
                                 <tck-setting key="webServerHome" value="${glassfish.home}/glassfish"/>
                                 <tck-setting key="webServerHost" value="localhost"/>
                                 <tck-setting key="webServerPort" value="${port.http}"/>
-                                
+
                                 <tck-setting key="securedWebServicePort" value="${port.https}"/>
                                 <tck-setting key="s1as.admin.port" value="${port.admin}"/>
                                 <tck-setting key="glassfish.admin.port" value="${port.admin}"/>
                                 <tck-setting key="orb.port" value="${port.orb}"/>
                                 <tck-setting key="database.port" value="${port.derby}"/>
                                 <tck-setting key="harness.log.port" value="${port.harness.log}"/>
-                                
+
                                 <tck-setting key="report.dir" value="${tck.home}/facesreport/faces"/>
                                 <tck-setting key="work.dir" value="${tck.home}/faceswork/faces"/>
 
                                 <tck-setting key="impl.vi" value="glassfish"/>
                                 <tck-setting key="impl.vi.deploy.dir" value="${webServerHome}/domains/domain1/autodeploy"/>
                                 <tck-setting key="impl.deploy.timeout.multiplier" value="960"/>
-                                
+
                                 <tck-setting key="jsf.classes" value="${webServerHome}/modules/cdi-api.jar;${webServerHome}/modules/jakarta.servlet.jsp.jstl-api.jar;${webServerHome}/modules/jakarta.inject.jar;${webServerHome}/modules/jakarta.faces.jar;${webServerHome}/modules/jakarta.servlet.jsp-api.jar;${webServerHome}/modules/jakarta.servlet-api.jar;${webServerHome}/modules/expressly.jar"/>
 
                                 <limit maxwait="60">
@@ -272,10 +272,10 @@
                                         <arg value="domain1"/>
                                     </exec>
                                 </limit>
-                                
+
                                 <mkdir dir="${tck.home}/facesreport"/>
                                 <mkdir dir="${tck.home}/facesreport/faces"/>
-                                
+
                                 <replace file="${tck.home}/bin/xml/ts.top.import.xml" if:set="suspend-tck" >
                                   <replacetoken><![CDATA[<jvmarg value="-Xmx512m"/>]]></replacetoken>
                                   <replacevalue><![CDATA[<jvmarg value="-Xmx512m"/>
@@ -299,24 +299,24 @@
                                 <replace file="${glassfish.home}/glassfish/domains/domain1/config/domain.xml" 
                                     token="-Xmx512m" value="-Xmx1024m" />
                                 <taskdef resource="net/sf/antcontrib/antcontrib.properties" classpathref="maven.plugin.classpath" />
-                                
+
                                 <limit maxwait="300">
                                     <exec executable="${glassfish.asadmin}" dir="${glassfish.home}/glassfish/bin" failonerror="true">
                                         <arg value="start-domain"/>
                                         <arg value="--suspend" if:set="glassfish.suspend"/>
                                     </exec>
                                 </limit>
-                                
+
                                 <!-- Deploy single test -->
                                 <sequential if:set="run.test" >
                                     <dirname property="test.dir" file="${tck.home}/src/${run.test}"/>
                                     <echo>Deploying from ${test.dir}</echo>
-                                    
+
                                     <exec executable="${ant.home}/bin/ant" dir="${test.dir}" failonerror="true">
                                         <arg value="deploy"  />
                                     </exec>
                                 </sequential>
-                                
+
                                 <!-- Deploy all tests -->
                                 <sequential unless:set="run.test" >
                                     <echo>Deploying all archives</echo>
@@ -362,7 +362,7 @@
                                 <exec executable="${glassfish.asadmin}" dir="${glassfish.home}/glassfish/bin">
                                     <arg value="stop-domain" />
                                 </exec>
-                                
+
                                 <if>
                                     <not>
                                         <equals arg1="${testResult}" arg2="0" />

--- a/tck/old-tck/run/pom.xml
+++ b/tck/old-tck/run/pom.xml
@@ -296,8 +296,8 @@
                         </goals>
                         <configuration>
                             <target xmlns:if="ant:if" xmlns:unless="ant:unless">
-                                <replace file="${glassfish.home}/glassfish/domains/domain1/config/domain.xml" 
-                                    token="-Xmx512m" value="-Xmx1024m" />
+                                <replace file="${glassfish.home}/glassfish/domains/domain1/config/domain.xml"
+                                    token="-Xmx512m" value="-Xmx4g" />
                                 <taskdef resource="net/sf/antcontrib/antcontrib.properties" classpathref="maven.plugin.classpath" />
 
                                 <limit maxwait="300">

--- a/tck/pom.xml
+++ b/tck/pom.xml
@@ -41,7 +41,7 @@ mvn clean install -Dmojarra.noupdate
 
 Build old TCK once from the root (NOT from the /old-tck folder)
 
-mvn clean install -pl :old-tck-build  
+mvn clean install -pl :old-tck-build
 
 
 
@@ -95,19 +95,25 @@ mvn clean install -pl :old-tck-run -Dglassfish.suspend
         <maven.compiler.release>17</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        
+
         <maven.test.skip>false</maven.test.skip>
         <skipTests>false</skipTests>
         <test.selenium>true</test.selenium>
-        <chromedriver.version>124</chromedriver.version>
-        
-        <faces.version>4.1.0-SNAPSHOT</faces.version>
-        
-        <!-- 
+
+        <arquillian.version>1.10.0.Final</arquillian.version>
+        <arquillian-suite-extension.version>1.2.2</arquillian-suite-extension.version>
+        <chromedriver.version>139</chromedriver.version>
+        <faces.version>4.1.3-SNAPSHOT</faces.version>
+        <htmlunit.version>4.13.0</htmlunit.version>
+        <selenium.version>4.35.0</selenium.version>
+        <shrinkwrap-resolver.version>3.3.4</shrinkwrap-resolver.version>
+        <webdrivermanager.version>6.2.0</webdrivermanager.version>
+
+        <!--
             Set to the actual Faces API the implementation being tested is using.
-            
+
             This can best be done in a profile specific to the implementation.
-            See the standard profiles for examples. 
+            See the standard profiles for examples.
         -->
         <sigtest.api.groupId></sigtest.api.groupId>
         <sigtest.api.artifactId></sigtest.api.artifactId>
@@ -122,19 +128,19 @@ mvn clean install -pl :old-tck-run -Dglassfish.suspend
             <dependency>
                 <groupId>org.jboss.arquillian</groupId>
                 <artifactId>arquillian-bom</artifactId>
-                <version>1.9.5.Final</version>
+                <version>${arquillian.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>org.jboss.arquillian.container</groupId>
                 <artifactId>arquillian-container-test-api</artifactId>
-                <version>1.9.5.Final</version>
+                <version>${arquillian.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.omnifaces.arquillian</groupId>
-                <artifactId>glassfish-client-ee10</artifactId>
-                <version>1.8</version>
+                <groupId>junit</groupId>
+                <artifactId>junit</artifactId>
+                <version>4.13.2</version>
                 <scope>test</scope>
             </dependency>
 
@@ -144,7 +150,7 @@ mvn clean install -pl :old-tck-run -Dglassfish.suspend
                 <version>${faces.version}</version>
                 <scope>provided</scope>
             </dependency>
-            
+
             <dependency>
                 <groupId>jakarta.el</groupId>
                 <artifactId>jakarta.el-api</artifactId>
@@ -186,37 +192,43 @@ mvn clean install -pl :old-tck-run -Dglassfish.suspend
             </dependency>
             <dependency>
                 <groupId>org.htmlunit</groupId>
+                <artifactId>htmlunit</artifactId>
+                <version>${htmlunit.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.htmlunit</groupId>
                 <artifactId>htmlunit-core-js</artifactId>
-                <version>4.13.0</version>
+                <version>${htmlunit.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.htmlunit</groupId>
                 <artifactId>neko-htmlunit</artifactId>
-                <version>4.13.0</version>
+                <version>${htmlunit.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.htmlunit</groupId>
                 <artifactId>htmlunit-cssparser</artifactId>
-                <version>4.13.0</version>
+                <version>${htmlunit.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.htmlunit</groupId>
                 <artifactId>htmlunit-xpath</artifactId>
-                <version>4.13.0</version>
+                <version>${htmlunit.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.htmlunit</groupId>
                 <artifactId>htmlunit-csp</artifactId>
-                <version>4.13.0</version>
+                <version>${htmlunit.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.htmlunit</groupId>
                 <artifactId>htmlunit-websocket-client</artifactId>
-                <version>4.13.0</version>
+                <version>${htmlunit.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>
-    
+
     <dependencies>
         <dependency>
             <groupId>jakarta.faces</groupId>
@@ -252,7 +264,7 @@ mvn clean install -pl :old-tck-run -Dglassfish.suspend
             <artifactId>jakarta.enterprise.cdi-api</artifactId>
             <scope>provided</scope>
         </dependency>
-        
+
         <dependency>
             <groupId>jakarta.inject</groupId>
             <artifactId>jakarta.inject-api</artifactId>
@@ -265,7 +277,7 @@ mvn clean install -pl :old-tck-run -Dglassfish.suspend
             <version>3.1.1</version>
             <scope>provided</scope>
         </dependency>
-        
+
         <dependency>
             <groupId>jakarta.ejb</groupId>
             <artifactId>jakarta.ejb-api</artifactId>
@@ -298,7 +310,6 @@ mvn clean install -pl :old-tck-run -Dglassfish.suspend
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.13.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -314,14 +325,14 @@ mvn clean install -pl :old-tck-run -Dglassfish.suspend
         <dependency>
             <groupId>org.jboss.shrinkwrap.resolver</groupId>
             <artifactId>shrinkwrap-resolver-impl-maven</artifactId>
-            <version>3.3.4</version>
+            <version>${shrinkwrap-resolver.version}</version>
             <type>jar</type>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jboss.shrinkwrap.resolver</groupId>
             <artifactId>shrinkwrap-resolver-impl-maven-archive</artifactId>
-            <version>3.3.4</version>
+            <version>${shrinkwrap-resolver.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -339,7 +350,6 @@ mvn clean install -pl :old-tck-run -Dglassfish.suspend
         <dependency>
             <groupId>org.htmlunit</groupId>
             <artifactId>htmlunit</artifactId>
-            <version>4.13.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -419,7 +429,7 @@ mvn clean install -pl :old-tck-run -Dglassfish.suspend
                     </execution>
                 </executions>
             </plugin>
-            
+
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>
@@ -429,7 +439,7 @@ mvn clean install -pl :old-tck-run -Dglassfish.suspend
                     <failOnMissingWebXml>false</failOnMissingWebXml>
                 </configuration>
             </plugin>
-            
+
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
@@ -450,7 +460,7 @@ mvn clean install -pl :old-tck-run -Dglassfish.suspend
                     </systemPropertyVariables>
                 </configuration>
             </plugin>
-            
+
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-report-plugin</artifactId>
@@ -490,7 +500,7 @@ mvn clean install -pl :old-tck-run -Dglassfish.suspend
     </reporting>
 
     <profiles>
-    
+
         <profile>
             <id>build-epl-tck</id>
             <activation>
@@ -501,7 +511,7 @@ mvn clean install -pl :old-tck-run -Dglassfish.suspend
                 <licenseFile>${project.basedir}/LICENSE.md</licenseFile>
             </properties>
         </profile>
-    
+
         <profile>
             <id>custom</id>
         </profile>
@@ -521,19 +531,20 @@ mvn clean install -pl :old-tck-run -Dglassfish.suspend
             </activation>
 
             <properties>
+                <arquillian.glassfish.version>2.1.0</arquillian.glassfish.version>
                 <!-- Explicit version of Mojarra to test -->
                 <mojarra.version>4.1.0</mojarra.version>
-                
-                <!-- 
+
+                <!--
                     By default this profile will copy the Mojarra version to test to GlassFish.
-                    Set this to "true"" to skip copying and therefor use GlassFish as is. That is 
-                    useful to test GlassFish itself instead of just a specific Mojarra version.   
+                    Set this to "true"" to skip copying and therefor use GlassFish as is. That is
+                    useful to test GlassFish itself instead of just a specific Mojarra version.
                 -->
                 <mojarra.noupdate>false</mojarra.noupdate>
 
-                <!-- 
+                <!--
                     Exact artefact used by GlassFish that holds the API classes.
-                    This is used by the signature test in module /faces-signaturetest 
+                    This is used by the signature test in module /faces-signaturetest
                 -->
                 <sigtest.api.groupId>org.glassfish</sigtest.api.groupId>
                 <sigtest.api.artifactId>jakarta.faces</sigtest.api.artifactId>
@@ -541,16 +552,22 @@ mvn clean install -pl :old-tck-run -Dglassfish.suspend
 
                 <!-- Verhicle used for testing the Mojarra version -->
                 <glassfish.version>8.0.0-M12</glassfish.version>
+                <glassfish.dirName>glassfish8</glassfish.dirName>
                 <glassfish.root>${maven.multiModuleProjectDirectory}/target</glassfish.root>
-                <glassfish.home>${glassfish.root}/glassfish8</glassfish.home>
+                <glassfish.home>${glassfish.root}/${glassfish.dirName}</glassfish.home>
             </properties>
 
             <dependencies>
-                <!-- The actual Arquillian connector -->
                 <dependency>
-                    <groupId>org.omnifaces.arquillian</groupId>
+                    <groupId>ee.omnifish.arquillian</groupId>
                     <artifactId>arquillian-glassfish-server-managed</artifactId>
-                    <version>1.8</version>
+                    <version>${arquillian.glassfish.version}</version>
+                    <scope>test</scope>
+                </dependency>
+                <dependency>
+                    <groupId>ee.omnifish.arquillian</groupId>
+                    <artifactId>glassfish-client-ee11</artifactId>
+                    <version>${arquillian.glassfish.version}</version>
                     <scope>test</scope>
                 </dependency>
             </dependencies>
@@ -643,11 +660,13 @@ mvn clean install -pl :old-tck-run -Dglassfish.suspend
 
         <profile>
             <id>piranha-embedded-micro</id>
-
+      <properties>
+        <arquillian.piranha.version>21.6.0-SNAPSHOT</arquillian.piranha.version>
+      </properties>
             <dependencies>
                 <!-- Jakarta EE based client dependencies to contact a server via WebSocket or REST -->
                 <dependency>
-                    <groupId>org.omnifaces.arquillian</groupId>
+                    <groupId>ee.omnifish.arquillian</groupId>
                     <artifactId>glassfish-client-ee10</artifactId>
                     <scope>test</scope>
                 </dependency>
@@ -655,7 +674,7 @@ mvn clean install -pl :old-tck-run -Dglassfish.suspend
                 <dependency>
                     <groupId>cloud.piranha.arquillian</groupId>
                     <artifactId>piranha-arquillian-server</artifactId>
-                    <version>21.6.0-SNAPSHOT</version>
+                    <version>${arquillian.piranha.version}</version>
                     <scope>test</scope>
                 </dependency>
             </dependencies>
@@ -684,6 +703,7 @@ mvn clean install -pl :old-tck-run -Dglassfish.suspend
             <id>tomcat-remote</id>
 
             <properties>
+                <arquillian.tomcat.version>1.1.0.Final</arquillian.tomcat.version>
                 <skipEJB>true</skipEJB>
                 <skipCDI>true</skipCDI>
                 <skipJSF>true</skipJSF>
@@ -694,7 +714,7 @@ mvn clean install -pl :old-tck-run -Dglassfish.suspend
                 <dependency>
                     <groupId>org.jboss.arquillian.container</groupId>
                     <artifactId>arquillian-tomcat-remote-7</artifactId>
-                    <version>1.1.0.Final</version>
+                    <version>${arquillian.tomcat.version}</version>
                     <scope>test</scope>
                 </dependency>
             </dependencies>
@@ -718,7 +738,8 @@ mvn clean install -pl :old-tck-run -Dglassfish.suspend
             <id>tomcat-ci-managed</id>
 
             <properties>
-                <skipEJB>true</skipEJB>
+                <arquillian.tomcat.version>1.1.0.Final</arquillian.tomcat.version>
+        <skipEJB>true</skipEJB>
                 <skipCDI>true</skipCDI>
                 <skipJSF>true</skipJSF>
                 <skipJACC>true</skipJACC>
@@ -754,7 +775,7 @@ mvn clean install -pl :old-tck-run -Dglassfish.suspend
                 <dependency>
                     <groupId>org.jboss.arquillian.container</groupId>
                     <artifactId>arquillian-tomcat-managed-7</artifactId>
-                    <version>1.1.0.Final</version>
+                    <version>${arquillian.tomcat.version}</version>
                     <scope>test</scope>
                 </dependency>
             </dependencies>
@@ -822,11 +843,14 @@ mvn clean install -pl :old-tck-run -Dglassfish.suspend
 
         <profile>
             <id>wildfly-ci-managed</id>
+            <properties>
+              <arquillian.wildfly.version>5.0.0.Alpha1</arquillian.wildfly.version>
+            </properties>
             <dependencies>
                 <dependency>
                     <groupId>org.wildfly.arquillian</groupId>
                     <artifactId>wildfly-arquillian-container-managed</artifactId>
-                    <version>5.0.0.Alpha1</version>
+                    <version>${arquillian.wildfly.version}</version>
                     <exclusions>
                         <exclusion>
                             <groupId>org.jboss.sasl</groupId>
@@ -863,25 +887,24 @@ mvn clean install -pl :old-tck-run -Dglassfish.suspend
             </activation>
 
             <properties>
-                <!-- Arquillian Dependencies -->
-                <payara.arquillian.container.version>3.0.alpha8</payara.arquillian.container.version>
+                <arquillian.payara.version>3.0.alpha8</arquillian.payara.version>
             </properties>
 
             <dependencies>
                 <dependency>
                     <groupId>fish.payara.arquillian</groupId>
                     <artifactId>arquillian-payara-server-remote</artifactId>
-                    <version>${payara.arquillian.container.version}</version>
+                    <version>${arquillian.payara.version}</version>
                     <scope>test</scope>
                 </dependency>
                 <dependency>
                     <groupId>fish.payara.arquillian</groupId>
                     <artifactId>payara-client-ee9</artifactId>
                     <scope>test</scope>
-                    <version>${payara.arquillian.container.version}</version>
+                    <version>${arquillian.payara.version}</version>
                 </dependency>
-                <!-- 
-                Solution for 
+                <!--
+                Solution for
                 WARNING: A class jakarta.activation.DataSource for a default provider MessageBodyWriter<jakarta.activation.DataSource> was not found. The provider is not available.
                 fish.payara.arquillian.shaded.glassfish.jersey.message.internal.MessagingBinders$EnabledProvidersBinder bindToBinder
                 -->

--- a/tck/pom.xml
+++ b/tck/pom.xml
@@ -454,14 +454,6 @@ mvn clean install -pl :old-tck-run -Dglassfish.suspend
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>integration-test</goal>
-                            <goal>verify</goal>
-                        </goals>
-                    </execution>
-                </executions>
                 <configuration>
                     <systemPropertyVariables>
                         <finalName>${project.build.finalName}</finalName>
@@ -469,11 +461,30 @@ mvn clean install -pl :old-tck-run -Dglassfish.suspend
                         <chromedriver.version>${chromedriver.version}</chromedriver.version>
                     </systemPropertyVariables>
                 </configuration>
+                <executions>
+                    <execution>
+                        <id>integration-test</id>
+                        <goals>
+                            <goal>integration-test</goal>
+                        </goals>
+                        <phase>integration-test</phase>
+                    </execution>
+                    <execution>
+                        <id>veify</id>
+                        <goals>
+                            <goal>verify</goal>
+                        </goals>
+                        <phase>verify</phase>
+                    </execution>
+                </executions>
             </plugin>
 
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-report-plugin</artifactId>
+                <configuration>
+                    <aggregate>true</aggregate>
+                </configuration>
                 <executions>
                     <execution>
                         <phase>post-integration-test</phase>
@@ -482,9 +493,6 @@ mvn clean install -pl :old-tck-run -Dglassfish.suspend
                         </goals>
                     </execution>
                 </executions>
-                <configuration>
-                    <aggregate>true</aggregate>
-                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/tck/pom.xml
+++ b/tck/pom.xml
@@ -99,6 +99,8 @@ mvn clean install -pl :old-tck-run -Dglassfish.suspend
         <maven.test.skip>false</maven.test.skip>
         <skipTests>false</skipTests>
         <test.selenium>true</test.selenium>
+        <failsafe.rerunFailingTestsCount>3</failsafe.rerunFailingTestsCount>
+        <failsafe.failOnFlakeCount>0</failsafe.failOnFlakeCount>
 
         <arquillian.version>1.10.0.Final</arquillian.version>
         <arquillian-suite-extension.version>1.2.2</arquillian-suite-extension.version>
@@ -392,22 +394,32 @@ mvn clean install -pl :old-tck-run -Dglassfish.suspend
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.13.0</version>
+                    <version>3.14.0</version>
                     </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-dependency-plugin</artifactId>
-                    <version>3.6.1</version>
+                    <version>3.8.1</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>3.2.5</version>
+                    <version>3.5.3</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-failsafe-plugin</artifactId>
-                    <version>3.2.5</version>
+                    <version>3.5.3</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-surefire-report-plugin</artifactId>
+                    <version>3.5.3</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-war-plugin</artifactId>
+                    <version>3.4.0</version>
                 </plugin>
             </plugins>
         </pluginManagement>
@@ -433,7 +445,6 @@ mvn clean install -pl :old-tck-run -Dglassfish.suspend
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>
-                <version>3.4.0</version>
                 <configuration>
                     <attachClasses>true</attachClasses>
                     <failOnMissingWebXml>false</failOnMissingWebXml>
@@ -452,7 +463,6 @@ mvn clean install -pl :old-tck-run -Dglassfish.suspend
                     </execution>
                 </executions>
                 <configuration>
-                    <rerunFailingTestsCount>3</rerunFailingTestsCount>
                     <systemPropertyVariables>
                         <finalName>${project.build.finalName}</finalName>
                         <test.selenium>${test.selenium}</test.selenium>
@@ -464,7 +474,6 @@ mvn clean install -pl :old-tck-run -Dglassfish.suspend
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-report-plugin</artifactId>
-                <version>3.2.5</version>
                 <executions>
                     <execution>
                         <phase>post-integration-test</phase>
@@ -485,7 +494,6 @@ mvn clean install -pl :old-tck-run -Dglassfish.suspend
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-report-plugin</artifactId>
-                <version>3.2.5</version>
                 <configuration>
                     <skipSurefireReport>${skipSurefireReport}</skipSurefireReport>
                     <aggregate>true</aggregate>
@@ -660,9 +668,9 @@ mvn clean install -pl :old-tck-run -Dglassfish.suspend
 
         <profile>
             <id>piranha-embedded-micro</id>
-      <properties>
-        <arquillian.piranha.version>21.6.0-SNAPSHOT</arquillian.piranha.version>
-      </properties>
+            <properties>
+                <arquillian.piranha.version>21.6.0-SNAPSHOT</arquillian.piranha.version>
+            </properties>
             <dependencies>
                 <!-- Jakarta EE based client dependencies to contact a server via WebSocket or REST -->
                 <dependency>
@@ -739,7 +747,7 @@ mvn clean install -pl :old-tck-run -Dglassfish.suspend
 
             <properties>
                 <arquillian.tomcat.version>1.1.0.Final</arquillian.tomcat.version>
-        <skipEJB>true</skipEJB>
+                <skipEJB>true</skipEJB>
                 <skipCDI>true</skipCDI>
                 <skipJSF>true</skipJSF>
                 <skipJACC>true</skipJACC>
@@ -844,7 +852,7 @@ mvn clean install -pl :old-tck-run -Dglassfish.suspend
         <profile>
             <id>wildfly-ci-managed</id>
             <properties>
-              <arquillian.wildfly.version>5.0.0.Alpha1</arquillian.wildfly.version>
+                <arquillian.wildfly.version>5.0.0.Alpha1</arquillian.wildfly.version>
             </properties>
             <dependencies>
                 <dependency>

--- a/tck/pom.xml
+++ b/tck/pom.xml
@@ -99,7 +99,7 @@ mvn clean install -pl :old-tck-run -Dglassfish.suspend
         <maven.test.skip>false</maven.test.skip>
         <skipTests>false</skipTests>
         <test.selenium>true</test.selenium>
-        <failsafe.rerunFailingTestsCount>3</failsafe.rerunFailingTestsCount>
+        <failsafe.rerunFailingTestsCount>0</failsafe.rerunFailingTestsCount>
         <failsafe.failOnFlakeCount>0</failsafe.failOnFlakeCount>
 
         <arquillian.version>1.10.0.Final</arquillian.version>
@@ -548,6 +548,7 @@ mvn clean install -pl :old-tck-run -Dglassfish.suspend
 
             <properties>
                 <arquillian.glassfish.version>2.1.0</arquillian.glassfish.version>
+                <slf4j.version>2.0.17</slf4j.version>
                 <!-- Explicit version of Mojarra to test -->
                 <mojarra.version>4.1.0</mojarra.version>
 
@@ -571,6 +572,8 @@ mvn clean install -pl :old-tck-run -Dglassfish.suspend
                 <glassfish.dirName>glassfish8</glassfish.dirName>
                 <glassfish.root>${maven.multiModuleProjectDirectory}/target</glassfish.root>
                 <glassfish.home>${glassfish.root}/${glassfish.dirName}</glassfish.home>
+                <test.logManager>org.glassfish.main.jul.GlassFishLogManager</test.logManager>
+                <test.logLevel>INFO</test.logLevel>
             </properties>
 
             <dependencies>
@@ -584,6 +587,18 @@ mvn clean install -pl :old-tck-run -Dglassfish.suspend
                     <groupId>ee.omnifish.arquillian</groupId>
                     <artifactId>glassfish-client-ee11</artifactId>
                     <version>${arquillian.glassfish.version}</version>
+                    <scope>test</scope>
+                </dependency>
+                <dependency>
+                    <groupId>org.glassfish.main</groupId>
+                    <artifactId>glassfish-jul-extension</artifactId>
+                    <version>${glassfish.version}</version>
+                    <scope>test</scope>
+                </dependency>
+                <dependency>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-jdk14</artifactId>
+                    <version>${slf4j.version}</version>
                     <scope>test</scope>
                 </dependency>
             </dependencies>
@@ -655,17 +670,21 @@ mvn clean install -pl :old-tck-run -Dglassfish.suspend
                         </executions>
                     </plugin>
                     <plugin>
-                         <artifactId>maven-failsafe-plugin</artifactId>
-                         <configuration>
-                             <systemPropertyVariables>
-                                 <glassfish.home>${glassfish.root}/glassfish8</glassfish.home>
-                                 <glassfish.systemProperties>
-                                     user.language=en
-                                     user.country=US
-                                 </glassfish.systemProperties>
-                                 <test.selenium>${test.selenium}</test.selenium>
-                             </systemPropertyVariables>
-                         </configuration>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <configuration>
+                            <systemPropertyVariables>
+                                <glassfish.home>${glassfish.root}/glassfish8</glassfish.home>
+                                <glassfish.systemProperties>
+                                    user.language=en
+                                    user.country=US
+                                </glassfish.systemProperties>
+                                <glassfish.suspend>${glassfish.suspend}</glassfish.suspend>
+                                <test.selenium>${test.selenium}</test.selenium>
+                                <java.util.logging.manager>${test.logManager}</java.util.logging.manager>
+                                <java.util.logging.config.useDefaults>true</java.util.logging.config.useDefaults>
+                                <java.util.logging.config.defaultLevel>${test.logLevel}</java.util.logging.config.defaultLevel>
+                            </systemPropertyVariables>
+                        </configuration>
                     </plugin>
                 </plugins>
             </build>

--- a/tck/util/pom.xml
+++ b/tck/util/pom.xml
@@ -36,7 +36,6 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.13.2</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
@@ -46,48 +45,43 @@
         <dependency>
             <groupId>org.seleniumhq.selenium</groupId>
             <artifactId>selenium-java</artifactId>
-            <version>4.22.0</version>
+            <version>${selenium.version}</version>
         </dependency>
         <dependency>
             <groupId>org.seleniumhq.selenium</groupId>
             <artifactId>selenium-chrome-driver</artifactId>
-            <version>4.22.0</version>
+            <version>${selenium.version}</version>
         </dependency>
         <dependency>
             <groupId>org.seleniumhq.selenium</groupId>
-            <artifactId>selenium-devtools-v124</artifactId>
-            <version>4.22.0</version>
-        </dependency>
-        <dependency>
-            <groupId>commons-lang</groupId>
-            <artifactId>commons-lang</artifactId>
-            <version>2.6</version>
+            <artifactId>selenium-devtools-v${chromedriver.version}</artifactId>
+            <version>${selenium.version}</version>
         </dependency>
         <dependency>
             <groupId>io.github.bonigarcia</groupId>
             <artifactId>webdrivermanager</artifactId>
-            <version>6.1.0</version>
+            <version>${webdrivermanager.version}</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.shrinkwrap.resolver</groupId>
             <artifactId>shrinkwrap-resolver-impl-maven</artifactId>
-            <version>3.3.4</version>
+            <version>${shrinkwrap-resolver.version}</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.shrinkwrap.resolver</groupId>
             <artifactId>shrinkwrap-resolver-impl-maven-archive</artifactId>
-            <version>3.3.4</version>
+            <version>${shrinkwrap-resolver.version}</version>
         </dependency>
         <dependency>
             <groupId>org.eu.ingwar.tools</groupId>
             <artifactId>arquillian-suite-extension</artifactId>
-            <version>1.2.2</version>
+            <version>${arquillian-suite-extension.version}</version>
         </dependency>
 
         <dependency>
             <groupId>org.htmlunit</groupId>
             <artifactId>htmlunit</artifactId>
-            <version>4.13.0</version>
+			<scope>compile</scope>
         </dependency>
     </dependencies>
 </project>

--- a/tck/util/src/main/java/ee/jakarta/tck/faces/test/util/selenium/BaseITNG.java
+++ b/tck/util/src/main/java/ee/jakarta/tck/faces/test/util/selenium/BaseITNG.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Contributors to the Eclipse Foundation.
+ * Copyright (c) 2023, 2025 Contributors to the Eclipse Foundation.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -15,12 +15,8 @@
  */
 package ee.jakarta.tck.faces.test.util.selenium;
 
-import static java.lang.System.getProperty;
-import static org.jboss.shrinkwrap.api.ShrinkWrap.create;
-
 import java.io.File;
 import java.net.URL;
-import java.time.Duration;
 
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.test.api.ArquillianResource;
@@ -30,6 +26,9 @@ import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.runner.RunWith;
+
+import static java.lang.System.getProperty;
+import static org.jboss.shrinkwrap.api.ShrinkWrap.create;
 
 /**
  * Base class for tests, which provides a certain infrastructure can be used, but does not have to be
@@ -68,20 +67,14 @@ public class BaseITNG {
 
     protected WebPage getPage(String page) {
         webDriver.get(webUrl.toString() + page);
-        WebPage webPage = new WebPage(webDriver);
-        // Sometimes it takes longer until the first page is loaded after container startup
-        webPage.waitForPageToLoad(Duration.ofSeconds(120));
-        return webPage;
+        return new WebPage(webDriver);
     }
 
     /**
      * Selenium does not automatically update the page handles if a link is clicked without ajax
      */
     protected void updatePage() {
-        ExtendedWebDriver webDriver = getWebDriver();
-        for (String windowHandle : webDriver.getWindowHandles()) {
-            webDriver.switchTo().window(windowHandle);
-        }
+        webDriver.switchToWindowWithUrl(webDriver.getCurrentUrl());
     }
 
     protected int getStatusCode(String page) {

--- a/tck/util/src/main/java/ee/jakarta/tck/faces/test/util/selenium/ChromeDevtoolsDriver.java
+++ b/tck/util/src/main/java/ee/jakarta/tck/faces/test/util/selenium/ChromeDevtoolsDriver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Contributors to the Eclipse Foundation.
+ * Copyright (c) 2023, 2025 Contributors to the Eclipse Foundation.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -15,6 +15,7 @@
  */
 package ee.jakarta.tck.faces.test.util.selenium;
 
+import java.io.OutputStream;
 import java.net.URI;
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
@@ -33,7 +34,6 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Stream;
 
-import org.apache.commons.io.output.NullOutputStream;
 import org.openqa.selenium.By;
 import org.openqa.selenium.Capabilities;
 import org.openqa.selenium.Credentials;
@@ -50,17 +50,13 @@ import org.openqa.selenium.chrome.ChromeDriverService;
 import org.openqa.selenium.chrome.ChromeOptions;
 import org.openqa.selenium.chromium.ChromiumNetworkConditions;
 import org.openqa.selenium.devtools.DevTools;
-import org.openqa.selenium.devtools.v124.network.Network;
-import org.openqa.selenium.devtools.v124.network.model.Request;
-import org.openqa.selenium.devtools.v124.network.model.RequestId;
-import org.openqa.selenium.devtools.v124.network.model.ResponseReceived;
-import org.openqa.selenium.devtools.v124.network.model.TimeSinceEpoch;
-import org.openqa.selenium.html5.LocalStorage;
-import org.openqa.selenium.html5.Location;
-import org.openqa.selenium.html5.SessionStorage;
+import org.openqa.selenium.devtools.v139.network.Network;
+import org.openqa.selenium.devtools.v139.network.model.Request;
+import org.openqa.selenium.devtools.v139.network.model.RequestId;
+import org.openqa.selenium.devtools.v139.network.model.ResponseReceived;
+import org.openqa.selenium.devtools.v139.network.model.TimeSinceEpoch;
 import org.openqa.selenium.interactions.Sequence;
 import org.openqa.selenium.logging.EventType;
-import org.openqa.selenium.mobile.NetworkConnection;
 import org.openqa.selenium.print.PrintOptions;
 import org.openqa.selenium.remote.CommandExecutor;
 import org.openqa.selenium.remote.CommandPayload;
@@ -86,7 +82,6 @@ import static java.util.Optional.empty;
  *
  * @see also https://medium.com/codex/selenium4-a-peek-into-chrome-devtools-92bca6de55e0
  */
-@SuppressWarnings("unused")
 public class ChromeDevtoolsDriver implements ExtendedWebDriver {
 
     /*
@@ -156,7 +151,7 @@ public class ChromeDevtoolsDriver implements ExtendedWebDriver {
     public ChromeDevtoolsDriver(ChromeOptions options) {
         ChromeDriverService chromeDriverService = new ChromeDriverService.Builder().build();
 
-        chromeDriverService.sendOutputTo(NullOutputStream.INSTANCE);
+        chromeDriverService.sendOutputTo(OutputStream.nullOutputStream());
         delegate = new ChromeDriver(chromeDriverService, options);
     }
 
@@ -185,7 +180,7 @@ public class ChromeDevtoolsDriver implements ExtendedWebDriver {
             Logger.getLogger(ChromeDevtoolsDriver.class.getName())
                   .warning("Init timeout error, can happen, " + "if the driver already has been used, can be safely ignore");
         }
-        devTools.send(Network.enable(empty(), empty(), empty()));
+        devTools.send(Network.enable(empty(), empty(), empty(), empty()));
     }
 
     private void initNetworkListeners(DevTools devTools) {

--- a/tck/util/src/main/java/ee/jakarta/tck/faces/test/util/selenium/ChromeDevtoolsDriver.java
+++ b/tck/util/src/main/java/ee/jakarta/tck/faces/test/util/selenium/ChromeDevtoolsDriver.java
@@ -16,18 +16,23 @@
 package ee.jakarta.tck.faces.test.util.selenium;
 
 import java.io.OutputStream;
+import java.lang.Thread.State;
 import java.net.URI;
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
 import java.util.Collection;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.BiFunction;
+import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.logging.Level;
@@ -38,6 +43,7 @@ import org.openqa.selenium.By;
 import org.openqa.selenium.Capabilities;
 import org.openqa.selenium.Credentials;
 import org.openqa.selenium.JavascriptExecutor;
+import org.openqa.selenium.NoSuchWindowException;
 import org.openqa.selenium.OutputType;
 import org.openqa.selenium.Pdf;
 import org.openqa.selenium.ScriptKey;
@@ -51,8 +57,10 @@ import org.openqa.selenium.chrome.ChromeOptions;
 import org.openqa.selenium.chromium.ChromiumNetworkConditions;
 import org.openqa.selenium.devtools.DevTools;
 import org.openqa.selenium.devtools.v139.network.Network;
+import org.openqa.selenium.devtools.v139.network.model.MonotonicTime;
 import org.openqa.selenium.devtools.v139.network.model.Request;
 import org.openqa.selenium.devtools.v139.network.model.RequestId;
+import org.openqa.selenium.devtools.v139.network.model.ResourceType;
 import org.openqa.selenium.devtools.v139.network.model.ResponseReceived;
 import org.openqa.selenium.devtools.v139.network.model.TimeSinceEpoch;
 import org.openqa.selenium.interactions.Sequence;
@@ -60,14 +68,29 @@ import org.openqa.selenium.logging.EventType;
 import org.openqa.selenium.print.PrintOptions;
 import org.openqa.selenium.remote.CommandExecutor;
 import org.openqa.selenium.remote.CommandPayload;
+import org.openqa.selenium.remote.DriverCommand;
 import org.openqa.selenium.remote.ErrorHandler;
 import org.openqa.selenium.remote.FileDetector;
+import org.openqa.selenium.remote.RemoteWebDriver;
+import org.openqa.selenium.remote.RemoteWebElement;
+import org.openqa.selenium.remote.Response;
 import org.openqa.selenium.remote.SessionId;
+import org.openqa.selenium.support.ui.FluentWait;
+import org.openqa.selenium.support.ui.WebDriverWait;
 import org.openqa.selenium.virtualauthenticator.VirtualAuthenticator;
 import org.openqa.selenium.virtualauthenticator.VirtualAuthenticatorOptions;
 
 import static ee.jakarta.tck.faces.test.util.selenium.WebPage.STD_TIMEOUT;
+import static java.util.Comparator.comparing;
+import static java.util.Comparator.naturalOrder;
+import static java.util.Comparator.nullsFirst;
 import static java.util.Optional.empty;
+import static java.util.function.Predicate.not;
+import static java.util.logging.Level.FINE;
+import static java.util.logging.Level.FINEST;
+import static java.util.logging.Level.INFO;
+import static java.util.logging.Level.WARNING;
+import static org.apache.commons.lang3.builder.ToStringBuilder.reflectionToString;
 
 /**
  * Extended driver which we need for getting the http response code and the http response without having to revert to
@@ -82,17 +105,24 @@ import static java.util.Optional.empty;
  *
  * @see also https://medium.com/codex/selenium4-a-peek-into-chrome-devtools-92bca6de55e0
  */
-public class ChromeDevtoolsDriver implements ExtendedWebDriver {
+public class ChromeDevtoolsDriver extends RemoteWebDriver implements ExtendedWebDriver {
 
-    /*
+    private static final Logger LOG = Logger.getLogger(ChromeDevtoolsDriver.class.getName());
+    private static final Comparator<HttpCycleData> RESPONSE_TIME_COMPARATOR = comparing(HttpCycleData::getResponseTime,
+        nullsFirst(naturalOrder()));
+
+    /**
      * We only want the cdp version warning once, now matter how often the driver is called if not wanted at all the
      * selenium webdriver version must match the browser version
      */
-    static AtomicBoolean firstLog = new AtomicBoolean(Boolean.TRUE);
+    private static AtomicBoolean firstLog = new AtomicBoolean(Boolean.TRUE);
 
-    ChromeDriver delegate;
-    List<HttpCycleData> cycleData = new CopyOnWriteArrayList<>();
-    String lastGet;
+    private ChromeDriver delegate;
+    private ChromeDriverWait facesContentWait;
+    private ConcurrentLinkedQueue<HttpCycleData> cycleData = new ConcurrentLinkedQueue<>();
+    private ReentrantLock cycleDataWriteLock = new ReentrantLock();
+    private boolean firstRequest = true;
+    private String lastGet;
 
     public static ExtendedWebDriver stdInit() {
         Locale.setDefault(new Locale("en", "US"));
@@ -100,14 +130,16 @@ public class ChromeDevtoolsDriver implements ExtendedWebDriver {
 
         ChromeOptions options = new ChromeOptions();
 
-        if (System.getProperty("chromedriver.version") != null && !System.getProperty("chromedriver.version").isEmpty()) {
-            options.setBrowserVersion(System.getProperty("chromedriver.version"));
+        String chromedriverVersion = System.getProperty("chromedriver.version");
+        if (chromedriverVersion != null && !chromedriverVersion.isEmpty()) {
+            options.setBrowserVersion(chromedriverVersion);
         }
 
         // We can turn on a visual browser by
         // adding chromedriver.headless = false to our properties
         // default is headless = true
-        if (System.getProperty("chromedriver.headless") == null || "true".equals(System.getProperty("chromedriver.headless"))) {
+        String headless = System.getProperty("chromedriver.headless");
+        if (headless == null || "true".equals(headless)) {
             options.addArguments("--headless");
         }
 
@@ -116,13 +148,13 @@ public class ChromeDevtoolsDriver implements ExtendedWebDriver {
         options.addArguments("--allow-insecure-localhost");
         options.addArguments("--remote-allow-origins=*");
         options.addArguments("--ignore-urlfetcher-cert-requests");
-        options.addArguments("--auto-open-devtools-for-tabs");
+        if (Boolean.getBoolean("chromedriver.auto-open-devtools-for-tabs")) {
+            LOG.log(WARNING, "The --auto-open-devtools-for-tabs can cause test instability.");
+            options.addArguments("--auto-open-devtools-for-tabs");
+        }
         options.addArguments("--disable-gpu");
         options.setExperimentalOption("prefs", Map.of("intl.accept_languages", "en"));
         options.addArguments("--lang=en");
-
-        //* @deprecated Use {@link ChromeDriverService.Builder#withLogLevel(ChromeDriverLogLevel)} to set log level.
-        // options.setLogLevel(ChromeDriverLogLevel.OFF);
 
         ExtendedWebDriver driver = new ChromeDevtoolsDriver(options);
         driver.manage().timeouts().implicitlyWait(STD_TIMEOUT);
@@ -153,6 +185,9 @@ public class ChromeDevtoolsDriver implements ExtendedWebDriver {
 
         chromeDriverService.sendOutputTo(OutputStream.nullOutputStream());
         delegate = new ChromeDriver(chromeDriverService, options);
+        facesContentWait = new ChromeDriverWait(delegate, STD_TIMEOUT, Duration.ofMillis(100L))
+            .ignoring(WebDriverException.class);
+        setCommandExecutor(delegate.getCommandExecutor());
     }
 
     /**
@@ -177,37 +212,54 @@ public class ChromeDevtoolsDriver implements ExtendedWebDriver {
             devTools.createSession();
             devTools.send(Network.clearBrowserCache());
         } catch (TimeoutException ex) {
-            Logger.getLogger(ChromeDevtoolsDriver.class.getName())
-                  .warning("Init timeout error, can happen, " + "if the driver already has been used, can be safely ignore");
+            LOG.warning("Init timeout error, can happen, if the driver already has been used, can be safely ignore");
         }
         devTools.send(Network.enable(empty(), empty(), empty(), empty()));
     }
 
     private void initNetworkListeners(DevTools devTools) {
-        devTools.addListener(Network.requestWillBeSent(), entry -> {
-            // The Faces ajax only targets itself
-            // That way we can filter out resource requests early
-            if (!entry.getRequest().getUrl().contains(lastGet)) {
+        devTools.addListener(Network.requestWillBeSent(), request -> {
+            if (isIgnored(request.getType().orElse(null))) {
                 return;
             }
-
-            HttpCycleData data = new HttpCycleData();
-            data.requestId = entry.getRequestId();
-            data.request = entry.getRequest();
-            cycleData.add(data);
+            cycleDataWriteLock.lock();
+            try {
+                LOG.log(INFO, () -> "Recording request: " + reflectionToString(request));
+                HttpCycleData data = findOrCreate(request.getRequestId());
+                data.request = request.getRequest();
+                cycleData.add(data);
+            } finally {
+                cycleDataWriteLock.unlock();
+            }
         });
 
-        devTools.addListener(Network.responseReceived(), entry -> {
-            RequestId requestId = entry.getRequestId();
-            // Only in case of a match we add response to request
-            // so we only cover our ajax cycle and the original get
-            Optional<HttpCycleData> found =
-                    cycleData.stream()
-                             .filter(item -> item.requestId.toJson().equals(requestId.toJson()))
-                             .findFirst();
-
-            found.ifPresent(httpCycleData -> httpCycleData.responseReceived = entry);
+        // Sometimes response event comes even before request event.
+        devTools.addListener(Network.responseReceived(), response -> {
+            if (isIgnored(response.getType())) {
+                return;
+            }
+            cycleDataWriteLock.lock();
+            try {
+                LOG.log(INFO, () -> "Recording response: " + reflectionToString(response));
+                HttpCycleData data = findOrCreate(response.getRequestId());
+                data.responseReceived = response;
+                cycleData.add(data);
+            } finally {
+                cycleDataWriteLock.unlock();
+            }
         });
+    }
+
+    /**
+     * Interesting for us are just {@link ResourceType#XHR} and {@link ResourceType#DOCUMENT} types.
+     */
+    private boolean isIgnored(ResourceType resourceType) {
+        return resourceType != ResourceType.XHR && resourceType != ResourceType.DOCUMENT;
+    }
+
+    private HttpCycleData findOrCreate(RequestId requestId) {
+        return cycleData.stream().filter(data -> data.isRequest(requestId)).findFirst()
+            .orElse(new HttpCycleData(requestId));
     }
 
     public Capabilities getCapabilities() {
@@ -228,6 +280,19 @@ public class ChromeDevtoolsDriver implements ExtendedWebDriver {
 
     public void launchApp(String id) {
         delegate.launchApp(id);
+    }
+
+    @Override
+    protected Response execute(CommandPayload payload) {
+        // Session can change, there's a command for that.
+        setSessionId(delegate.getSessionId().toString());
+        Response response = super.execute(payload);
+        if (DriverCommand.CLICK_ELEMENT.equals(payload.getName())) {
+            LOG.log(FINEST, "Some element click was executed, waiting for Faces for sure ...");
+            waitForFaces(STD_TIMEOUT);
+            LOG.log(FINEST, "Waiting finished.");
+        }
+        return response;
     }
 
     public Map<String, Object> executeCdpCommand(String commandName, Map<String, Object> parameters) {
@@ -296,8 +361,106 @@ public class ChromeDevtoolsDriver implements ExtendedWebDriver {
 
     @Override
     public void get(String url) {
+        LOG.log(INFO, "Opening URL {0}", url);
         lastGet = url;
+        if (firstRequest) {
+            firstRequest = false;
+            getAndWaitForWindowAndFaces(url, Duration.ofSeconds(60));
+        } else {
+            getAndWaitForFaces(url, Duration.ofSeconds(10));
+        }
+    }
+
+    /**
+     * Navigates the current window to the url and waits until the retrieved page is settled down,
+     * which means all additional XHR requests were processed.
+     * If the window was switched somehow, tries to find the right window again.
+     *
+     * @param url target link
+     * @param timeout time to wait.
+     */
+    protected void getAndWaitForWindowAndFaces(String url, Duration timeout) {
+        WebDriverWait waitForWindow = new WebDriverWait(delegate, timeout, Duration.ofSeconds(5));
+        WebDriverWait waitForJs = new WebDriverWait(delegate, Duration.ofSeconds(10L), Duration.ofMillis(10));
+        waitForWindow.until(d -> {
+            try {
+                d.get(url);
+            } catch (NoSuchWindowException e) {
+                switchToWindowWithUrl(lastGet);
+                return false;
+            }
+            try {
+                waitForJs.until(e -> !cycleData.isEmpty());
+            } catch (TimeoutException e) {
+                // Will reload the page again
+                return false;
+            }
+            return true;
+        });
+        LOG.log(FINEST, "Communication with Faces started!");
+        waitForFaces(timeout);
+    }
+
+    /**
+     * Navigates the current window to the url and waits until the retrieved page is settled down,
+     * which means all additional XHR requests were processed.
+     *
+     * @param url target link
+     * @param timeout time to wait.
+     */
+    protected void getAndWaitForFaces(String url, Duration timeout) {
         delegate.get(url);
+        waitForFaces(timeout);
+    }
+
+    @Override
+    public void waitForFaces(Duration timeout) {
+        Duration pause = Duration.ofMillis(100);
+        // Some tests click a button and immediately check the result.
+        // As they probably produced a XHR request immediately,
+        // we should allow it to make it to the cycleData.
+        try {
+            Thread.sleep(pause.toMillis());
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+        ChromeDriverWait wait = new ChromeDriverWait(delegate, timeout, pause);
+        wait.until(d -> {
+            if (cycleData.isEmpty()) {
+                LOG.log(FINEST, "Waiting for communication with Faces server ...");
+                return false;
+            }
+            HttpCycleData data = getLastGetData();
+            LOG.log(FINEST, "LastGetData: {0}", data);
+            if (data == null) {
+                return false;
+            }
+            JavascriptExecutor jsExecutor = getJSExecutor();
+            String jsCommand = "return document.readyState";
+            Object result = jsExecutor.executeScript(jsCommand);
+            LOG.log(FINE, () -> jsCommand + " returned " + result);
+            // See JavaScript specifications for readyState values
+            return "complete".equals(result);
+        });
+    }
+
+    @Override
+    public void switchToWindowWithUrl(String url) {
+        for (String handle : getWindowHandles()) {
+            delegate.switchTo().window(handle);
+            if (delegate.getCurrentUrl().equals(url)) {
+                LOG.log(INFO, "Switched to open window with the url: {0}", delegate.getCurrentUrl());
+                return;
+            }
+        }
+        for (String handle : getWindowHandles()) {
+            delegate.switchTo().window(handle);
+            if (delegate.getCurrentUrl().startsWith("http")) {
+                LOG.log(WARNING, "Switched to random window using any http url. URL: {0}", delegate.getCurrentUrl());
+                return;
+            }
+        }
+        throw new IllegalStateException("Failed to find usable window.");
     }
 
     @Override
@@ -312,32 +475,43 @@ public class ChromeDevtoolsDriver implements ExtendedWebDriver {
 
     @Override
     public WebElement findElement(By locator) {
-        return delegate.findElement(locator);
+        return facesContentWait.until(driver -> {
+            RemoteWebElement element = (RemoteWebElement) driver.findElement(locator);
+            // element.getText will use our execute method.
+            // This is a temporary workaround for Spec1263IT and others which doesn't wait
+            // after click() until the element is redrawn.
+            element.setParent(this);
+            return element;
+        });
     }
 
     @Override
     public List<WebElement> findElements(By locator) {
-        return delegate.findElements(locator);
+        return facesContentWait.until(driver -> driver.findElements(locator));
     }
 
     @Override
     public String getPageSource() {
-        return delegate.getPageSource();
+        return facesContentWait.until(driver -> driver.getPageSource());
     }
 
     @Override
     public String getPageText() {
-        String head = delegate.findElement(By.tagName("head")).getAttribute("innerText").replaceAll("[\\s\\n ]", " ");
-        String body = delegate.findElement(By.tagName("body")).getAttribute("innerText").replaceAll("[\\s\\n ]", " ");
-        return head + " " + body;
+        return facesContentWait.until(driver -> {
+            String head = driver.findElement(By.tagName("head")).getAttribute("innerText").replaceAll("[\\s\\n ]", " ");
+            String body = driver.findElement(By.tagName("body")).getAttribute("innerText").replaceAll("[\\s\\n ]", " ");
+            return head + " " + body;
+        });
     }
 
     @Override
     public String getPageTextReduced() {
-        String head = delegate.findElement(By.tagName("head")).getAttribute("innerText");
-        String body = delegate.findElement(By.tagName("body")).getAttribute("innerText");
-        // handle blanks and nbsps
-        return (head + " " + body).replaceAll("[\\s\\u00A0]+", " ");
+        return facesContentWait.until(driver -> {
+            String head = driver.findElement(By.tagName("head")).getAttribute("innerText");
+            String body = driver.findElement(By.tagName("body")).getAttribute("innerText");
+            // handle blanks and nbsps
+            return (head + " " + body).replaceAll("[\\s\\u00A0]+", " ");
+        });
     }
 
     /**
@@ -352,6 +526,7 @@ public class ChromeDevtoolsDriver implements ExtendedWebDriver {
 
         cycleData.clear();
         lastGet = null;
+        firstRequest = false;
     }
 
     /**
@@ -400,29 +575,28 @@ public class ChromeDevtoolsDriver implements ExtendedWebDriver {
 
     @Override
     public int getResponseStatus() {
-        try {
-            HttpCycleData data = getLastGetData();
-            if (data == null) {
-                return -1;
-            }
-            if (data.responseReceived == null) {
-                return -1;
-            }
-            return data.responseReceived.getResponse().getStatus();
-        } catch (java.util.NoSuchElementException ex) {
+        HttpCycleData data = getLastGetData();
+        if (data == null || !data.hasResponse()) {
             return -1;
         }
+        return data.responseReceived.getResponse().getStatus();
     }
 
     @Override
     public String getResponseBody() {
         HttpCycleData data = getLastGetData();
+        if (data == null) {
+            return null;
+        }
         return delegate.getDevTools().send(Network.getResponseBody(data.requestId)).getBody();
     }
 
     @Override
     public String getRequestData() {
         HttpCycleData data = getLastGetData();
+        if (data == null) {
+            return null;
+        }
         return data.request.getPostData().orElse("");
     }
 
@@ -435,7 +609,7 @@ public class ChromeDevtoolsDriver implements ExtendedWebDriver {
     }
 
     public List<WebElement> findElements(SearchContext context, BiFunction<String, Object, CommandPayload> findCommand, By locator) {
-        return delegate.findElements(context, findCommand, locator);
+        return facesContentWait.until(driver -> driver.findElements(context, findCommand, locator));
     }
 
     public Object executeScript(String script, Object... args) {
@@ -503,37 +677,17 @@ public class ChromeDevtoolsDriver implements ExtendedWebDriver {
     }
 
     private HttpCycleData getLastGetData() {
-        sortResponses();
+        if (lastGet == null) {
+            return null;
+        }
 
-        return cycleData
-                .stream()
-                .filter(item -> item.request.getUrl().contains(lastGet))
-                // missing last api
-                .reduce((item1, item2) -> item2).orElse(null);
-    }
-
-    private void sortResponses() {
-        // We sort by response timestamps, with items with no response being first
-        // last response always being the one at the bottom
-        cycleData.sort((o1, o2) -> {
-            if (o1.responseReceived == null) {
-                return -1;
-            }
-
-            if (o2.responseReceived == null) {
-                return 1;
-            }
-
-            return Long.compare(o1.responseReceived.getTimestamp().toJson().longValue(),
-                    o2.responseReceived.getTimestamp().toJson().longValue());
-        });
+        return cycleData.stream().filter(item -> item.hasBaseUrl(lastGet)).sorted(RESPONSE_TIME_COMPARATOR.reversed())
+            .findFirst().orElse(null);
     }
 
     @Override
     public void printProcessedResponses() {
-        sortResponses();
-
-        cycleData.stream().filter(item -> item.responseReceived != null)
+        cycleData.stream().filter(HttpCycleData::hasResponse).sorted(RESPONSE_TIME_COMPARATOR)
                 // Missing last api
                 .forEach(item -> {
                     System.out.println("Url: " + item.request.getUrl());
@@ -551,13 +705,77 @@ public class ChromeDevtoolsDriver implements ExtendedWebDriver {
 
     @Override
     public JavascriptExecutor getJSExecutor() {
-        return delegate;
+        return this;
     }
 
+    private class ChromeDriverWait extends FluentWait<ChromeDriver> {
+        ChromeDriverWait(ChromeDriver input, Duration timeout, Duration pause) {
+            super(input);
+            withTimeout(timeout);
+            pollingEvery(pause);
+        }
+
+        public <V> V until(Function<? super ChromeDriver, V> isTrue) {
+            // Block if there is anything what could result in changes.
+            super.until(d -> !isCommunicationInProgress());
+            return super.until(isTrue);
+        }
+
+        public ChromeDriverWait ignoring(Class<? extends Throwable> exceptionType) {
+            return ignoreAll(List.of(exceptionType));
+        }
+
+        public <K extends Throwable> ChromeDriverWait ignoreAll(Collection<Class<? extends K>> types) {
+            super.ignoreAll(types);
+            return this;
+        }
+
+        private boolean isCommunicationInProgress() {
+            Optional<HttpCycleData> incomplete = cycleData.stream().filter(not(HttpCycleData::hasResponse)).findAny();
+            if (incomplete.isPresent()) {
+                LOG.log(FINE, "Still waiting for response for {0}.", incomplete.get());
+                return true;
+            }
+            return false;
+        }
+    }
 }
 
 class HttpCycleData {
-    public RequestId requestId;
+    public final RequestId requestId;
     public Request request;
     public ResponseReceived responseReceived;
+
+    public HttpCycleData(RequestId requestId) {
+        this.requestId = requestId;
+    }
+
+    public boolean isRequest(RequestId id) {
+        return requestId.toJson().equals(id.toJson());
+    }
+
+    public boolean hasBaseUrl(String urlBase) {
+        String url = request == null ? null : request.getUrl();
+        return url != null && url.startsWith(urlBase);
+    }
+
+    public boolean hasResponse() {
+        return responseReceived != null;
+    }
+
+    public Integer getResponseTime() {
+        if (responseReceived == null) {
+            return null;
+        }
+        MonotonicTime timestamp = responseReceived.getTimestamp();
+        if (timestamp == null) {
+            return null;
+        }
+        return timestamp.toJson().intValue();
+    }
+
+    @Override
+    public String toString() {
+        return reflectionToString(this);
+    }
 }

--- a/tck/util/src/main/java/ee/jakarta/tck/faces/test/util/selenium/DriverPool.java
+++ b/tck/util/src/main/java/ee/jakarta/tck/faces/test/util/selenium/DriverPool.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Contributors to the Eclipse Foundation.
+ * Copyright (c) 2023, 2025 Contributors to the Eclipse Foundation.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -21,7 +21,6 @@ import java.util.concurrent.ConcurrentLinkedQueue;
  * a helper class providing pool management for our drivers Note, the pool itself is thread safe (and must be), the
  * drivers are not!
  */
-@SuppressWarnings("unused")
 public class DriverPool {
 
     ConcurrentLinkedQueue<ExtendedWebDriver> allDrivers = new ConcurrentLinkedQueue<>();
@@ -35,7 +34,7 @@ public class DriverPool {
     public synchronized ExtendedWebDriver getOrNewInstance() {
         // synchronized to avoid get race conditions.... there is a non synchonzed part between the check and remove
         // to make this easy we simply synchronize the get to fix it
-        ExtendedWebDriver webDriver = (availableDrivers.size() > 0) ? availableDrivers.remove() : null;
+        ExtendedWebDriver webDriver = availableDrivers.isEmpty() ? null : availableDrivers.remove();
         if (webDriver == null) {
             webDriver = ChromeDevtoolsDriver.stdInit();
             allDrivers.add(webDriver);
@@ -83,7 +82,7 @@ public class DriverPool {
      * cleans up the pool
      */
     public void quitAll() {
-        allDrivers.stream().forEach(webDriver -> webDriver.quit());
+        allDrivers.stream().forEach(ExtendedWebDriver::quit);
         allDrivers.clear();
         availableDrivers.clear();
     }

--- a/tck/util/src/main/java/ee/jakarta/tck/faces/test/util/selenium/ExtendedWebDriver.java
+++ b/tck/util/src/main/java/ee/jakarta/tck/faces/test/util/selenium/ExtendedWebDriver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Contributors to the Eclipse Foundation.
+ * Copyright (c) 2023, 2025 Contributors to the Eclipse Foundation.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -14,6 +14,8 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 or Apache-2.0
  */
 package ee.jakarta.tck.faces.test.util.selenium;
+
+import java.time.Duration;
 
 import org.openqa.selenium.JavascriptExecutor;
 import org.openqa.selenium.WebDriver;
@@ -81,6 +83,22 @@ public interface ExtendedWebDriver extends WebDriver {
      * debugging helper which allows to look into the processed response data
      */
     void printProcessedResponses();
+
+
+    /**
+     * Waits for until the communication with Faces server is completed.
+     *
+     * @param timeout
+     */
+    void waitForFaces(Duration timeout);
+
+    /**
+     * Takes current windows handles and switches the driver to the one with the given url.
+     * If such window was not found, result is undefined.
+     *
+     * @param url
+     */
+    void switchToWindowWithUrl(String url);
 
     /**
      * quits the driver engine


### PR DESCRIPTION
- Chrome randomly opened devtools window
- Responses sometimes come before requests (not logical, but I have seen that)
- Requests and responses can be filtered by type
- Using ConcurrentLinkedQueue and lock rather than CopyOnWriteArrayList
  - Filtering current data is possible at any time
  - For updating/creating the record we lock changes
- Some tests click buttons and immediately test results, but browser uses more threads to process the event. In these cases we just watch until we can touch new/reloaded elements.
- Improved logging
  - Using lighter formater for GF
  - GJULE is configurable from command line: `-Dtest.logLevel=FINEST`
  - Some dependencies use SLF4J

This PR should be merged after #2048 and then to 5.0 too - there will be few conflicts as @BalusC already addressed some of issues, but nothing complicated. Solutions in this PR should play well with fixes there, especially if Chrome would start using async threads completely out of our control.

For 5.0 there will be some conflicts, but I will handle easily - I will delete the workaround with element.clicks and also that sleep in the begin of waitForFaces - these should be controlled by tests and waituntil conditions instead. All that can be simplified when tests will be perfect.
