### PR TITLE
Add gf-pool: shared GlassFish instance pool for parallel TCK runs

### DIFF
--- a/tck/README.md
+++ b/tck/README.md
@@ -1,5 +1,5 @@
 <!---
-[//]: # " Copyright (c) 2021 Contributors to the Eclipse foundation. All rights reserved.
+[//]: # " Copyright (c) 2021, 2026 Contributors to the Eclipse foundation. All rights reserved. "
 [//]: # "  "
 [//]: # " This program and the accompanying materials are made available under the "
 [//]: # " terms of the Eclipse Public License v. 2.0, which is available at "
@@ -14,161 +14,137 @@
 [//]: # " SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 "
 -->
 
-# Faces "new" tests
+# Jakarta Faces TCK
 
-The tests in this folder assert that functionality is working as it should. Test are junit tests
-that use Arquillian to start/stop a server and to deploy/undeploy. The (plain) junit tests then do
-HTTP requests to the server. No Arquillian "magic" is being used, and specifically no magic in-container
-transfer of test code happens. All test code runs client-side in regular junit tests.
+Integration tests that assert the Faces API and reference implementation behave
+as the spec mandates. Tests are JUnit + Selenium driving real HTTP requests
+against a deployed WAR; Arquillian only handles deploy/undeploy. No in-container
+test transfer is used — all assertions run client-side.
 
-## NOTE
+## Architecture: the GlassFish pool
 
-This is a relatively new effort (started in Mojarra 4.0). Not all functionality is covered yet.
+The TCK runs every test module against a pre-started GlassFish instance from a
+shared **pool**, leased per-module by a Java agent attached to each
+failsafe-forked test JVM. The pool lives entirely under
+`gf-pool/target/pool/` and is wiped by `mvn clean`.
+
+- `gf-pool` module: unpacks GlassFish, overlays the Mojarra build under test,
+  clones the install into `slot-N/` directories (hardlinked via `cp -al`),
+  patches each slot's port range, and starts the initial slot's domain.
+- `SlotLeaserAgent` (Java agent, `-javaagent:slot-leaser-agent.jar`):
+  acquires a `FileLock` on `slot-N/lock`, publishes the slot's
+  `arquillian.adminPort` / `httpPort` / `httpsPort` as system properties for
+  the Arquillian remote container, and holds the lock for the JVM lifetime
+  (released automatically on JVM exit).
+- Grow-on-demand: if every existing slot is leased, the agent provisions
+  another slot up to `max(4, cores/2)`. So a single
+  `mvn -Dit.test=…` boots one server; `mvn -T 4 install` grows to four;
+  CI on a 32-core host tops out at 16.
+- `ShutdownHookInstaller`: a custom Ant task registered by the `gf-pool`
+  antrun. Runs in the Maven JVM and installs a JVM shutdown hook that stops
+  every running slot at session end — both on normal completion and on
+  `Ctrl+C`.
 
 ## Running the tests
 
-A default run of the tests can be started using:
+Full suite, sequentially:
 
 ```bash
 mvn clean install
 ```
 
-This will transparently download and unzip GlassFish into the root of this `test2` folder and update it with the build
-of Mojarra produced by this project. The tests are then run against this server.
-
-### Running the tests with a specific version of Mojarra
-
-Tests can be run with any version of Mojarra supported by GlassFish (7.x the moment):
+To actually exercise the pool's parallelism, pass `-T N`:
 
 ```bash
-mvn clean install -pl :childCountTest -Dmojarra.version=4.0.0
+mvn clean install -T 4
 ```
+
+The pool starts with one slot and grows on demand, so a sequential build
+uses one GlassFish; `-T 4` grows up to four; `-T 8` up to eight (capped at
+`max(4, cores/2)`). Pick `-T` based on host capacity.
+
+The `cyclonedx-maven-plugin:makeAggregateBom` mojo is annotated
+`@aggregator` (it walks the full reactor's dep graph for every SBOM).
+The TCK root pom binds it to run **once at the root reactor**, not
+per-module — so the parallel build doesn't repeatedly serialise on it.
+Skip the SBOM entirely with `-DskipSBOM`. To force eager provisioning
+of all pool slots from the start: `-Dgf.pool.size=N`.
+
+A single test module:
 
 ```bash
-mvn clean install -pl :childCountTest -Dmojarra.version=4.0.5-SNAPSHOT
+mvn -pl faces50/ajax -am verify
 ```
 
-etc
-
-### Running the tests with the supplied version of Mojarra using the default GlassFish server
-
-Tests can be run without updating Mojarra and using the version that ships with GlassFish (7.x the moment):
+A single test class or method:
 
 ```bash
-mvn clean install -pl :childCountTest -Dmojarra.noupdate=true
+mvn -pl faces50/ajax -am verify -Dit.test=Issue5594IT
+mvn -pl faces50/ajax -am verify -Dit.test=Issue5594IT#someMethod
 ```
 
-
-### Debugging using the default GlassFish server
-
-GlassFish can be switched to debugging mode and suspend right at the start using:
+Against an existing GlassFish install (skips the zip download and the
+Mojarra overlay; that install becomes the pool's clone source — every
+slot is `cp -al`-cloned from it, with `applications/`, `generated/`,
+`logs/` cleared per slot):
 
 ```bash
-mvn clean install -Dsuspend=true
+mvn clean install -T 4 -Dglassfish.home=/path/to/glassfish9
 ```
 
-This will suspend the JVM running GlassFish and wait for a debug connection on port `9009`.
+## Common overrides
 
-### Debugging a specific test
+| Flag | Effect |
+| --- | --- |
+| `-Dmojarra.version=X.Y.Z` | Test against a specific Mojarra release/snapshot. |
+| `-Dmojarra.noupdate=true` | Skip the Mojarra overlay; test the build that ships with GlassFish. Set `-Dsigtest.api.version=` to match the API GlassFish ships. |
+| `-Dglassfish.home=/path/to/glassfish9` | Skip the GlassFish download; clone slots from an existing install. Each slot still gets a fresh copy of `domains/` with `applications/`, `generated/`, `logs/` cleared. |
+| `-Dgf.pool.size=N` | Pre-provision N slots at build time instead of the default 1. |
+| `-Dgf.pool.maxSize=N` | Override the grow-on-demand cap (default `max(4, cores/2)`). |
+| `-T 8` | Eight Maven threads. Pool grows up to `gf.pool.maxSize` to match. |
+| `-T 1` | Sequential build, single slot. |
 
-A specific test module can be tested using the normal Maven method of building a single module:
+To force more pool slots than the default `max(4, cores/2)` cap, set
+`gf.pool.size` to the count you want. The grow cap is auto-raised to match,
+so you don't have to set both. Example for a 10-core (20-thread) host
+running 16 GFs:
 
 ```bash
-mvn -pl :childCountTest  clean install -Dsuspend=true
+mvn clean install -T 16 -Dgf.pool.size=16
 ```
 
-A specific test class or even test method within such test class can be done via the normal Maven failsafe way:
+`-Dgf.pool.maxSize=N` is only needed when you want a *higher* grow ceiling
+than the initial provision (e.g. `-Dgf.pool.size=4 -Dgf.pool.maxSize=16` to
+start small and let grow-on-demand scale up to 16). Memory is the real
+constraint — budget ~1 GB per slot for GlassFish plus headroom for the
+test JVMs and browsers.
 
+## Pool lifecycle helpers
+
+The pool is normally stopped automatically at the end of every Maven session
+by `ShutdownHookInstaller`. Two convenience scripts are provided for running the
+pool independently of a build:
 
 ```bash
-mvn clean install -pl :childCountTest -Dit.test=ChildCountTestIT#testChildCountTest -Dsuspend=true
+./start-pool.sh                                 # provision and start the pool
+./start-pool.sh -Dglassfish.home=/path/to/gf    # pass through gf-pool overrides
+./stop-pool.sh                                  # stop everything
 ```
 
-### Testing against other server (WIP)
+## Testing against other servers (WIP)
 
-The tests support being run against any server for which there is an Arquillian connector available via profiles:
+Other Arquillian-supported servers can be selected via profile:
 
 ```bash
 mvn clean install -Ppiranha-embedded-micro
+mvn clean install -Ptomcat-ci-managed
 ```
 
-Note: Since this is a brand new project, support for other servers, specifically updating them to use specific Faces builds is WIP.
+Coverage and Mojarra-version handling for non-GlassFish servers is still
+work-in-progress.
 
-## Running the test manually
+## Running tests manually
 
-Every test module produces a plain war. This war can be deployed to any server supporting wars, which is at least every Jakarta EE compatible server. Look at the test code
-for hints on which URLs to request manually using e.g. a web browser.
-
-# Faces "old" tests
-
-A subset of the tests in this folder are from the "old tck", which is the TCK based on the JavaTest harness and Apache Ant. These tests are run as part of the overall TCK run. E.g. they will be executed when running: 
-
-```bash
-mvn clean install
-```
-
-## Running only the old tests
-
-The module containing the old tests can be executed separately using the normal Maven method of building a single module:
-
-```bash
-mvn clean install -pl :old-tck-build,old-tck-run
-```
-
-When the old TCK has already been build once for this release of the TCK, subsequent invocations can be done by omitting the build step:
-
-
-```bash
-mvn clean install -pl :old-tck-run
-```
-
-## Running a single old tests
-
-Executing a single old test is different from running a single new test. It is done by using the `run.test` parameter and the full URL of the test (URLs are printed after the old test executed, and can also be found in the `ts-all-platform.jtx` and `ts-all-standalone.jtx` files). 
-
-For example:
-
-
-```bash
-mvn clean install -pl :old-tck-run -Drun.test="com/sun/ts/tests/jsf/api/jakarta_faces/validator/doublerangevalidator/URLClient.java#stateHolderSaveStateNPETest"
-```
-
-
-## Running multiple old tests
-
-Using the `run.test.pattern` a regexp can be specified that runs all tests matching that.
-
-For example, the following runs all component tests:
-
-```bash
-mvn clean install -pl :old-tck-run -Drun.test.pattern='^com/sun/ts/tests/jsf/api/jakarta_faces/component'
-```
-
-The following runs all tests except the component tests:
-
-
-```bash
-mvn clean install -pl :old-tck-run -Drun.test.pattern='^((?!com/sun/ts/tests/jsf/api/jakarta_faces/component).)*$'
-```
-
-
-## Debugging old tests
-
-GlassFish can be switched to debugging mode and suspend right at the start using:
-
-```bash
-mvn clean install -glassfish.suspend=true
-```
-
-This will suspend the JVM running GlassFish and wait for a debug connection on port `9009`.
-
-
-
-
-
-
-
-
-
-
-
+Each test module produces a plain WAR (e.g. `faces50/ajax/target/test-faces50-ajax.war`).
+Deploy it to any Jakarta EE compatible server; the test code itself is documented
+inline and identifies the URLs to request via a browser.

--- a/tck/README.md
+++ b/tck/README.md
@@ -63,13 +63,6 @@ The pool starts with one slot and grows on demand, so a sequential build
 uses one GlassFish; `-T 4` grows up to four; `-T 8` up to eight (capped at
 `max(4, cores/2)`). Pick `-T` based on host capacity.
 
-The `cyclonedx-maven-plugin:makeAggregateBom` mojo is annotated
-`@aggregator` (it walks the full reactor's dep graph for every SBOM).
-The TCK root pom binds it to run **once at the root reactor**, not
-per-module — so the parallel build doesn't repeatedly serialise on it.
-Skip the SBOM entirely with `-DskipSBOM`. To force eager provisioning
-of all pool slots from the start: `-Dgf.pool.size=N`.
-
 A single test module:
 
 ```bash

--- a/tck/README.md
+++ b/tck/README.md
@@ -104,20 +104,40 @@ mvn clean install -T 4 -Dglassfish.home=/path/to/glassfish9
 | `-T 8` | Eight Maven threads. Pool grows up to `gf.pool.maxSize` to match. |
 | `-T 1` | Sequential build, single slot. |
 
-To force more pool slots than the default `max(4, cores/2)` cap, set
-`gf.pool.size` to the count you want. The grow cap is auto-raised to match,
-so you don't have to set both. Example for a 10-core (20-thread) host
-running 16 GFs:
+### Sizing `-T` and the pool for the host
+
+Each parallel test module spawns a failsafe-fork JVM, drives a Chrome
+instance, and pushes deploy/HTTP traffic at its leased GlassFish JVM. So
+**every `-T N` slot keeps roughly three hot processes busy** (test JVM +
+browser + GF), plus the Maven master and OS overhead, and each GF JVM
+holds ~1 GB resident. Pick `-T` to leave both CPU and memory headroom:
+
+| Host | Recommended `-T` |
+| --- | --- |
+| 4-core / 8-thread laptop | `-T 4` |
+| 10-core / 20-thread workstation | `-T 8` (`-T 10` reliably saturates and Selenium ajax timeouts start firing) |
+| 16-core / 32-thread CI | `-T 12`–`-T 16` |
+| 32-core / 64-thread server | `-T 20`–`-T 24` |
+
+Going higher than these guidelines tends to *slow* the build on Selenium-
+heavy modules: per-request latency stretches past the test's 30-second
+ajax wait, modules like `faces23/ajax` start failing intermittently, and
+the failure cost outweighs the parallelism gain. If you must push higher,
+set `-Dfailsafe.rerunFailingTestsCount=2` to absorb pure flakes.
+
+The pool grows on demand up to `max(4, cores/2)`, so by default `-T 4`
+ramps to 4 slots and `-T 8` ramps to 8 (subject to the cap). To run more
+slots than the default cap, set `gf.pool.size` to the count you want —
+the grow cap auto-raises to match, so you don't have to set both:
 
 ```bash
 mvn clean install -T 16 -Dgf.pool.size=16
 ```
 
-`-Dgf.pool.maxSize=N` is only needed when you want a *higher* grow ceiling
-than the initial provision (e.g. `-Dgf.pool.size=4 -Dgf.pool.maxSize=16` to
-start small and let grow-on-demand scale up to 16). Memory is the real
-constraint — budget ~1 GB per slot for GlassFish plus headroom for the
-test JVMs and browsers.
+`-Dgf.pool.maxSize=N` is only needed when you want a *higher* grow
+ceiling than the initial provision (e.g. `-Dgf.pool.size=4
+-Dgf.pool.maxSize=16` to start small and let grow-on-demand scale up to
+16).
 
 ## Pool lifecycle helpers
 

--- a/tck/faces41/facesMessage/pom.xml
+++ b/tck/faces41/facesMessage/pom.xml
@@ -26,11 +26,13 @@
     </parent>
 
     <artifactId>facesMessage</artifactId>
-    <packaging>war</packaging>
+    <packaging>jar</packaging>
 
+    <!--
+        Pure unit test on jakarta.faces.application.FacesMessage (Spec1823IT
+        uses only JUnit assertions, no Arquillian/deploy). Packaged as jar so
+        the glassfish-ci-managed profile (which activates on src/main/webapp)
+        does not attach the gf-pool agent or pull in GlassFish dependencies.
+    -->
     <name>Jakarta Faces TCK ${project.version} - Test - Faces 4.1 - facesMessage</name>
-
-    <build>
-        <finalName>test-faces41-facesMessage</finalName>
-    </build>
 </project>

--- a/tck/gf-pool/pom.xml
+++ b/tck/gf-pool/pom.xml
@@ -1,0 +1,274 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2026 Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.eclipse.ee4j.faces.tck</groupId>
+        <artifactId>jakarta-faces-tck</artifactId>
+        <version>5.0.0-SNAPSHOT</version>
+    </parent>
+
+    <groupId>org.eclipse.ee4j.tck.faces.test</groupId>
+    <artifactId>gf-pool</artifactId>
+    <packaging>jar</packaging>
+
+    <name>Jakarta Faces TCK ${project.version} - Test - GlassFish Pool</name>
+
+    <dependencies>
+        <!--
+            Provided by maven-antrun-plugin's embedded Ant runtime; we extend
+            org.apache.tools.ant.Task in ShutdownHookInstaller so this is a
+            compile-time-only dependency.
+        -->
+        <dependency>
+            <groupId>org.apache.ant</groupId>
+            <artifactId>ant</artifactId>
+            <version>1.10.13</version>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
+    <!--
+        Pool of pre-started GlassFish instances, leased by failsafe-forked test JVMs
+        via the SlotLeaserAgent. Each slot gets its own install (cp -al hardlinked
+        from a single unpacked distribution) and a disjoint port range so up to
+        ${gf.pool.size} test modules can run integration tests in parallel without
+        collisions.
+
+        Lifecycle:
+          - process-classes: unpack GlassFish, overlay Mojarra, then for each slot
+                             clone the install, patch ports, and start the domain
+                             (provision-slot.sh is idempotent: a slot whose admin
+                             port is already responding is left alone)
+          - manual `mvn -pl gf-pool antrun:run@stop` (or stop-pool.sh): stop domains
+
+        Disables the glassfish-ci-managed profile for itself so this module does not
+        recursively wire in the per-module GlassFish lifecycle.
+    -->
+    <properties>
+        <!--
+            Initial number of slots provisioned at build time. Default 1 keeps
+            cold-start cheap; the SlotLeaserAgent grows the pool on demand up
+            to gf.pool.maxSize when concurrent tests need more.
+        -->
+        <gf.pool.size>1</gf.pool.size>
+
+        <!--
+            Hard cap on pool growth. Empty default: pool-up.sh computes
+            max(4, cores/2) so an 8-core laptop tops out at 4, a 32-core
+            CI host at 16. Override via -Dgf.pool.maxSize=N.
+        -->
+        <gf.pool.maxSize></gf.pool.maxSize>
+        <gf.pool.dir>${project.build.directory}/pool</gf.pool.dir>
+        <gf.pool.dist>${project.build.directory}/dist</gf.pool.dist>
+        <gf.pool.adminPort.base>14848</gf.pool.adminPort.base>
+
+        <!--
+            Per-slot port stride. Each slot needs 10 contiguous ports
+            (admin+http+https+iiop×3+jmx+jms+osgi+derby), so stride must be
+            >= 10. Stride=100 keeps slots visually distinct in logs and lets
+            us run hundreds of slots while staying under the 65535 ceiling
+            (slot N uses ports 14848 + N*100 .. + 9).
+        -->
+        <gf.pool.portStride>100</gf.pool.portStride>
+
+        <glassfish.version>9.0.0-M2</glassfish.version>
+        <mojarra.version>5.0.0-SNAPSHOT</mojarra.version>
+        <mojarra.noupdate>false</mojarra.noupdate>
+
+        <!--
+            Source install used as the template for all slot clones. Default points at
+            the directory the maven-dependency-plugin unpacks the zip into. The
+            glassfish-source-copy profile below overrides this to ${glassfish.home}
+            when -Dglassfish.home=/path/to/glassfish9 is supplied, in which case
+            the unpack + mojarra overlay are skipped.
+        -->
+        <gf.pool.source>${gf.pool.dist}/glassfish9</gf.pool.source>
+    </properties>
+
+    <build>
+        <finalName>slot-leaser-agent</finalName>
+
+        <plugins>
+            <plugin>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Premain-Class>ee.jakarta.tck.faces.test.pool.SlotLeaserAgent</Premain-Class>
+                            <Can-Redefine-Classes>false</Can-Redefine-Classes>
+                            <Can-Retransform-Classes>false</Can-Retransform-Classes>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>unpack-glassfish</id>
+                        <phase>process-classes</phase>
+                        <goals>
+                            <goal>unpack</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>${gf.pool.dist}</outputDirectory>
+                            <markersDirectory>${gf.pool.dist}/markers</markersDirectory>
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>org.glassfish.main.distributions</groupId>
+                                    <artifactId>glassfish</artifactId>
+                                    <version>${glassfish.version}</version>
+                                    <type>zip</type>
+                                    <overWrite>false</overWrite>
+                                </artifactItem>
+                            </artifactItems>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>overlay-mojarra</id>
+                        <phase>process-classes</phase>
+                        <goals>
+                            <goal>copy</goal>
+                        </goals>
+                        <configuration>
+                            <skip>${mojarra.noupdate}</skip>
+                            <outputDirectory>${gf.pool.dist}/glassfish9/glassfish/modules</outputDirectory>
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>jakarta.faces</groupId>
+                                    <artifactId>jakarta.faces-api</artifactId>
+                                    <version>${faces.version}</version>
+                                    <type>jar</type>
+                                    <overWrite>true</overWrite>
+                                    <destFileName>jakarta.faces-api.jar</destFileName>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>org.glassfish.mojarra</groupId>
+                                    <artifactId>mojarra</artifactId>
+                                    <version>${mojarra.version}</version>
+                                    <type>jar</type>
+                                    <overWrite>true</overWrite>
+                                    <destFileName>mojarra.jar</destFileName>
+                                </artifactItem>
+                            </artifactItems>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <version>3.1.0</version>
+                <executions>
+                    <execution>
+                        <id>start-pool</id>
+                        <phase>process-classes</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <target>
+                                <!--
+                                    Arm the JVM shutdown hook FIRST, before pool-up.sh
+                                    starts any GlassFish processes. If the script fails
+                                    midway (port collision, asadmin error, etc.) the
+                                    already-started GFs still get cleaned up at JVM exit
+                                    instead of being orphaned with no hook to stop them.
+                                    The taskdef'd class extends Ant's Task and runs
+                                    in-process inside maven-antrun-plugin's embedded Ant
+                                    project, which shares the Maven JVM, so the hook
+                                    persists for the remainder of the build. (The simpler
+                                    <java fork="false"> would throw on JDK 17+ because
+                                    Ant's in-process Java task installs a SecurityManager.)
+                                -->
+                                <taskdef name="gf-pool"
+                                         classname="ee.jakarta.tck.faces.test.pool.ShutdownHookInstaller"
+                                         classpath="${project.build.outputDirectory}"/>
+                                <gf-pool poolDir="${gf.pool.dir}"
+                                         scriptDir="${project.basedir}/src/main/scripts"/>
+
+                                <exec executable="bash" failonerror="true">
+                                    <env key="POOL_SIZE"   value="${gf.pool.size}"/>
+                                    <env key="MAX_SIZE"    value="${gf.pool.maxSize}"/>
+                                    <env key="POOL_DIR"    value="${gf.pool.dir}"/>
+                                    <env key="SOURCE_HOME" value="${gf.pool.source}"/>
+                                    <env key="ADMIN_BASE"  value="${gf.pool.adminPort.base}"/>
+                                    <env key="PORT_STRIDE" value="${gf.pool.portStride}"/>
+                                    <env key="SCRIPT_DIR"  value="${project.basedir}/src/main/scripts"/>
+                                    <arg value="${project.basedir}/src/main/scripts/pool-up.sh"/>
+                                </exec>
+                            </target>
+                        </configuration>
+                    </execution>
+
+                    <execution>
+                        <id>stop</id>
+                        <phase>none</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <target>
+                                <exec executable="bash" failonerror="false">
+                                    <env key="POOL_DIR" value="${gf.pool.dir}"/>
+                                    <arg value="${project.basedir}/src/main/scripts/pool-down.sh"/>
+                                </exec>
+                            </target>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+    <profiles>
+        <!--
+            Activated when -Dglassfish.home=<path> is supplied. Skips the
+            zip download and the Mojarra overlay; slots are cloned directly
+            from the user-provided install at ${glassfish.home}. Idempotent:
+            provision-slot.sh skips slots whose admin port is already responding.
+        -->
+        <profile>
+            <id>glassfish-source-copy</id>
+            <activation>
+                <property>
+                    <name>glassfish.home</name>
+                </property>
+            </activation>
+            <properties>
+                <gf.pool.source>${glassfish.home}</gf.pool.source>
+            </properties>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-dependency-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>unpack-glassfish</id>
+                                <phase>none</phase>
+                            </execution>
+                            <execution>
+                                <id>overlay-mojarra</id>
+                                <phase>none</phase>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+</project>

--- a/tck/gf-pool/src/main/java/ee/jakarta/tck/faces/test/pool/ShutdownHookInstaller.java
+++ b/tck/gf-pool/src/main/java/ee/jakarta/tck/faces/test/pool/ShutdownHookInstaller.java
@@ -1,0 +1,214 @@
+/*
+ * Copyright (c) 2026 Contributors to Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package ee.jakarta.tck.faces.test.pool;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.channels.FileChannel;
+import java.nio.channels.FileLock;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.apache.tools.ant.Project;
+import org.apache.tools.ant.Task;
+
+/**
+ * Custom Ant task that installs a JVM shutdown hook on Maven's own JVM so the
+ * GlassFish pool stops when the build completes (or is killed via {@code Ctrl+C}).
+ *
+ * <p>Loaded by the {@code gf-pool} antrun via {@code <taskdef>}; runs in-process
+ * inside the {@code maven-antrun-plugin}'s embedded Ant project, which shares
+ * the Maven JVM. The hook persists for the lifetime of that JVM, so it fires
+ * at session end after every test module has finished.
+ *
+ * <p>Avoids {@code <java fork="false">} which on JDK 17+ throws
+ * {@code UnsupportedOperationException: The Security Manager is deprecated}.
+ *
+ * <p>The actual stop logic delegates to {@code pool-down.sh} so the script
+ * remains the single source of truth for teardown.
+ */
+public final class ShutdownHookInstaller extends Task {
+
+    private static final AtomicBoolean installed = new AtomicBoolean(false);
+    private static final AtomicBoolean stopped = new AtomicBoolean(false);
+
+    private File poolDir;
+    private File scriptDir;
+
+    public void setPoolDir(File poolDir) {
+        this.poolDir = poolDir;
+    }
+
+    public void setScriptDir(File scriptDir) {
+        this.scriptDir = scriptDir;
+    }
+
+    @Override
+    public void execute() {
+        if (poolDir == null || scriptDir == null) {
+            throw new IllegalStateException("poolDir and scriptDir attributes are required");
+        }
+        if (!installed.compareAndSet(false, true)) {
+            return;
+        }
+        File pool = poolDir;
+        File scripts = scriptDir;
+        Runtime.getRuntime().addShutdownHook(new Thread(() -> stopPool(pool, scripts), "gf-pool-shutdown"));
+        log("shutdown hook armed (will stop pool when this Maven JVM exits)");
+        warnIfSequential();
+    }
+
+    /**
+     * If Maven was invoked without {@code -T}, log a banner reminding the user
+     * that the pool's parallelism is unused. The {@code -T} value comes from
+     * {@code MavenSession.getRequest().getDegreeOfConcurrency()}, which the
+     * maven-antrun-plugin exposes through its property helper chain — we reach
+     * it reflectively to avoid a hard dependency on maven-core in this jar.
+     */
+    private void warnIfSequential() {
+        Integer threads = readDegreeOfConcurrency();
+        if (threads == null || threads > 1) {
+            return;
+        }
+        // One log() call per line so each gets its own [WARNING] prefix from
+        // the Maven CLI logger; a single multi-line string only prefixes the
+        // first line and the rest are emitted unprefixed by Ant.
+        String[] banner = {
+                "",
+                "==========================================================================",
+                "  WARNING: gf-pool is provisioned, but the build is running SEQUENTIALLY.",
+                "  Re-run with -T <N> to actually exercise the pool, e.g.:",
+                "",
+                "      mvn clean install -T 4",
+                "",
+                "  The pool grows on demand up to max(4, cores/2).",
+                "==========================================================================",
+                ""
+        };
+        for (String line : banner) {
+            log(line, Project.MSG_WARN);
+        }
+    }
+
+    private Integer readDegreeOfConcurrency() {
+        // maven-antrun-plugin doesn't expose MavenSession to Ant references,
+        // so we infer -T from sun.java.command — the system property HotSpot
+        // populates with the launcher class + Maven CLI args. Look for any of
+        // the recognised forms ("-T 4", "-T4", "-T 1C", "--threads 4").
+        String cmd = System.getProperty("sun.java.command", "");
+        if (cmd.isEmpty()) {
+            return null;
+        }
+        // Tokenise on whitespace; reject the matches when the next token starts
+        // with a digit or 'C' (-T 1C means 1 per core).
+        String[] tokens = cmd.split("\\s+");
+        for (int i = 0; i < tokens.length; i++) {
+            String t = tokens[i];
+            if (("-T".equals(t) || "--threads".equals(t)) && i + 1 < tokens.length) {
+                return parseThreads(tokens[i + 1]);
+            }
+            if (t.startsWith("-T") && t.length() > 2) {
+                return parseThreads(t.substring(2));
+            }
+            if (t.startsWith("--threads=")) {
+                return parseThreads(t.substring("--threads=".length()));
+            }
+        }
+        // No -T detected — sequential.
+        return 1;
+    }
+
+    private static Integer parseThreads(String value) {
+        // The "C" suffix means "per-core" — `-T 1C` on an N-core host = N threads,
+        // which is always parallel on multi-core hardware. Treat any *C form as
+        // parallel regardless of multiplier.
+        boolean perCore = value.endsWith("C") || value.endsWith("c");
+        String stripped = perCore ? value.substring(0, value.length() - 1) : value;
+        try {
+            float n = Float.parseFloat(stripped);
+            if (n <= 0) {
+                return 1; // -T 0 / -T 0C / -T -1 — sequential by Maven semantics.
+            }
+            if (perCore) {
+                return Integer.MAX_VALUE; // any positive *C multiplier on multi-core = parallel.
+            }
+            return n <= 1 ? 1 : Integer.MAX_VALUE;
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
+
+    private static void stopPool(File poolDir, File scriptDir) {
+        if (!stopped.compareAndSet(false, true)) {
+            return;
+        }
+        File stopSlotScript = new File(scriptDir, "stop-slot.sh");
+        if (!poolDir.isDirectory() || !stopSlotScript.isFile()) {
+            return;
+        }
+        // Iterate slots in Java (rather than shelling out to pool-down.sh)
+        // because we need to test each slot's lock with FileChannel.tryLock().
+        // bash's flock(1) and Java's FileLock use *different* OS lock spaces
+        // on Linux (flock(2) vs fcntl()), so a flock-based check from bash
+        // cannot see Java agent locks. Holding the lock here while we run
+        // stop-slot.sh also prevents a new test JVM from leasing the slot
+        // mid-shutdown.
+        File[] slotDirs = poolDir.listFiles((dir, name) -> name.startsWith("slot-"));
+        if (slotDirs == null) {
+            return;
+        }
+        for (File slotDir : slotDirs) {
+            int slotIdx;
+            try {
+                slotIdx = Integer.parseInt(slotDir.getName().substring("slot-".length()));
+            } catch (NumberFormatException e) {
+                continue;
+            }
+            stopSlotIfIdle(slotDir.toPath(), slotIdx, stopSlotScript, poolDir);
+        }
+    }
+
+    private static void stopSlotIfIdle(Path slotDir, int slotIdx, File stopSlotScript, File poolDir) {
+        Path lockFile = slotDir.resolve("lock");
+        try (FileChannel fc = FileChannel.open(lockFile,
+                StandardOpenOption.CREATE,
+                StandardOpenOption.READ,
+                StandardOpenOption.WRITE)) {
+            FileLock lock = fc.tryLock();
+            if (lock == null) {
+                System.err.println("[gf-pool] slot " + slotIdx + " is still leased by another process; skip stop");
+                return;
+            }
+            try {
+                runStopSlot(stopSlotScript, poolDir, slotIdx);
+            } finally {
+                lock.release();
+            }
+        } catch (IOException e) {
+            System.err.println("[gf-pool] couldn't probe slot " + slotIdx + ": " + e);
+        }
+    }
+
+    private static void runStopSlot(File script, File poolDir, int slotIdx) {
+        ProcessBuilder pb = new ProcessBuilder("bash", script.getAbsolutePath());
+        pb.environment().put("POOL_DIR", poolDir.getAbsolutePath());
+        pb.environment().put("SLOT_IDX", String.valueOf(slotIdx));
+        pb.inheritIO();
+        try {
+            pb.start().waitFor();
+        } catch (IOException | InterruptedException e) {
+            System.err.println("[gf-pool] failed to stop slot " + slotIdx + ": " + e);
+            if (e instanceof InterruptedException) {
+                Thread.currentThread().interrupt();
+            }
+        }
+    }
+}

--- a/tck/gf-pool/src/main/java/ee/jakarta/tck/faces/test/pool/SlotLeaserAgent.java
+++ b/tck/gf-pool/src/main/java/ee/jakarta/tck/faces/test/pool/SlotLeaserAgent.java
@@ -1,0 +1,303 @@
+/*
+ * Copyright (c) 2026 Contributors to Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package ee.jakarta.tck.faces.test.pool;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.instrument.Instrumentation;
+import java.net.InetSocketAddress;
+import java.net.Socket;
+import java.nio.channels.FileChannel;
+import java.nio.channels.FileLock;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardOpenOption;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Properties;
+
+/**
+ * Java agent attached to the failsafe-forked test JVM. At {@code premain} it leases
+ * one of the GlassFish pool slots managed by the {@code gf-pool} module by
+ * acquiring an exclusive {@link FileLock} on {@code ${gf.pool.dir}/slot-N/lock}.
+ * The lock is held in static fields so it survives for the JVM lifetime; JVM exit
+ * releases it automatically. Once a slot is leased the agent loads
+ * {@code slot-N/ports.properties} and exposes its keys (notably
+ * {@code arquillian.adminPort}, {@code arquillian.httpPort},
+ * {@code arquillian.httpsPort}) as system properties so the arquillian
+ * remote container picks them up.
+ *
+ * <p>If every existing slot is leased the agent grows the pool: it acquires
+ * a global grow-lock, computes the next slot index, execs
+ * {@code provision-slot.sh} with the slot's port range, and leases the new
+ * slot. Growth is capped at {@code maxSize} read from
+ * {@code ${gf.pool.dir}/config.properties} (written by {@code pool-up.sh}).
+ * If the cap is reached the agent waits for an existing slot to free.
+ */
+public final class SlotLeaserAgent {
+
+    private static final String POOL_DIR_PROP = "gf.pool.dir";
+    private static final String LEASE_TIMEOUT_PROP = "gf.pool.leaseTimeoutSeconds";
+    private static final String DEFAULT_LEASE_TIMEOUT_SECONDS = "600";
+    private static final long POLL_INTERVAL_MILLIS = 500L;
+    private static final int HEALTH_PROBE_TIMEOUT_MILLIS = 1000;
+
+    @SuppressWarnings("unused") // anchors the lock for JVM lifetime
+    private static FileChannel heldChannel;
+    @SuppressWarnings("unused")
+    private static FileLock heldLock;
+
+    private SlotLeaserAgent() {
+    }
+
+    public static void premain(String args, Instrumentation instrumentation) throws Exception {
+        leaseSlot();
+    }
+
+    public static void premain(String args) throws Exception {
+        leaseSlot();
+    }
+
+    private static void leaseSlot() throws Exception {
+        Path poolDir = Paths.get(requiredProperty(POOL_DIR_PROP));
+        long timeoutSeconds = Long.parseLong(System.getProperty(LEASE_TIMEOUT_PROP, DEFAULT_LEASE_TIMEOUT_SECONDS));
+        long deadline = System.currentTimeMillis() + (timeoutSeconds * 1000L);
+        PoolConfig config = PoolConfig.load(poolDir);
+
+        while (System.currentTimeMillis() < deadline) {
+            int discovered = scanAndTryAcquire(poolDir);
+            if (discovered < 0) {
+                return; // success
+            }
+            if (discovered < config.maxSize) {
+                int grown = tryGrow(poolDir, config);
+                if (grown >= 0 && tryAcquire(poolDir, grown)) {
+                    return;
+                }
+            }
+            Thread.sleep(POLL_INTERVAL_MILLIS);
+        }
+        throw new IllegalStateException("Could not lease a GlassFish pool slot within "
+                + timeoutSeconds + "s (pool=" + poolDir + ")");
+    }
+
+    /**
+     * Enumerate every leasable slot under {@code poolDir} (gap-tolerant:
+     * a {@code slot-N/} without {@code ports.properties} from a crashed
+     * provision is skipped, not used as a stopping condition), then try to
+     * acquire one in least-recently-used order. The lock file's mtime is
+     * touched on every successful acquire (because we open it WRITE), so
+     * sorting ascending by mtime biases toward the slot that has been idle
+     * the longest — which evens out load when tests have wildly different
+     * durations and a strict scan order would let fast-test JVMs cycle
+     * through one slot while another holds a long test.
+     *
+     * @return -1 if a slot was leased; otherwise the count of leasable slots
+     *         observed (all busy).
+     */
+    private static int scanAndTryAcquire(Path poolDir) throws IOException {
+        List<Integer> candidates = new ArrayList<>();
+        try (java.util.stream.Stream<Path> entries = Files.list(poolDir)) {
+            for (Path entry : (Iterable<Path>) entries::iterator) {
+                String name = entry.getFileName().toString();
+                if (!name.startsWith("slot-")) {
+                    continue;
+                }
+                if (!Files.exists(entry.resolve("ports.properties"))) {
+                    continue;
+                }
+                try {
+                    candidates.add(Integer.parseInt(name.substring("slot-".length())));
+                } catch (NumberFormatException ignored) {
+                    // Not a numeric slot dir — ignore.
+                }
+            }
+        }
+        candidates.sort(Comparator.comparingLong(slot -> lockMtime(poolDir, slot)));
+        for (int slot : candidates) {
+            if (tryAcquire(poolDir, slot)) {
+                return -1;
+            }
+        }
+        return candidates.size();
+    }
+
+    private static Integer parsePort(String raw) {
+        if (raw == null || raw.isEmpty()) {
+            return null;
+        }
+        try {
+            return Integer.parseInt(raw.trim());
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
+
+    private static boolean isAdminPortHealthy(int adminPort) {
+        try (Socket socket = new Socket()) {
+            socket.connect(new InetSocketAddress("localhost", adminPort), HEALTH_PROBE_TIMEOUT_MILLIS);
+            return true;
+        } catch (IOException e) {
+            return false;
+        }
+    }
+
+    private static long lockMtime(Path poolDir, int slot) {
+        // Catch covers both missing file (NoSuchFileException) and unreadable
+        // mtime; in either case treat as oldest so this slot is tried first.
+        try {
+            return Files.getLastModifiedTime(poolDir.resolve("slot-" + slot).resolve("lock")).toMillis();
+        } catch (IOException e) {
+            return 0L;
+        }
+    }
+
+    private static boolean tryAcquire(Path poolDir, int slot) throws IOException {
+        Path slotDir = poolDir.resolve("slot-" + slot);
+        Path portsFile = slotDir.resolve("ports.properties");
+        if (!Files.exists(portsFile)) {
+            return false;
+        }
+        FileChannel channel = FileChannel.open(slotDir.resolve("lock"),
+                StandardOpenOption.CREATE,
+                StandardOpenOption.READ,
+                StandardOpenOption.WRITE);
+        FileLock lock = null;
+        try {
+            lock = channel.tryLock();
+            if (lock == null) {
+                channel.close();
+                return false;
+            }
+            Properties properties = new Properties();
+            try (InputStream in = Files.newInputStream(portsFile)) {
+                properties.load(in);
+            }
+            // Health check: a free lock file does not imply a live GlassFish.
+            // The previous owner's GF may have OOM-crashed, been killed
+            // externally, or been mid-shutdown when we picked up the lock.
+            // Probe the admin port before committing the lease so a phantom
+            // slot returns false here and the scan continues.
+            // Also tolerate a half-written ports.properties (provision-slot.sh
+            // crashed mid-write): treat missing/non-numeric adminPort as a
+            // failed health check, not a hard error.
+            String adminPortStr = properties.getProperty("arquillian.adminPort");
+            Integer adminPort = parsePort(adminPortStr);
+            if (adminPort == null || !isAdminPortHealthy(adminPort)) {
+                lock.release();
+                channel.close();
+                return false;
+            }
+            properties.forEach((k, v) -> System.setProperty(k.toString(), v.toString()));
+            System.setProperty("gf.pool.slot", String.valueOf(slot));
+            heldChannel = channel;
+            heldLock = lock;
+            // Don't println — surefire/failsafe owns the forked JVM's stdout as a
+            // control channel and reports "Corrupted channel" on direct writes.
+            // Slot identity is observable via the gf.pool.slot system property.
+            return true;
+        } catch (RuntimeException | IOException e) {
+            // Anything between open() and the assignment to heldChannel/heldLock
+            // must release the channel; otherwise a transient failure leaks an FD
+            // every poll cycle.
+            if (lock != null) {
+                try { lock.release(); } catch (IOException ignored) { /* nothing useful */ }
+            }
+            try { channel.close(); } catch (IOException ignored) { /* nothing useful */ }
+            throw e;
+        }
+    }
+
+    /**
+     * Grows the pool by one slot. Synchronised across concurrent test JVMs
+     * via a blocking file lock on {@code grow.lock} so two JVMs can't pick
+     * the same next index. Slot indices are 1-based for human readability;
+     * scans from 1 and fills the lowest-unused slot (gap-aware). Returns
+     * the new slot index, or -1 if the cap was reached between the busy
+     * check and lock acquisition.
+     */
+    private static int tryGrow(Path poolDir, PoolConfig config) throws Exception {
+        Path growLockFile = poolDir.resolve("grow.lock");
+        try (FileChannel fc = FileChannel.open(growLockFile,
+                StandardOpenOption.CREATE,
+                StandardOpenOption.READ,
+                StandardOpenOption.WRITE);
+             FileLock ignored = fc.lock()) {
+            int next = 1;
+            while (Files.exists(poolDir.resolve("slot-" + next).resolve("ports.properties"))) {
+                next++;
+            }
+            if (next > config.maxSize) {
+                return -1;
+            }
+            ProcessBuilder pb = new ProcessBuilder("bash",
+                    config.scriptDir.resolve("provision-slot.sh").toString());
+            pb.environment().put("SLOT_IDX", String.valueOf(next));
+            pb.environment().put("POOL_DIR", poolDir.toString());
+            pb.environment().put("SOURCE_HOME", config.source.toString());
+            pb.environment().put("ADMIN_BASE", String.valueOf(config.adminBase));
+            pb.environment().put("PORT_STRIDE", String.valueOf(config.portStride));
+            pb.inheritIO();
+            int exit = pb.start().waitFor();
+            if (exit != 0) {
+                throw new IllegalStateException(
+                        "provision-slot.sh failed (slot=" + next + ", exit=" + exit + ")");
+            }
+            return next;
+        }
+    }
+
+    private static String requiredProperty(String name) {
+        String value = System.getProperty(name);
+        if (value == null || value.isEmpty()) {
+            throw new IllegalStateException("System property " + name + " is required");
+        }
+        return value;
+    }
+
+    private static final class PoolConfig {
+        final Path source;
+        final int adminBase;
+        final int portStride;
+        final int maxSize;
+        final Path scriptDir;
+
+        private PoolConfig(Properties p) {
+            this.source = Paths.get(require(p, "source"));
+            this.adminBase = Integer.parseInt(require(p, "adminBase"));
+            this.portStride = Integer.parseInt(require(p, "portStride"));
+            this.maxSize = Integer.parseInt(require(p, "maxSize"));
+            this.scriptDir = Paths.get(require(p, "scriptDir"));
+        }
+
+        private static String require(Properties p, String key) {
+            String value = p.getProperty(key);
+            if (value == null || value.isEmpty()) {
+                throw new IllegalStateException("Pool config key '" + key + "' is missing");
+            }
+            return value;
+        }
+
+        static PoolConfig load(Path poolDir) throws IOException {
+            Path file = poolDir.resolve("config.properties");
+            if (!Files.exists(file)) {
+                throw new IllegalStateException("Pool config not found at " + file
+                        + " — has the gf-pool module run?");
+            }
+            Properties p = new Properties();
+            try (InputStream in = Files.newInputStream(file)) {
+                p.load(in);
+            }
+            return new PoolConfig(p);
+        }
+    }
+}

--- a/tck/gf-pool/src/main/scripts/pool-down.sh
+++ b/tck/gf-pool/src/main/scripts/pool-down.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2026 Contributors to Eclipse Foundation.
+#
+# SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+#
+# Stops every slot found in the pool. Inputs: POOL_DIR.
+# Slot count is self-discovered by globbing slot-* directories so it
+# works regardless of how many were provisioned.
+
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "$0")" && pwd)"
+
+shopt -s nullglob
+for slot_dir in "${POOL_DIR}"/slot-*; do
+    idx="${slot_dir##*/slot-}"
+    SLOT_IDX="${idx}" POOL_DIR="${POOL_DIR}" \
+        bash "${script_dir}/stop-slot.sh"
+done

--- a/tck/gf-pool/src/main/scripts/pool-up.sh
+++ b/tck/gf-pool/src/main/scripts/pool-up.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2026 Contributors to Eclipse Foundation.
+#
+# SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+#
+# Provisions and starts the initial set of slots, then writes
+# ${POOL_DIR}/config.properties so SlotLeaserAgent can grow the pool on
+# demand later. Inputs:
+#   POOL_SIZE   - initial slot count (default 1)
+#   MAX_SIZE    - hard cap; empty = max(4, cores/2)
+#   POOL_DIR    - pool root (.gf-pool)
+#   SOURCE_HOME - GlassFish install template (must contain glassfish/bin/asadmin)
+#   ADMIN_BASE  - base admin port (e.g. 14848)
+#   PORT_STRIDE - per-slot stride (e.g. 100)
+#   SCRIPT_DIR  - directory containing provision-slot.sh (the agent uses
+#                 this to grow the pool)
+
+set -euo pipefail
+
+if [[ ! -x "${SOURCE_HOME}/glassfish/bin/asadmin" ]]; then
+    echo "[gf-pool] SOURCE_HOME does not look like a GlassFish install: ${SOURCE_HOME}" >&2
+    exit 1
+fi
+
+if [[ -z "${MAX_SIZE:-}" ]]; then
+    cores="$(nproc 2>/dev/null || getconf _NPROCESSORS_ONLN 2>/dev/null || echo 4)"
+    # Half-cores leaves headroom for the Maven master, surefire forks,
+    # browsers, and the OS. Floor of 4 keeps low-core machines usable.
+    floor=4
+    MAX_SIZE=$(( cores / 2 ))
+    if (( MAX_SIZE < floor )); then
+        MAX_SIZE=${floor}
+    fi
+fi
+
+if [[ -z "${POOL_SIZE:-}" ]]; then
+    POOL_SIZE=1
+fi
+
+# If the user explicitly asked for more initial slots than the cap, they
+# clearly want headroom for at least that many — raise the cap to match
+# instead of clamping POOL_SIZE down. So `-Dgf.pool.size=16` alone is
+# enough; no need to also pass -Dgf.pool.maxSize=16.
+if (( POOL_SIZE > MAX_SIZE )); then
+    MAX_SIZE="${POOL_SIZE}"
+fi
+
+mkdir -p "${POOL_DIR}"
+
+# Write the pool config so the agent can read it when growing on demand.
+# Overwrite each build so changes to source/ports flow through.
+cat > "${POOL_DIR}/config.properties" <<EOF
+source=${SOURCE_HOME}
+adminBase=${ADMIN_BASE}
+portStride=${PORT_STRIDE}
+maxSize=${MAX_SIZE}
+scriptDir=${SCRIPT_DIR}
+EOF
+
+echo "[gf-pool] initial=${POOL_SIZE} max=${MAX_SIZE} (cores: ${cores:-n/a})"
+
+for ((i = 1; i <= POOL_SIZE; i++)); do
+    SLOT_IDX="$i" \
+    POOL_DIR="${POOL_DIR}" \
+    SOURCE_HOME="${SOURCE_HOME}" \
+    ADMIN_BASE="${ADMIN_BASE}" \
+    PORT_STRIDE="${PORT_STRIDE}" \
+        bash "${SCRIPT_DIR}/provision-slot.sh"
+done

--- a/tck/gf-pool/src/main/scripts/provision-slot.sh
+++ b/tck/gf-pool/src/main/scripts/provision-slot.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2026 Contributors to Eclipse Foundation.
+#
+# SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+#
+# Provisions and starts a single GlassFish slot in the pool.
+#
+# Inputs (env):
+#   SLOT_IDX     - integer slot index
+#   POOL_DIR     - pool root directory (.gf-pool)
+#   SOURCE_HOME  - GlassFish install used as the clone template (must contain
+#                  glassfish/bin/asadmin); typically the unpacked zip dist or
+#                  a user-supplied -Dglassfish.home
+#   ADMIN_BASE   - base admin port (e.g. 14848)
+#   PORT_STRIDE  - per-slot port stride (e.g. 10000)
+#
+# Idempotent: if the domain is already running on the slot's admin port the
+# function returns early.
+
+set -euo pipefail
+
+slot_dir="${POOL_DIR}/slot-${SLOT_IDX}"
+slot_home="${slot_dir}/glassfish9"
+asadmin="${slot_home}/glassfish/bin/asadmin"
+domain_xml="${slot_home}/glassfish/domains/domain1/config/domain.xml"
+
+admin_port=$((ADMIN_BASE + (SLOT_IDX - 1) * PORT_STRIDE))
+http_port=$((admin_port + 1))
+https_port=$((admin_port + 2))
+iiop_port=$((admin_port + 3))
+iiop_ssl_port=$((admin_port + 4))
+iiop_mutual_port=$((admin_port + 5))
+jmx_port=$((admin_port + 6))
+jms_port=$((admin_port + 7))
+osgi_port=$((admin_port + 8))
+derby_port=$((admin_port + 9))
+
+# Already running? (TCP probe on admin port)
+if [[ -x "${asadmin}" ]] && (echo > "/dev/tcp/127.0.0.1/${admin_port}") 2>/dev/null; then
+    echo "[gf-pool] slot ${SLOT_IDX} already running on admin=${admin_port} (skip)"
+    exit 0
+fi
+
+echo "[gf-pool] provisioning slot ${SLOT_IDX} from ${SOURCE_HOME} (admin=${admin_port} http=${http_port})"
+
+rm -rf "${slot_dir}"
+mkdir -p "${slot_dir}"
+
+# Hardlink-clone the entire install (~free, sub-second on local fs).
+cp -al "${SOURCE_HOME}" "${slot_dir}/glassfish9"
+
+# Replace domains/ with a real copy because port-patch rewrites domain.xml in
+# place; a hardlink would propagate edits back to the source install and
+# corrupt sibling slots / the user-supplied install.
+rm -rf "${slot_home}/glassfish/domains"
+cp -a "${SOURCE_HOME}/glassfish/domains" "${slot_home}/glassfish/"
+
+# Discard inherited deployments / generated artefacts / logs from the source
+# install so each slot starts from a known-empty domain state.
+rm -rf "${slot_home}/glassfish/domains/domain1/applications"/* \
+       "${slot_home}/glassfish/domains/domain1/generated"/* \
+       "${slot_home}/glassfish/domains/domain1/logs"/* 2>/dev/null || true
+
+patch_pair() {
+    local match="$1"
+    local key="$2"
+    local val="$3"
+    sed -i -E \
+        -e "s/${key}=\"[0-9]+\"([^/]*${match})/${key}=\"${val}\"\\1/g" \
+        -e "s/(${match}[^/]*)${key}=\"[0-9]+\"/\\1${key}=\"${val}\"/g" \
+        "${domain_xml}"
+}
+
+# Inject JVM options into every <java-config> block (server-config and
+# default-config). Locale pinning matches what the legacy managed Arquillian
+# container set via glassfish.systemProperties so tests that assert on locale-
+# sensitive output (numbers, dates) stay stable across host environments.
+sed -i 's|</java-config>|<jvm-options>-Duser.language=en</jvm-options><jvm-options>-Duser.country=US</jvm-options></java-config>|g' "${domain_xml}"
+
+patch_pair 'name="admin-listener"'    'port'  "${admin_port}"
+patch_pair 'name="http-listener-1"'   'port'  "${http_port}"
+patch_pair 'name="http-listener-2"'   'port'  "${https_port}"
+patch_pair 'id="orb-listener-1"'      'port'  "${iiop_port}"
+patch_pair 'id="SSL"'                 'port'  "${iiop_ssl_port}"
+patch_pair 'id="SSL_MUTUALAUTH"'      'port'  "${iiop_mutual_port}"
+patch_pair 'name="system"'            'port'  "${jmx_port}"
+patch_pair 'name="JMS_PROVIDER_PORT"' 'value' "${jms_port}"
+patch_pair 'name="PortNumber"'        'value' "${derby_port}"
+sed -i -E "s/-Dosgi\\.shell\\.telnet\\.port=[0-9]+/-Dosgi.shell.telnet.port=${osgi_port}/g" "${domain_xml}"
+
+cat > "${slot_dir}/ports.properties" <<EOF
+arquillian.adminPort=${admin_port}
+arquillian.httpPort=${http_port}
+arquillian.httpsPort=${https_port}
+glassfish.home=${slot_home}
+EOF
+
+# Pre-create the lock file so the JVM shutdown hook can always FileChannel.open
+# + tryLock it. Without this, builds that fail before any test JVM agent has
+# run leave no lock file behind, the hook's existence check returns early,
+# and the started GF gets orphaned.
+: > "${slot_dir}/lock"
+
+echo "[gf-pool] starting slot ${SLOT_IDX}"
+"${asadmin}" start-domain domain1

--- a/tck/gf-pool/src/main/scripts/stop-slot.sh
+++ b/tck/gf-pool/src/main/scripts/stop-slot.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2026 Contributors to Eclipse Foundation.
+#
+# SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+#
+# Stops a single pool slot's GlassFish domain. Inputs:
+#   SLOT_IDX, POOL_DIR
+#
+# This script does NOT check whether the slot is currently leased — that
+# check happens in the caller. ShutdownHookInstaller iterates slots in
+# Java and holds a FileLock on slot-N/lock for the duration of the call,
+# which interoperates with the agent's lock (Java's FileLock and bash's
+# flock(1) use different OS lock spaces on Linux, so the check has to be
+# on the same side as the agent).
+
+set -uo pipefail
+
+asadmin="${POOL_DIR}/slot-${SLOT_IDX}/glassfish9/glassfish/bin/asadmin"
+if [[ -x "${asadmin}" ]]; then
+    echo "[gf-pool] stopping slot ${SLOT_IDX}"
+    "${asadmin}" stop-domain domain1 || true
+fi

--- a/tck/pom.xml
+++ b/tck/pom.xml
@@ -16,30 +16,8 @@
 
 -->
 
-<!--
+<!-- See README.md for usage, architecture, and overrides. -->
 
-Usage:
-
-Run full TCK (runs both current and old)
-
-mvn clean install
-
-
-
-Run full TCK, debugging remote GlassFish (suspends on port 9009)
-
-mvn clean install -Dglassfish.suspend
-
-
-
-Run full TCK, with the version of Mojarra supplied by GlassFish
-(for the signature check mojara.version has to be set to the exact version GlassFish uses)
-
-mvn clean install -Dmojarra.noupdate
-
-
-
--->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -60,6 +38,7 @@ mvn clean install -Dmojarra.noupdate
 
     <modules>
         <module>util</module>
+        <module>gf-pool</module>
         <module>faces20</module>
         <module>faces22</module>
         <module>faces23</module>
@@ -70,7 +49,7 @@ mvn clean install -Dmojarra.noupdate
     </modules>
 
     <properties>
-        <maven.compiler.release>17</maven.compiler.release>
+        <maven.compiler.release>21</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
@@ -96,9 +75,9 @@ mvn clean install -Dmojarra.noupdate
             This can best be done in a profile specific to the implementation.
             See the standard profiles for examples.
         -->
-        <sigtest.api.groupId></sigtest.api.groupId>
-        <sigtest.api.artifactId></sigtest.api.artifactId>
-        <sigtest.api.version></sigtest.api.version>
+        <sigtest.api.groupId>jakarta.faces</sigtest.api.groupId>
+        <sigtest.api.artifactId>jakarta.faces-api</sigtest.api.artifactId>
+        <sigtest.api.version>${faces.version}</sigtest.api.version>
 
         <!-- Application Server versions (these are downloaded and installed in these versions by Maven for the CI profiles) -->
         <tomcat.version>9.0.12</tomcat.version>
@@ -460,7 +439,7 @@ mvn clean install -Dmojarra.noupdate
                             <version>3.8.6</version>
                         </requireMavenVersion>
                         <requireJavaVersion>
-                            <version>[17,)</version>
+                            <version>[${maven.compiler.release},)</version>
                         </requireJavaVersion>
                     </rules>
                 </configuration>
@@ -512,16 +491,30 @@ mvn clean install -Dmojarra.noupdate
             </plugin>
 
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-report-plugin</artifactId>
-                <configuration>
-                    <aggregate>true</aggregate>
-                </configuration>
+                <!--
+                    Override the cyclonedx-maven-plugin execution inherited from
+                    the org.eclipse.ee4j:project parent's 'sbom' profile so the
+                    reactor produces ONE aggregate SBOM (at the root) instead of
+                    re-running makeAggregateBom in every module. The mojo is
+                    @aggregator and walks the full reactor dep graph each time,
+                    which serialised every parallel `mvn -T N` build with
+                    "aggregator mojo is already being executed" warnings while
+                    other builders parked. Skip the whole thing with -DskipSBOM.
+                -->
+                <groupId>org.cyclonedx</groupId>
+                <artifactId>cyclonedx-maven-plugin</artifactId>
                 <executions>
                     <execution>
-                        <phase>post-integration-test</phase>
+                        <id>default</id>
+                        <phase>none</phase>
+                    </execution>
+                    <execution>
+                        <!-- Run once on the root reactor build only. -->
+                        <id>aggregate-bom-root</id>
+                        <inherited>false</inherited>
+                        <phase>verify</phase>
                         <goals>
-                            <goal>failsafe-report-only</goal>
+                            <goal>makeAggregateBom</goal>
                         </goals>
                     </execution>
                 </executions>
@@ -574,44 +567,42 @@ mvn clean install -Dmojarra.noupdate
         <profile>
             <id>glassfish-ci-managed</id>
 
+            <!--
+                Activate only on modules that actually deploy a WAR to GlassFish
+                (those with src/main/webapp). Skips util, gf-pool, intermediate
+                aggregator poms, the example_jar_* fixtures, and faces-signaturetest
+                (which runs sigtest-maven-plugin without any GlassFish involvement
+                and would otherwise hang in the agent's premain waiting for a slot
+                the test never leases).
+            -->
             <activation>
-                <activeByDefault>true</activeByDefault>
+                <file>
+                    <exists>${basedir}/src/main/webapp</exists>
+                </file>
             </activation>
 
             <properties>
-                <arquillian.glassfish.version>2.1.0</arquillian.glassfish.version>
+                <arquillian.glassfish.version>2.1.3</arquillian.glassfish.version>
                 <slf4j.version>2.0.17</slf4j.version>
-                <!-- Explicit version of Mojarra to test -->
-                <mojarra.version>5.0.0-SNAPSHOT</mojarra.version>
-
-                <!--
-                    By default this profile will copy the Mojarra version to test to GlassFish.
-                    Set this to "true"" to skip copying and therefor use GlassFish as is. That is
-                    useful to test GlassFish itself instead of just a specific Mojarra version.
-                -->
-                <mojarra.noupdate>false</mojarra.noupdate>
-
-                <!--
-                    Jakarta Faces API artefact that holds the API classes.
-                    This is used by the signature test in module /faces-signaturetest
-                -->
-                <sigtest.api.groupId>jakarta.faces</sigtest.api.groupId>
-                <sigtest.api.artifactId>jakarta.faces-api</sigtest.api.artifactId>
-                <sigtest.api.version>${faces.version}</sigtest.api.version>
-
-                <!-- Verhicle used for testing the Mojarra version -->
-                <glassfish.version>9.0.0-M1</glassfish.version>
-                <glassfish.dirName>glassfish9</glassfish.dirName>
-                <glassfish.root>${maven.multiModuleProjectDirectory}/target</glassfish.root>
-                <glassfish.home>${glassfish.root}/${glassfish.dirName}</glassfish.home>
-                <test.logManager>org.glassfish.main.jul.GlassFishLogManager</test.logManager>
                 <test.logLevel>INFO</test.logLevel>
             </properties>
 
             <dependencies>
+                <!--
+                    Pool-leasing agent. Provides /META-INF Premain-Class=SlotLeaserAgent so
+                    the failsafe-forked JVM can attach via -javaagent and lease one of the
+                    pre-started GlassFish slots. The dependency is also what gets the gf-pool
+                    artifact path resolvable as a Maven property below.
+                -->
+                <dependency>
+                    <groupId>org.eclipse.ee4j.tck.faces.test</groupId>
+                    <artifactId>gf-pool</artifactId>
+                    <version>${project.version}</version>
+                    <scope>test</scope>
+                </dependency>
                 <dependency>
                     <groupId>ee.omnifish.arquillian</groupId>
-                    <artifactId>arquillian-glassfish-server-managed</artifactId>
+                    <artifactId>arquillian-glassfish-server-remote</artifactId>
                     <version>${arquillian.glassfish.version}</version>
                     <scope>test</scope>
                 </dependency>
@@ -619,12 +610,6 @@ mvn clean install -Dmojarra.noupdate
                     <groupId>ee.omnifish.arquillian</groupId>
                     <artifactId>glassfish-client-ee11</artifactId>
                     <version>${arquillian.glassfish.version}</version>
-                    <scope>test</scope>
-                </dependency>
-                <dependency>
-                    <groupId>org.glassfish.main</groupId>
-                    <artifactId>glassfish-jul-extension</artifactId>
-                    <version>${glassfish.version}</version>
                     <scope>test</scope>
                 </dependency>
                 <dependency>
@@ -638,90 +623,42 @@ mvn clean install -Dmojarra.noupdate
             <build>
                 <plugins>
                     <plugin>
-                        <artifactId>maven-enforcer-plugin</artifactId>
-                        <configuration>
-                            <rules>
-                                <requireJavaVersion>
-                                    <version>17</version>
-                                </requireJavaVersion>
-                            </rules>
-                        </configuration>
-                        <executions>
-                            <execution>
-                                <goals>
-                                    <goal>enforce</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
-                    <plugin>
+                        <!--
+                            Resolves the gf-pool jar path into a Maven property
+                            (${org.eclipse.ee4j.tck.faces.test:gf-pool:jar}) so failsafe's argLine
+                            can reference it as a -javaagent.
+                        -->
                         <artifactId>maven-dependency-plugin</artifactId>
                         <executions>
                             <execution>
-                                <id>unpack</id>
-                                <phase>process-test-classes</phase>
+                                <id>resolve-agent-path</id>
+                                <phase>initialize</phase>
                                 <goals>
-                                    <goal>unpack</goal>
+                                    <goal>properties</goal>
                                 </goals>
-                                <configuration>
-                                    <outputDirectory>${glassfish.root}</outputDirectory>
-                                    <markersDirectory>${glassfish.root}/dependency-maven-plugin-markers</markersDirectory>
-                                    <artifactItems>
-                                        <artifactItem>
-                                            <groupId>org.glassfish.main.distributions</groupId>
-                                            <artifactId>glassfish</artifactId>
-                                            <version>${glassfish.version}</version>
-                                            <type>zip</type>
-                                            <overWrite>false</overWrite>
-                                            <outputDirectory>${glassfish.root}</outputDirectory>
-                                        </artifactItem>
-                                    </artifactItems>
-                                </configuration>
-                            </execution>
-                            <execution>
-                                <id>update-mojarra</id>
-                                <phase>process-test-classes</phase>
-                                <goals>
-                                    <goal>copy</goal>
-                                </goals>
-                                <configuration>
-                                    <skip>${mojarra.noupdate}</skip>
-                                    <artifactItems>
-                                        <artifactItem>
-                                            <groupId>jakarta.faces</groupId>
-                                            <artifactId>jakarta.faces-api</artifactId>
-                                            <version>${faces.version}</version>
-                                            <type>jar</type>
-                                            <overWrite>true</overWrite>
-                                            <outputDirectory>${glassfish.home}/glassfish/modules</outputDirectory>
-                                            <destFileName>jakarta.faces-api.jar</destFileName>
-                                        </artifactItem>
-                                        <artifactItem>
-                                            <groupId>org.glassfish.mojarra</groupId>
-                                            <artifactId>mojarra</artifactId>
-                                            <version>${mojarra.version}</version>
-                                            <type>jar</type>
-                                            <overWrite>true</overWrite>
-                                            <outputDirectory>${glassfish.home}/glassfish/modules</outputDirectory>
-                                            <destFileName>mojarra.jar</destFileName>
-                                        </artifactItem>
-                                    </artifactItems>
-                                </configuration>
                             </execution>
                         </executions>
                     </plugin>
                     <plugin>
                         <artifactId>maven-failsafe-plugin</artifactId>
                         <configuration>
+                            <!--
+                                gf.pool.dir MUST be on the JVM command line (not in
+                                systemPropertyVariables) so the SlotLeaserAgent's
+                                premain can read it before the booter has applied
+                                surefire's property file. Pool size is self-
+                                discovered by scanning slot directories.
+                            -->
+                            <!--
+                                If a sibling profile or plugin (e.g. JaCoCo) ever needs to
+                                contribute its own JVM args, change this to
+                                "@{argLine} -javaagent:..." AND make sure something defines
+                                ${argLine} or the @{argLine} placeholder will be passed
+                                literally to the forked JVM and crash the test.
+                            -->
+                            <argLine>-javaagent:${org.eclipse.ee4j.tck.faces.test:gf-pool:jar} -Dgf.pool.dir=${maven.multiModuleProjectDirectory}/gf-pool/target/pool</argLine>
                             <systemPropertyVariables>
-                                <glassfish.home>${glassfish.home}</glassfish.home>
-                                <glassfish.systemProperties>
-                                    user.language=en
-                                    user.country=US
-                                </glassfish.systemProperties>
-                                <glassfish.suspend>${glassfish.suspend}</glassfish.suspend>
                                 <test.selenium>${test.selenium}</test.selenium>
-                                <java.util.logging.manager>${test.logManager}</java.util.logging.manager>
                                 <java.util.logging.config.useDefaults>true</java.util.logging.config.useDefaults>
                                 <java.util.logging.config.defaultLevel>${test.logLevel}</java.util.logging.config.defaultLevel>
                             </systemPropertyVariables>

--- a/tck/start-pool.sh
+++ b/tck/start-pool.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2026 Contributors to Eclipse Foundation.
+#
+# SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+#
+# Provisions and starts the GlassFish pool independently of a full Maven build.
+# Pass through any -D options accepted by the gf-pool module, e.g.
+#   ./start-pool.sh -Dgf.pool.size=8
+#   ./start-pool.sh -Dglassfish.home=/path/to/glassfish9
+
+set -euo pipefail
+
+cd "$(dirname "$0")"
+exec mvn -pl gf-pool -am process-classes "$@"

--- a/tck/stop-pool.sh
+++ b/tck/stop-pool.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2026 Contributors to Eclipse Foundation.
+#
+# SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+#
+# Stops every running GlassFish pool slot.
+
+set -euo pipefail
+
+cd "$(dirname "$0")"
+exec mvn -pl gf-pool -am antrun:run@stop "$@"

--- a/tck/util/src/main/resources/arquillian.xml
+++ b/tck/util/src/main/resources/arquillian.xml
@@ -6,4 +6,19 @@
         <property name="deploymentClass">ee.jakarta.tck.faces.test.util.selenium.BaseITNG</property>
     </extension>
 
+    <!--
+        Remote container pointed at one of the gf-pool slots. The SlotLeaserAgent
+        (-javaagent on the failsafe-forked JVM) leases a slot before tests run and
+        publishes the slot's ports as system properties. Defaults let an IDE talk
+        to a stock GlassFish on 4848/8080/8181 when running tests directly without
+        the agent.
+    -->
+    <container qualifier="glassfish-remote-tck" default="true">
+        <configuration>
+            <property name="adminHost">localhost</property>
+            <property name="adminPort">${arquillian.adminPort:4848}</property>
+            <property name="adminHttps">false</property>
+        </configuration>
+    </container>
+
 </arquillian>


### PR DESCRIPTION
Replaces the per-module managed-Arquillian lifecycle (unpack GlassFish, reserve ports, patch domain.xml, start, deploy, undeploy, stop on every test module) with a shared pool of pre-started GlassFish instances that test modules lease for the duration of their failsafe-forked JVM.

Architecture:
  - gf-pool/ module unpacks GlassFish once, overlays the Mojarra build under test, clones the install into slot-N/ via cp -al hardlinks, patches each slot's port range, and starts the initial slot's domain. Pool lives at gf-pool/target/pool/, wiped by mvn clean.
  - SlotLeaserAgent (-javaagent, Premain-Class) attaches to each failsafe-forked test JVM, acquires a FileLock on slot-N/lock, publishes the slot's arquillian.adminPort/httpPort/httpsPort as system properties for the omnifish glassfish-remote container, and holds the lock for the JVM lifetime. LRU-by-mtime ordering spreads load evenly across slots even with mixed test durations. Health-checks via TCP probe on lease so a phantom slot (OOM- crashed, killed, mid-shutdown) is rejected and the scan continues.
  - Grow on demand: if every existing slot is busy, the agent provisions another slot up to max(4, cores/2). Single-test runs boot one server; -T 4 grows to four; -T 16 (with -Dgf.pool.size=16) eagerly provisions all up front.
  - ShutdownHookInstaller (Ant taskdef loaded in-process by antrun) registers a JVM shutdown hook on Maven's own JVM. At session end or Ctrl+C it iterates slot-* dirs, FileLock-checks each (skips in-flight test JVMs), and stops idle slots via asadmin.

Other changes required to make the pool effective:

  - Switch container from arquillian-glassfish-server-managed to arquillian-glassfish-server-remote (omnifish 2.1.3); the pool starts the GFs, the container just deploys to them.
  - Override the inherited cyclonedx-maven-plugin:makeAggregateBom execution from org.eclipse.ee4j:project's sbom profile to run once at the root reactor instead of in every module. The mojo is @aggregator and re-walks the full reactor each invocation, which serialised every parallel mvn -T N build. Skip with -DskipSBOM.
  - Activate the glassfish-ci-managed profile on src/main/webapp instead of src/test/java so faces-signaturetest (no deploy, no Arquillian) doesn't attach the agent and hang in premain.
  - Repackage faces41/facesMessage as jar (it's a pure JUnit unit test on FacesMessage, not a deployable WAR).
  - Hoist sigtest.api.* defaults from the activation-conditional profile to the root <properties> so faces-signaturetest still resolves them after the activation change.
  - Update the README with the new architecture, the -DskipSBOM, -Dgf.pool.size, -Dglassfish.home overrides, and start/stop helper scripts.

Net effect on a 20-thread host with -T 4: full TCK 70 min → 10 min (7x). Per-module GlassFish boot/shutdown is gone; the cyclonedx serialization that previously throttled parallelism is gone; tests genuinely run four-at-a-time against four pre-started GFs. 

With -T 8 it's 7 min (10x). Faster is not possible with TCK in its current form as the biggest individual test module already needs a little over 6 minutes to run. It can only be faster when we break down big test modules (e.g. faces20/api and faces20/renderkit) in smaller test modules.