### PR TITLE
Auto-skip CSP-backport-incompatible ITs for Mojarra 4.0.17+ / 4.1.8+

### DIFF
--- a/tck/pom.xml
+++ b/tck/pom.xml
@@ -385,7 +385,7 @@
             <properties>
                 <!-- Explicit version of Mojarra to test -->
                 <mojarra.noupdate>false</mojarra.noupdate>
-                <mojarra.version>4.0.11</mojarra.version>
+                <mojarra.version>4.0.17-SNAPSHOT</mojarra.version>
 
                 <!-- Verhicle used for testing the Mojarra version -->
                 <glassfish.version>7.0.25</glassfish.version>
@@ -460,6 +460,49 @@
                                  <glassfish.home>${glassfish.root}/glassfish7</glassfish.home>
                              </systemPropertyVariables>
                          </configuration>
+                    </plugin>
+
+                    <!--
+                        Auto-skip the IT tests that are incompatible with the CSP backport in Mojarra 4.0.17+ / 4.1.8+
+                        (#5606 — inline event-attribute assumptions that no longer hold once handlers are attached via
+                        mojarra.ael). Detection is by mojarra.version; only the 4.0.17+ and 4.1.8+ ranges trigger the
+                        exclusions — older Mojarra and any other (newer or non-Mojarra) versions run unfiltered.
+                    -->
+                    <plugin>
+                        <groupId>org.codehaus.gmavenplus</groupId>
+                        <artifactId>gmavenplus-plugin</artifactId>
+                        <version>3.0.2</version>
+                        <dependencies>
+                            <dependency>
+                                <groupId>org.apache.groovy</groupId>
+                                <artifactId>groovy</artifactId>
+                                <version>4.0.21</version>
+                                <scope>runtime</scope>
+                            </dependency>
+                        </dependencies>
+                        <executions>
+                            <execution>
+                                <id>compute-csp-backport-flags</id>
+                                <phase>validate</phase>
+                                <goals><goal>execute</goal></goals>
+                                <configuration>
+                                    <scripts>
+                                        <script><![CDATA[
+                                            def raw = (project.properties['mojarra.version'] ?: '').replace('-SNAPSHOT', '')
+                                            if (!(raw ==~ /\d+\.\d+\.\d+/)) return
+                                            def (maj, min, inc) = raw.tokenize('.')*.toInteger()
+                                            def cspBackport =
+                                                (maj == 4 && min == 0 && inc >= 17) ||
+                                                (maj == 4 && min == 1 && inc >= 8)
+                                            if (cspBackport && !project.properties.containsKey('it.test')) {
+                                                project.properties['it.test'] = '**/*IT.java,!**/Issue2439IT.java,!**/Issue2674IT.java,!**/Issue4331IT.java,!**/Spec1238IT.java'
+                                                project.properties['failsafe.failIfNoSpecifiedTests'] = 'false'
+                                            }
+                                        ]]></script>
+                                    </scripts>
+                                </configuration>
+                            </execution>
+                        </executions>
                     </plugin>
                 </plugins>
             </build>


### PR DESCRIPTION
The CSP backport (eclipse-ee4j/mojarra#5606 for Mojarra 4.0.17 and 4.1.8) replaces inline event-handler attributes (onclick/onchange/onfocus/...) with trailing <script>mojarra.ael(...)</script> listeners. A handful of HtmlUnit-based 4.0 ITs assert against those now-empty inline attributes and can't be edited:

- Issue2439IT (faces22/ajax) — reads input.onchange
- Issue2674IT (faces22/ajax) — reads input.onfocus
- Issue4331IT, Spec1238IT (faces23/searchExpression) — read input.onchange

To avoid hand-passing -Dit.test=... on every run, parse mojarra.version in the validate phase via gmavenplus-plugin and, only when the version falls in 4.0.17+ or 4.1.8+, populate it.test with the exclusion pattern and set failsafe.failIfNoSpecifiedTests=false. Anything else (older Mojarra, 4.2.x, 5.x, or a non-Mojarra impl overriding mojarra.version) runs unfiltered. A user-supplied -Dit.test=... still wins.

Lives only inside the glassfish-ci-managed profile, so MyFaces/Tomcat/Payara runs are untouched.

---

cc: @jasondlee 

Same PR for 4.1 here: https://github.com/jakartaee/faces/pull/2153