### PR TITLE
TCK build failed when switching back from 5.0 to 4.0 branch

### DIFF
--- a/tck/old-tck/build/pom.xml
+++ b/tck/old-tck/build/pom.xml
@@ -76,10 +76,21 @@
                 <configuration>
                     <filesets>
                         <fileset>
-                            <directory>old-tck/source/release/JSF_BUILD</directory>
+                            <directory>${project.basedir}/../source/release/JSF_BUILD</directory>
                             <includes>
                                 <include>**</include>
                             </includes>
+                        </fileset>
+                        <fileset>
+                            <directory>${project.basedir}/../source/lib</directory>
+                            <includes>
+                                <include>*.jar</include>
+                            </includes>
+                            <excludes>
+                                <exclude>ant_sun.jar</exclude>
+                                <exclude>apiCheck.jar</exclude>
+                                <exclude>javatest.jar</exclude>
+                            </excludes>
                         </fileset>
                     </filesets>
                 </configuration>

--- a/tck/old-tck/build/pom.xml
+++ b/tck/old-tck/build/pom.xml
@@ -84,13 +84,8 @@
                         <fileset>
                             <directory>${project.basedir}/../source/lib</directory>
                             <includes>
-                                <include>*.jar</include>
+                                <include>jakarta.faces-api.jar</include>
                             </includes>
-                            <excludes>
-                                <exclude>ant_sun.jar</exclude>
-                                <exclude>apiCheck.jar</exclude>
-                                <exclude>javatest.jar</exclude>
-                            </excludes>
                         </fileset>
                     </filesets>
                 </configuration>


### PR DESCRIPTION
TCK build failed when switching back from 5.0 to 4.0 branch within the same local git repo; it turns out that the jakarta-faces-api.jar in /tck/old-tck/source/lib directory was of 5.0 version! (and caused compilation error on FacesMessage.Severity because it was migrated to enum). So the /tck/old-tck/source/lib/jakarta-faces-api.jar was somehow never deleted/updated if it already exists. So the mvn clean plugin had to be adjusted to ensure that all untracked files (the downloaded jars) in /tck/old-tck/source/lib are explicitly removed during build. This way the TCK module in the repo is guaranteed portable across different branches / API versions.

This fix ensures that executing `mvn clean install` from either `/tck` or `/tck/old-tck` is always repeatable across different branches / API versions and guarantees that the `/tck/old-tck/source/lib/jakarta-faces-api.jar` is of the correct version.

Same PR for 4.1: https://github.com/jakartaee/faces/pull/2130