### PR TITLE
Fixed classpath separator

### DIFF
--- a/tck/old-tck/run/pom.xml
+++ b/tck/old-tck/run/pom.xml
@@ -239,7 +239,7 @@
                                 <tck-setting key="impl.vi.deploy.dir" value="${webServerHome}/domains/domain1/autodeploy"/>
                                 <tck-setting key="impl.deploy.timeout.multiplier" value="960"/>
 
-                                <tck-setting key="jsf.classes" value="${webServerHome}/modules/cdi-api.jar:${webServerHome}/modules/jakarta.servlet.jsp.jstl-api.jar:${webServerHome}/modules/jakarta.inject.jar:${webServerHome}/modules/jakarta.faces.jar:${webServerHome}/modules/jakarta.servlet.jsp-api.jar:${webServerHome}/modules/jakarta.servlet-api.jar:${webServerHome}/modules/expressly.jar"/>
+                                <tck-setting key="jsf.classes" value="${webServerHome}/modules/cdi-api.jar${pathsep}${webServerHome}/modules/jakarta.servlet.jsp.jstl-api.jar${pathsep}${webServerHome}/modules/jakarta.inject.jar${pathsep}${webServerHome}/modules/jakarta.faces.jar${pathsep}${webServerHome}/modules/jakarta.servlet.jsp-api.jar${pathsep}${webServerHome}/modules/jakarta.servlet-api.jar${pathsep}${webServerHome}/modules/expressly.jar"/>
 
                                 <limit maxwait="60">
                                     <exec executable="${glassfish.asadmin}" dir="${glassfish.home}/glassfish/bin" failonerror="true">

--- a/tck/old-tck/source/pom-bundle.xml
+++ b/tck/old-tck/source/pom-bundle.xml
@@ -320,7 +320,7 @@
                                 <tck-setting key="impl.vi.deploy.dir" value="${webServerHome}/domains/domain1/autodeploy"/>
                                 <tck-setting key="impl.deploy.timeout.multiplier" value="960"/>
 
-                                <tck-setting key="jsf.classes" value="${webServerHome}/modules/cdi-api.jar;${webServerHome}/modules/jakarta.servlet.jsp.jstl-api.jar;${webServerHome}/modules/jakarta.inject.jar;${webServerHome}/modules/jakarta.faces.jar;${webServerHome}/modules/jakarta.servlet.jsp-api.jar;${webServerHome}/modules/jakarta.servlet-api.jar;${webServerHome}/modules/expressly.jar"/>
+                                <tck-setting key="jsf.classes" value="${webServerHome}/modules/cdi-api.jar${pathsep}${webServerHome}/modules/jakarta.servlet.jsp.jstl-api.jar${pathsep}${webServerHome}/modules/jakarta.inject.jar${pathsep}${webServerHome}/modules/jakarta.faces.jar${pathsep}${webServerHome}/modules/jakarta.servlet.jsp-api.jar${pathsep}${webServerHome}/modules/jakarta.servlet-api.jar${pathsep}${webServerHome}/modules/expressly.jar"/>
 
                                 <limit maxwait="300">
                                     <exec executable="${glassfish.asadmin}" dir="${glassfish.home}/glassfish/bin">


### PR DESCRIPTION
- Not sure if anyone was able to run it on windows, but on linux it caused mixing `;` and `:` on a single classpath visible also in the log output in command: `com.sun.ts.lib.harness.ExecTSTestCmd CLASSPATH=`