### PR TITLE
util/WebPage: cleanup of legacy practices and workarounds

### DIFF
--- a/tck/faces20/flows/basicflowcall/src/test/java/ee/jakarta/tck/faces/test/faces20/flows/basicflowcall/BasicflowcallIT.java
+++ b/tck/faces20/flows/basicflowcall/src/test/java/ee/jakarta/tck/faces/test/faces20/flows/basicflowcall/BasicflowcallIT.java
@@ -32,15 +32,15 @@ class BasicflowcallIT extends BaseITNG {
     void facesFlowCallTest() {
         // Outside the Flow structure. (/index.xhtml)
         WebPage page = getPage("faces/index.xhtml");
-        assertTrue(page.isInPageText("Outside of flow"), "Outside of flow");
+        assertTrue(page.containsText("Outside of flow"), "Outside of flow");
 
         // First page of Flow. (flow-a/flow-a.xhtml)
         WebElement startA = findByIdSuffix(page, "start_a");
         page.guardHttp(startA::click);
 
-        assertTrue(page.isInPageText("First page in the flow"), "First page in the flow");
-        assertTrue(page.isInPageText("Flow_a_Bean"), "Flow_a_Bean");
-        assertTrue(page.matchesPageText("(?s).*Has a flow:\\s+true\\..*"), "Has a flow: true");
+        assertTrue(page.containsText("First page in the flow"), "First page in the flow");
+        assertTrue(page.containsText("Flow_a_Bean"), "Flow_a_Bean");
+        assertTrue(page.matchesText("(?s).*Has a flow:\\s+true\\..*"), "Has a flow: true");
         assertEquals("", findByIdSuffix(page, "param1FromFlowB").getText(), "param1FromFlowB");
         assertEquals("", findByIdSuffix(page, "param2FromFlowB").getText(), "param2FromFlowB");
 
@@ -48,7 +48,7 @@ class BasicflowcallIT extends BaseITNG {
         WebElement nextA = findByIdSuffix(page, "next_a");
         page.guardHttp(nextA::click);
 
-        assertTrue(page.isInPageText("Second page in the flow"), "Second page in the flow");
+        assertTrue(page.containsText("Second page in the flow"), "Second page in the flow");
 
         WebElement input = findByIdSuffix(page, "input");
         String value = "" + System.currentTimeMillis();
@@ -58,14 +58,14 @@ class BasicflowcallIT extends BaseITNG {
         WebElement next = findByIdSuffix(page, "next");
         page.guardHttp(next::click);
 
-        assertTrue(page.isInPageText(value), "value");
+        assertTrue(page.containsText(value), "value");
 
         // Enter flow-b, passing parameters.
         WebElement callB = findByIdSuffix(page, "callB");
         page.guardHttp(callB::click);
 
-        assertTrue(page.isInPageText("Flow_b_Bean"), "Flow_b_Bean");
-        assertFalse((page.getPageText() + page.getInputValues()).contains("Flow_a_Bean"), "Not Flow_a_Bean");
+        assertTrue(page.containsText("Flow_b_Bean"), "Flow_b_Bean");
+        assertFalse(page.containsText("Flow_a_Bean"), "Not Flow_a_Bean");
         assertEquals("param1Value", findByIdSuffix(page, "param1FromFlowA").getText(), "param1FromFlowA");
         assertEquals("param2Value", findByIdSuffix(page, "param2FromFlowA").getText(), "param2FromFlowA");
 
@@ -73,7 +73,7 @@ class BasicflowcallIT extends BaseITNG {
         nextA = findByIdSuffix(page, "next_a");
         page.guardHttp(nextA::click);
 
-        assertTrue(page.isInPageText("Second page in the flow"), "Second page in the flow (flow-b)");
+        assertTrue(page.containsText("Second page in the flow"), "Second page in the flow (flow-b)");
 
         input = findByIdSuffix(page, "input");
         value = "" + System.currentTimeMillis();
@@ -83,7 +83,7 @@ class BasicflowcallIT extends BaseITNG {
         next = findByIdSuffix(page, "next");
         page.guardHttp(next::click);
 
-        assertTrue(page.isInPageText(value), "value (flow-b)");
+        assertTrue(page.containsText(value), "value (flow-b)");
 
         // Enter flow-a, passing parameters.
         WebElement callA = findByIdSuffix(page, "callA");
@@ -96,7 +96,7 @@ class BasicflowcallIT extends BaseITNG {
         nextA = findByIdSuffix(page, "next_a");
         page.guardHttp(nextA::click);
 
-        assertTrue(page.isInPageText("Second page in the flow"), "Second page in the flow (flow-a reentered)");
+        assertTrue(page.containsText("Second page in the flow"), "Second page in the flow (flow-a reentered)");
 
         // Enter last page of Flow-a
         next = findByIdSuffix(page, "next");

--- a/tck/faces20/flows/basicimplicit/src/test/java/ee/jakarta/tck/faces/test/faces20/flows/basicimplicit/BasicimplicitIT.java
+++ b/tck/faces20/flows/basicimplicit/src/test/java/ee/jakarta/tck/faces/test/faces20/flows/basicimplicit/BasicimplicitIT.java
@@ -29,22 +29,22 @@ class BasicimplicitIT extends BaseITNG {
     @Test
     void facesFlowImplicitTest() {
         WebPage page = getPage("faces/index.xhtml");
-        assertTrue(page.isInPageText("Page with link to flow entry"), "Page with link to flow entry");
+        assertTrue(page.containsText("Page with link to flow entry"), "Page with link to flow entry");
 
         WebElement start = findByIdSuffix(page, "start");
         page.guardHttp(start::click);
 
-        assertTrue(page.isInPageText("First page in the flow"), "First page in the flow");
-        assertTrue(page.isInPageText("basicFlow"), "basicFlow");
+        assertTrue(page.containsText("First page in the flow"), "First page in the flow");
+        assertTrue(page.containsText("basicFlow"), "basicFlow");
 
         page = getPage("faces/index.xhtml");
-        assertTrue(page.isInPageText("Page with link to flow entry"), "Page with link to flow entry");
+        assertTrue(page.containsText("Page with link to flow entry"), "Page with link to flow entry");
 
         start = findByIdSuffix(page, "start");
         page.guardHttp(start::click);
 
-        assertTrue(page.isInPageText("First page in the flow"), "First page in the flow");
-        assertTrue(page.isInPageText("basicFlow"), "basicFlow");
+        assertTrue(page.containsText("First page in the flow"), "First page in the flow");
+        assertTrue(page.containsText("basicFlow"), "basicFlow");
     }
 
     private static WebElement findByIdSuffix(WebPage page, String id) {

--- a/tck/faces20/flows/basicmethodcall/src/test/java/ee/jakarta/tck/faces/test/faces20/flows/basicmethodcall/BasicmethodcallIT.java
+++ b/tck/faces20/flows/basicmethodcall/src/test/java/ee/jakarta/tck/faces/test/faces20/flows/basicmethodcall/BasicmethodcallIT.java
@@ -34,7 +34,7 @@ class BasicmethodcallIT extends BaseITNG {
 
     private void goTest(String startId) {
         WebPage page = getPage("faces/index.xhtml");
-        assertTrue(page.isInPageText("Outside of flow"), "Outside of flow");
+        assertTrue(page.containsText("Outside of flow"), "Outside of flow");
 
         WebElement start = findByIdSuffix(page, startId);
         page.guardHttp(start::click);
@@ -42,7 +42,7 @@ class BasicmethodcallIT extends BaseITNG {
         WebElement outcomeFromMethod = findByIdSuffix(page, "outcome-from-method");
         page.guardHttp(outcomeFromMethod::click);
 
-        assertTrue(page.isInPageText("Last page in the flow"), "Last page in the flow");
+        assertTrue(page.containsText("Last page in the flow"), "Last page in the flow");
 
         page = getPage("faces/index.xhtml");
 
@@ -52,7 +52,7 @@ class BasicmethodcallIT extends BaseITNG {
         WebElement outcomeFromMarkup = findByIdSuffix(page, "outcome-from-markup");
         page.guardHttp(outcomeFromMarkup::click);
 
-        assertTrue(page.isInPageText("voidMethod called in flow-a"), "voidMethod called in flow-a");
+        assertTrue(page.containsText("voidMethod called in flow-a"), "voidMethod called in flow-a");
     }
 
     private static WebElement findByIdSuffix(WebPage page, String id) {

--- a/tck/faces20/flows/basicmultipage/src/test/java/ee/jakarta/tck/faces/test/faces20/flows/basicmultipage/BasicmultipageIT.java
+++ b/tck/faces20/flows/basicmultipage/src/test/java/ee/jakarta/tck/faces/test/faces20/flows/basicmultipage/BasicmultipageIT.java
@@ -30,34 +30,34 @@ class BasicmultipageIT extends BaseITNG {
     @Test
     void facesFlowEntryExitTest() {
         WebPage page = getPage("faces/index.xhtml");
-        assertTrue(page.isInPageText("Page with link to flow entry"), "Page with link to flow entry");
+        assertTrue(page.containsText("Page with link to flow entry"), "Page with link to flow entry");
 
         WebElement start = findByIdSuffix(page, "start");
         page.guardHttp(start::click);
 
-        assertTrue(page.isInPageText("First page in the flow"), "First page in the flow");
-        assertTrue(page.isInPageText("basicFlow"), "basicFlow");
+        assertTrue(page.containsText("First page in the flow"), "First page in the flow");
+        assertTrue(page.containsText("basicFlow"), "basicFlow");
 
         page = getPage("faces/index.xhtml");
-        assertTrue(page.isInPageText("Page with link to flow entry"), "Page with link to flow entry");
+        assertTrue(page.containsText("Page with link to flow entry"), "Page with link to flow entry");
 
         start = findByIdSuffix(page, "start");
         page.guardHttp(start::click);
 
-        assertTrue(page.isInPageText("First page in the flow"), "First page in the flow");
-        assertTrue(page.isInPageText("basicFlow"), "basicFlow");
+        assertTrue(page.containsText("First page in the flow"), "First page in the flow");
+        assertTrue(page.containsText("basicFlow"), "basicFlow");
     }
 
     @Test
     void facesFlowScopeTest() {
         WebPage page = getPage("faces/index.xhtml");
-        assertTrue(page.isInPageText("Page with link to flow entry"), "Page with link to flow entry");
+        assertTrue(page.containsText("Page with link to flow entry"), "Page with link to flow entry");
 
         WebElement start = findByIdSuffix(page, "start");
         page.guardHttp(start::click);
 
-        assertTrue(page.isInPageText("First page in the flow"), "First page in the flow");
-        assertTrue(page.isInPageText("basicFlow"), "basicFlow");
+        assertTrue(page.containsText("First page in the flow"), "First page in the flow");
+        assertTrue(page.containsText("basicFlow"), "basicFlow");
 
         WebElement nextA = findByIdSuffix(page, "next_a");
         page.guardHttp(nextA::click);
@@ -69,13 +69,13 @@ class BasicmultipageIT extends BaseITNG {
         WebElement next = findByIdSuffix(page, "next");
         page.guardHttp(next::click);
 
-        assertTrue(page.isInPageText(flowScopeValue), "flowScopeValue visible");
+        assertTrue(page.containsText(flowScopeValue), "flowScopeValue visible");
 
         WebElement returnButton = findByIdSuffix(page, "return");
         page.guardHttp(returnButton::click);
 
-        assertTrue(page.isInPageText("return page"), "return page");
-        assertFalse((page.getPageText() + page.getInputValues()).contains(flowScopeValue), "flowScopeValue not visible");
+        assertTrue(page.containsText("return page"), "return page");
+        assertFalse(page.containsText(flowScopeValue), "flowScopeValue not visible");
     }
 
     private static WebElement findByIdSuffix(WebPage page, String id) {

--- a/tck/faces20/flows/basicswitch/src/test/java/ee/jakarta/tck/faces/test/faces20/flows/basicswitch/BasicswitchIT.java
+++ b/tck/faces20/flows/basicswitch/src/test/java/ee/jakarta/tck/faces/test/faces20/flows/basicswitch/BasicswitchIT.java
@@ -40,7 +40,7 @@ class BasicswitchIT extends BaseITNG {
 
     private void exerciseSwitch(String startId, String switchId, String expectedResult) {
         WebPage page = getPage("faces/index.xhtml");
-        assertTrue(page.isInPageText("Outside of flow"), "Outside of flow");
+        assertTrue(page.containsText("Outside of flow"), "Outside of flow");
 
         WebElement start = findByIdSuffix(page, startId);
         page.guardHttp(start::click);
@@ -48,7 +48,7 @@ class BasicswitchIT extends BaseITNG {
         WebElement switchButton = findByIdSuffix(page, switchId);
         page.guardHttp(switchButton::click);
 
-        assertTrue(page.isInPageText(expectedResult), expectedResult);
+        assertTrue(page.containsText(expectedResult), expectedResult);
     }
 
     private static WebElement findByIdSuffix(WebPage page, String id) {

--- a/tck/faces20/flows/factory/src/test/java/ee/jakarta/tck/faces/test/faces20/flows/factory/FactoryIT.java
+++ b/tck/faces20/flows/factory/src/test/java/ee/jakarta/tck/faces/test/faces20/flows/factory/FactoryIT.java
@@ -29,15 +29,15 @@ class FactoryIT extends BaseITNG {
     @Test
     void facesFlowFactoryTest() {
         WebPage page = getPage("faces/index.xhtml");
-        assertTrue(page.isInPageText("Page with link to flow entry"), "Page with link to flow entry");
+        assertTrue(page.containsText("Page with link to flow entry"), "Page with link to flow entry");
 
         WebElement start = findByIdSuffix(page, "start");
         page.guardHttp(start::click);
 
-        assertTrue(page.isInPageText("First page in the flow"), "First page in the flow");
-        assertTrue(page.isInPageText("basicFlow"), "basicFlow");
-        assertTrue(page.isInPageText("Did we wrap: true"), "Did we wrap: true");
-        assertTrue(page.isInPageText("Did we inject: MyAppBean"), "Did we inject: MyAppBean");
+        assertTrue(page.containsText("First page in the flow"), "First page in the flow");
+        assertTrue(page.containsText("basicFlow"), "basicFlow");
+        assertTrue(page.containsText("Did we wrap: true"), "Did we wrap: true");
+        assertTrue(page.containsText("Did we inject: MyAppBean"), "Did we inject: MyAppBean");
     }
 
     private static WebElement findByIdSuffix(WebPage page, String id) {

--- a/tck/faces20/flows/intermediate/src/test/java/ee/jakarta/tck/faces/test/faces20/flows/intermediate/IntermediateIT.java
+++ b/tck/faces20/flows/intermediate/src/test/java/ee/jakarta/tck/faces/test/faces20/flows/intermediate/IntermediateIT.java
@@ -40,7 +40,7 @@ class IntermediateIT extends BaseITNG {
 
     private void goTest(String button) {
         WebPage page = getPage("faces/index.xhtml");
-        assertTrue(page.isInPageText("Outside of flow"), "Outside of flow");
+        assertTrue(page.containsText("Outside of flow"), "Outside of flow");
 
         WebElement enter = findByIdSuffix(page, button);
         page.guardHttp(enter::click);
@@ -48,20 +48,20 @@ class IntermediateIT extends BaseITNG {
         WebElement createCustomer = findByIdSuffix(page, "createCustomer");
         page.guardHttp(createCustomer::click);
 
-        assertTrue(page.isInPageText("View customer page"), "View customer page");
-        assertTrue(page.matchesPageText("(?s).*Customer Id:\\s+([0-9])+.*"), "Customer Id present");
+        assertTrue(page.containsText("View customer page"), "View customer page");
+        assertTrue(page.matchesText("(?s).*Customer Id:\\s+([0-9])+.*"), "Customer Id present");
 
         WebElement upgrade = findByIdSuffix(page, "upgrade");
         page.guardHttp(upgrade::click);
 
-        assertTrue(page.isInPageText("View customer page"), "View customer page (after upgrade)");
-        assertTrue(page.matchesPageText("(?s).*Customer is upgraded:\\s+true.*"), "Customer is upgraded: true");
+        assertTrue(page.containsText("View customer page"), "View customer page (after upgrade)");
+        assertTrue(page.matchesText("(?s).*Customer is upgraded:\\s+true.*"), "Customer is upgraded: true");
 
         WebElement exit = findByIdSuffix(page, "exit");
         page.guardHttp(exit::click);
 
-        assertTrue(page.isInPageText("return page"), "return page");
-        assertTrue(page.isInPageText("Finalizer called"), "Finalizer called");
+        assertTrue(page.containsText("return page"), "return page");
+        assertTrue(page.containsText("Finalizer called"), "Finalizer called");
     }
 
     private static WebElement findByIdSuffix(WebPage page, String id) {

--- a/tck/faces20/flows/multipagewebinf/src/test/java/ee/jakarta/tck/faces/test/faces20/flows/multipagewebinf/MultipagewebinfIT.java
+++ b/tck/faces20/flows/multipagewebinf/src/test/java/ee/jakarta/tck/faces/test/faces20/flows/multipagewebinf/MultipagewebinfIT.java
@@ -30,34 +30,34 @@ class MultipagewebinfIT extends BaseITNG {
     @Test
     void facesFlowWebInfEntryExitTest() {
         WebPage page = getPage("faces/index.xhtml");
-        assertTrue(page.isInPageText("Page with link to flow entry"), "Page with link to flow entry");
+        assertTrue(page.containsText("Page with link to flow entry"), "Page with link to flow entry");
 
         WebElement start = findByIdSuffix(page, "start");
         page.guardHttp(start::click);
 
-        assertTrue(page.isInPageText("First page in the flow"), "First page in the flow");
-        assertTrue(page.isInPageText("basicFlow"), "basicFlow");
+        assertTrue(page.containsText("First page in the flow"), "First page in the flow");
+        assertTrue(page.containsText("basicFlow"), "basicFlow");
 
         page = getPage("faces/index.xhtml");
-        assertTrue(page.isInPageText("Page with link to flow entry"), "Page with link to flow entry");
+        assertTrue(page.containsText("Page with link to flow entry"), "Page with link to flow entry");
 
         start = findByIdSuffix(page, "start");
         page.guardHttp(start::click);
 
-        assertTrue(page.isInPageText("First page in the flow"), "First page in the flow");
-        assertTrue(page.isInPageText("basicFlow"), "basicFlow");
+        assertTrue(page.containsText("First page in the flow"), "First page in the flow");
+        assertTrue(page.containsText("basicFlow"), "basicFlow");
     }
 
     @Test
     void facesFlowWebInfScopeTest() {
         WebPage page = getPage("faces/index.xhtml");
-        assertTrue(page.isInPageText("Page with link to flow entry"), "Page with link to flow entry");
+        assertTrue(page.containsText("Page with link to flow entry"), "Page with link to flow entry");
 
         WebElement start = findByIdSuffix(page, "start");
         page.guardHttp(start::click);
 
-        assertTrue(page.isInPageText("First page in the flow"), "First page in the flow");
-        assertTrue(page.isInPageText("basicFlow"), "basicFlow");
+        assertTrue(page.containsText("First page in the flow"), "First page in the flow");
+        assertTrue(page.containsText("basicFlow"), "basicFlow");
 
         WebElement nextA = findByIdSuffix(page, "next_a");
         page.guardHttp(nextA::click);
@@ -69,13 +69,13 @@ class MultipagewebinfIT extends BaseITNG {
         WebElement next = findByIdSuffix(page, "next");
         page.guardHttp(next::click);
 
-        assertTrue(page.isInPageText(flowScopeValue), "flowScopeValue visible");
+        assertTrue(page.containsText(flowScopeValue), "flowScopeValue visible");
 
         WebElement returnButton = findByIdSuffix(page, "return");
         page.guardHttp(returnButton::click);
 
-        assertTrue(page.isInPageText("return page"), "return page");
-        assertFalse((page.getPageText() + page.getInputValues()).contains(flowScopeValue), "flowScopeValue not visible");
+        assertTrue(page.containsText("return page"), "return page");
+        assertFalse(page.containsText(flowScopeValue), "flowScopeValue not visible");
     }
 
     private static WebElement findByIdSuffix(WebPage page, String id) {

--- a/tck/faces20/jstl/src/test/java/ee/jakarta/tck/faces/test/faces20/jstl/JstlIT.java
+++ b/tck/faces20/jstl/src/test/java/ee/jakarta/tck/faces/test/faces20/jstl/JstlIT.java
@@ -200,7 +200,7 @@ class JstlIT extends BaseITNG {
     @Test
     void jstlCoreForEachTagTest() {
         WebPage page = getPage("faces/foreachtag/foreachtag_facelet.xhtml");
-        String body = page.getPageSource();
+        String body = page.getSource();
 
         // case 1: String array iteration
         assertAllPresent(body, List.of("Firstname: Geddy", "Firstname: Alex", "Firstname: Neil"));

--- a/tck/faces20/protectedView/src/test/java/ee/jakarta/tck/faces/test/faces20/protectedview/ProtectedViewsTestIT.java
+++ b/tck/faces20/protectedView/src/test/java/ee/jakarta/tck/faces/test/faces20/protectedview/ProtectedViewsTestIT.java
@@ -44,7 +44,7 @@ class ProtectedViewsTestIT extends BaseITNG {
 
     assertEquals(0, page.findElements​(By.id("messOne")).size(), "Illegal Access of a Protected View!");
 
-    assertTrue(page.isInPageText("jakarta.faces.application.ProtectedViewException"), "Expected a ProtectedViewException when accessing a protected view");
+    assertTrue(page.containsText("jakarta.faces.application.ProtectedViewException"), "Expected a ProtectedViewException when accessing a protected view");
 
   }
 

--- a/tck/faces20/renderkit/input/src/test/java/ee/jakarta/tck/faces/test/faces20/renderkit/manycheckbox/ManycheckboxIT.java
+++ b/tck/faces20/renderkit/input/src/test/java/ee/jakarta/tck/faces/test/faces20/renderkit/manycheckbox/ManycheckboxIT.java
@@ -176,7 +176,7 @@ class ManycheckboxIT extends BaseITNG {
 
         page.guardHttp(findByIdSuffix(page, "command")::click);
 
-        assertFalse(page.getPageSource().contains("Error:"), "post-back contains 'Error:'");
+        assertFalse(page.containsText("Error:"), "post-back contains 'Error:'");
 
         for (String id : SELECT_IDS) {
             List<WebElement> items = findCheckboxItems(page, id);

--- a/tck/faces20/renderkit/input/src/test/java/ee/jakarta/tck/faces/test/faces20/renderkit/manylistbox/ManylistboxIT.java
+++ b/tck/faces20/renderkit/input/src/test/java/ee/jakarta/tck/faces/test/faces20/renderkit/manylistbox/ManylistboxIT.java
@@ -189,7 +189,7 @@ class ManylistboxIT extends BaseITNG {
 
         page.guardHttp(findByIdSuffix(page, "command")::click);
 
-        assertFalse(page.getPageSource().contains("Error:"), "post-back contains 'Error:'");
+        assertFalse(page.containsText("Error:"), "post-back contains 'Error:'");
 
         for (String id : SELECT_IDS) {
             WebElement select = findByIdSuffix(page, id);

--- a/tck/faces20/renderkit/input/src/test/java/ee/jakarta/tck/faces/test/faces20/renderkit/manymenu/ManymenuIT.java
+++ b/tck/faces20/renderkit/input/src/test/java/ee/jakarta/tck/faces/test/faces20/renderkit/manymenu/ManymenuIT.java
@@ -162,7 +162,7 @@ class ManymenuIT extends BaseITNG {
 
         page.guardHttp(findByIdSuffix(page, "command")::click);
 
-        assertFalse(page.getPageSource().contains("Error:"), "post-back contains 'Error:'");
+        assertFalse(page.containsText("Error:"), "post-back contains 'Error:'");
 
         for (String id : SELECT_IDS) {
             WebElement select = findByIdSuffix(page, id);

--- a/tck/faces20/renderkit/input/src/test/java/ee/jakarta/tck/faces/test/faces20/renderkit/oneradio/OneradioIT.java
+++ b/tck/faces20/renderkit/input/src/test/java/ee/jakarta/tck/faces/test/faces20/renderkit/oneradio/OneradioIT.java
@@ -94,7 +94,7 @@ class OneradioIT extends BaseITNG {
         WebElement label111 = findLabelFor(page, radio111.getAttribute("id"));
         assertEquals("&foo", label110.getText().trim(), "radio11:0 label text (unescaped)");
         assertEquals("&bar", label111.getText().trim(), "radio11:1 label text (escaped)");
-        assertTrue(page.getPageSource().contains("&amp;bar</label>"), "radio11:1 escaped in source");
+        assertTrue(page.containsSource("&amp;bar</label>"), "radio11:1 escaped in source");
 
         // radio12: binding, two radios, none checked
         WebElement radio120 = findByIdSuffix(page, "radio12:0");

--- a/tck/faces20/renderkit/structure/src/test/java/ee/jakarta/tck/faces/test/faces20/renderkit/commandlink/CommandlinkIT.java
+++ b/tck/faces20/renderkit/structure/src/test/java/ee/jakarta/tck/faces/test/faces20/renderkit/commandlink/CommandlinkIT.java
@@ -38,23 +38,23 @@ class CommandlinkIT extends BaseITNG {
         WebElement link1 = findByIdSuffix(page, "link1");
         assertEquals("#", link1.getDomAttribute("href"), "link1 href");
         assertEquals("Click Me1", link1.getText(), "link1 text");
-        assertNotNull(getBehaviorScript(page, link1), "link1 onclick script");
+        assertNotNull(page.getBehaviorScript(link1), "link1 onclick script");
 
         WebElement link2 = findByIdSuffix(page, "link2");
         assertEquals("#", link2.getDomAttribute("href"), "link2 href");
         assertEquals("Click Me2", link2.getText(), "link2 text");
         assertEquals("sansserif", link2.getDomAttribute("class"), "link2 class");
-        assertNotNull(getBehaviorScript(page, link2), "link2 onclick script");
+        assertNotNull(page.getBehaviorScript(link2), "link2 onclick script");
 
         WebElement link3 = findByIdSuffix(page, "link3");
         assertEquals("#", link3.getDomAttribute("href"), "link3 href");
         assertEquals("Click Me3", link3.getText(), "link3 text");
-        assertNotNull(getBehaviorScript(page, link3), "link3 onclick script");
+        assertNotNull(page.getBehaviorScript(link3), "link3 onclick script");
 
         WebElement link5 = findByIdSuffix(page, "link5");
         assertEquals("sansserif", link5.getDomAttribute("class"), "link5 class");
         assertEquals("Disabled Link", link5.getText(), "link5 text");
-        assertNull(getBehaviorScript(page, link5), "link5 no onclick (disabled)");
+        assertNull(page.getBehaviorScript(link5), "link5 no onclick (disabled)");
 
         WebElement link6 = findByIdSuffix(page, "link6");
         assertEquals("Disabled Link(Nested)", link6.getText(), "link6 text (nested, disabled)");

--- a/tck/faces20/viewhandler/src/test/java/ee/jakarta/tck/faces/test/faces20/viewhandler/ViewHandlerIT.java
+++ b/tck/faces20/viewhandler/src/test/java/ee/jakarta/tck/faces/test/faces20/viewhandler/ViewHandlerIT.java
@@ -48,8 +48,8 @@ class ViewHandlerIT extends BaseITNG {
 
         assertEquals(200, page.getResponseStatus(),
                 "Initial GET of greetings.jsf must not fail; ViewHandler.createView received an invalid viewId.");
-        assertTrue(page.isInPage(EXPECTED_TEXT),
-                "Expected greetings page to render; instead got: " + page.getPageSource());
+        assertTrue(page.containsText(EXPECTED_TEXT),
+                "Expected greetings page to render; instead got: " + page.getSource());
     }
 
     /**
@@ -74,8 +74,8 @@ class ViewHandlerIT extends BaseITNG {
 
         assertEquals(200, page.getResponseStatus(),
                 "Postback to greetings.jsf must not fail; ViewHandler.restoreView received an invalid viewId.");
-        assertTrue(page.isInPage(EXPECTED_TEXT),
-                "Expected greetings page after postback; instead got: " + page.getPageSource());
+        assertTrue(page.containsText(EXPECTED_TEXT),
+                "Expected greetings page after postback; instead got: " + page.getSource());
     }
 
 }

--- a/tck/faces22/ajax-inputs/src/main/webapp/attributeNameIsOn.xhtml
+++ b/tck/faces22/ajax-inputs/src/main/webapp/attributeNameIsOn.xhtml
@@ -31,12 +31,12 @@
              <script type="text/javascript">
               var statusUpdate = function statusUpdate(data) {
                  var statusArea = document.getElementById("statusArea");
-                 var text = statusArea.value;
+                 var text = statusArea.innerText;
                  text = text + "Name: "+data.source.id;
                  if (data.type === "event") {
                      text = text + " Response: "+data.responseText;
                  }
-                 statusArea.value = text;
+                 statusArea.innerText = text;
               }
             </script>
     <h:form id="form1">
@@ -51,7 +51,7 @@
        <br/>
        <br/>
        <h3> Status:</h3>
-       <textarea id="statusArea" cols="40" rows="10" readonly="readonly" />
+       <div id="statusArea"/>
     </h:form>
 </h:body>
 </html>

--- a/tck/faces22/ajax-inputs/src/main/webapp/issue1957.xhtml
+++ b/tck/faces22/ajax-inputs/src/main/webapp/issue1957.xhtml
@@ -29,12 +29,12 @@
              <script type="text/javascript">
               var statusUpdate = function statusUpdate(data) {
                  var statusArea = document.getElementById("statusArea");
-                 var text = statusArea.value;
+                 var text = statusArea.innerText;
                  text = text + "Name: "+data.source.id;
                  if (data.type === "event") {
                      text = text +" Event: "+data.status+" ";
                  }
-                 statusArea.value = text;
+                 statusArea.innerText = text;
               }
             </script>
 
@@ -51,7 +51,7 @@
 
             <p>
               <h3> Status:</h3>
-              <textarea id="statusArea" cols="40" rows="10" readonly="readonly" />
+              <div id="statusArea"/>
             </p>
 
       </h:body>

--- a/tck/faces22/ajax-inputs/src/main/webapp/issue2179-page2.xhtml
+++ b/tck/faces22/ajax-inputs/src/main/webapp/issue2179-page2.xhtml
@@ -30,12 +30,12 @@
              <script type="text/javascript">
               var statusUpdate = function statusUpdate(data) {
                  var statusArea = document.getElementById("statusArea");
-                 var text = statusArea.value;
+                 var text = statusArea.innerText;
                  text = text + "Name: "+data.source.id;
                  if (data.type === "error") {
                      text = text + " Error: "+data.status+" "+data.errorMessage;
                  }
-                 statusArea.value = text;
+                 statusArea.innerText = text;
               }
             </script>
 
@@ -53,7 +53,7 @@
 
             <p>
               <h3> Status:</h3>
-              <textarea id="statusArea" cols="40" rows="10" readonly="readonly" />
+              <div id="statusArea"/>
             </p>
 
       </h:body>

--- a/tck/faces22/ajax-inputs/src/test/java/ee/jakarta/tck/faces/test/servlet30/ajax_selenium/Issue1533IT.java
+++ b/tck/faces22/ajax-inputs/src/test/java/ee/jakarta/tck/faces/test/servlet30/ajax_selenium/Issue1533IT.java
@@ -44,10 +44,10 @@ class Issue1533IT extends BaseITNG {
         WebElement input = page.findElement(By.id("form:vip:0"));
         page.guardAjax(input::click);
         
-        assertTrue(page.getPageSource().indexOf("form:vip-true") != -1);
+        assertTrue(page.containsText("form:vip-true"));
         input =  page.findElement(By.id("form:vip:1"));
         page.guardAjax(input::click);
 
-        assertTrue(page.getPageSource().indexOf("form:vip-false") != -1);
+        assertTrue(page.containsText("form:vip-false"));
     }
 }

--- a/tck/faces22/ajax-inputs/src/test/java/ee/jakarta/tck/faces/test/servlet30/ajax_selenium/Issue1957IT.java
+++ b/tck/faces22/ajax-inputs/src/test/java/ee/jakarta/tck/faces/test/servlet30/ajax_selenium/Issue1957IT.java
@@ -40,8 +40,8 @@ class Issue1957IT extends BaseITNG {
         WebPage page = getPage("issue1957.xhtml");
         WebElement span = page.findElement(By.id("form:group"));
         page.guardAjax(span::click);
-        assertTrue(page.isInPage("form:group Event: begin"));
-        assertTrue(page.isInPage("form:group Event: complete"));
-        assertTrue(page.isInPage("form:group Event: success"));
+        assertTrue(page.containsText("form:group Event: begin"));
+        assertTrue(page.containsText("form:group Event: complete"));
+        assertTrue(page.containsText("form:group Event: success"));
     }
 }

--- a/tck/faces22/ajax-inputs/src/test/java/ee/jakarta/tck/faces/test/servlet30/ajax_selenium/Issue2179IT.java
+++ b/tck/faces22/ajax-inputs/src/test/java/ee/jakarta/tck/faces/test/servlet30/ajax_selenium/Issue2179IT.java
@@ -38,7 +38,7 @@ class Issue2179IT extends BaseITNG {
   @Test
   void encodeException() throws Exception {
         WebPage page = getPage("issue2179-page1.xhtml");
-        assertTrue(page.getPageTextReduced().contains("IO EXCEPTION!!!!!"));
+        assertTrue(page.containsText("IO EXCEPTION!!!!!"));
     }
 
   /**
@@ -48,14 +48,10 @@ class Issue2179IT extends BaseITNG {
    */
   @Test
   void decodeException() {
-        // the major change is to shift the textarea over
-        // apparently they used the text attribute which does not work
-        // on new browsers, innerText must be used
-        // or a div with innerHTML which always will work, also value does work
         WebPage page = getPage("issue2179-page2.xhtml");
         WebElement button = page.findElement(By.id("form:submit"));
         page.guardAjax(button::click);
 
-        assertTrue(page.getInputValues().contains("Name: form:submit Error: serverError"));
+        assertTrue(page.containsText("Name: form:submit Error: serverError"));
     }
 }

--- a/tck/faces22/ajax-inputs/src/test/java/ee/jakarta/tck/faces/test/servlet30/ajax_selenium/Issue2255IT.java
+++ b/tck/faces22/ajax-inputs/src/test/java/ee/jakarta/tck/faces/test/servlet30/ajax_selenium/Issue2255IT.java
@@ -38,19 +38,19 @@ class Issue2255IT extends BaseITNG {
   @Test
   void behaviorState() throws Exception {
         WebPage page = getPage("divInComposite.xhtml");
-        assertTrue(page.isInPage("false"));
+        assertTrue(page.containsText("false"));
         WebElement cbox =  page.findElement(By.id("cc:form:test"));
         page.guardAjax(cbox::click);
 
-        assertTrue(page.isInPage("true"));
+        assertTrue(page.containsText("true"));
         page.guardAjax(cbox::click);
 
-        assertTrue(page.isInPage("false"));
+        assertTrue(page.containsText("false"));
         page.guardAjax(cbox::click);
 
-        assertTrue(page.isInPage("true"));
+        assertTrue(page.containsText("true"));
         page.guardAjax(cbox::click);
 
-        assertTrue(page.isInPage("false"));
+        assertTrue(page.containsText("false"));
     }
 }

--- a/tck/faces22/ajax-inputs/src/test/java/ee/jakarta/tck/faces/test/servlet30/ajax_selenium/Issue2340IT.java
+++ b/tck/faces22/ajax-inputs/src/test/java/ee/jakarta/tck/faces/test/servlet30/ajax_selenium/Issue2340IT.java
@@ -43,21 +43,21 @@ class Issue2340IT extends BaseITNG {
         WebElement anchor = page.findElement(By.id("testLink"));
         page.guardAjax(anchor::click);
 
-        assertTrue(page.isInPage("LINK ACTION"));
+        assertTrue(page.containsText("LINK ACTION"));
         WebElement radio1 = page.findElement(By.id("testRadio:0"));
         WebElement radio2 = page.findElement(By.id("testRadio:1"));
         WebElement radio3 = page.findElement(By.id("testRadio:2"));
 
         page.guardAjax(radio1::click);
 
-        assertTrue(page.isInPage("RADIO:red"));
+        assertTrue(page.containsText("RADIO:red"));
 
         page.guardAjax(radio2::click);
 
-        assertTrue(page.isInPage("RADIO:blue"));
+        assertTrue(page.containsText("RADIO:blue"));
 
         page.guardAjax(radio3::click);
 
-        assertTrue(page.isInPage("RADIO:white"));
+        assertTrue(page.containsText("RADIO:white"));
     }
 }

--- a/tck/faces22/ajax-inputs/src/test/java/ee/jakarta/tck/faces/test/servlet30/ajax_selenium/Issue2381IT.java
+++ b/tck/faces22/ajax-inputs/src/test/java/ee/jakarta/tck/faces/test/servlet30/ajax_selenium/Issue2381IT.java
@@ -44,7 +44,7 @@ class Issue2381IT extends BaseITNG {
         WebElement button = page.findElement(By.id("form1:bodytag"));
         page.guardAjax(button::click);
         
-        assertTrue(page.isInPage("BODY CLASS:foo"));
+        assertTrue(page.containsText("BODY CLASS:foo"));
     }
 
 }

--- a/tck/faces22/ajax-inputs/src/test/java/ee/jakarta/tck/faces/test/servlet30/ajax_selenium/Issue2407IT.java
+++ b/tck/faces22/ajax-inputs/src/test/java/ee/jakarta/tck/faces/test/servlet30/ajax_selenium/Issue2407IT.java
@@ -16,7 +16,7 @@
 
 package ee.jakarta.tck.faces.test.servlet30.ajax_selenium;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import jakarta.faces.component.behavior.AjaxBehavior;
 import jakarta.faces.component.html.HtmlCommandButton;
@@ -40,9 +40,9 @@ class Issue2407IT extends BaseITNG {
     @Test
     void updateAttributeNamedValue() throws Exception {
         WebPage page = getPage("attributeNameIsValue.xhtml");
-        assertTrue(page.isCondition(webDriver1 -> page.findElement(By.id("form1:foo")).getDomProperty("value").equals("foo")));
-        WebElement button = page.findElement(By.id("form1:button"));
-        button.click();
-        assertTrue(page.isCondition(webDriver1 -> page.findElement(By.id("form1:foo")).getDomProperty("value").equals("bar")));
+        WebElement foo = page.findElement(By.id("form1:foo"));
+        assertEquals("foo", foo.getDomProperty("value"));
+        page.guardAjax(page.findElement(By.id("form1:button"))::click);
+        assertEquals("bar", foo.getDomProperty("value"));
     }
 }

--- a/tck/faces22/ajax-inputs/src/test/java/ee/jakarta/tck/faces/test/servlet30/ajax_selenium/Issue2408IT.java
+++ b/tck/faces22/ajax-inputs/src/test/java/ee/jakarta/tck/faces/test/servlet30/ajax_selenium/Issue2408IT.java
@@ -47,16 +47,16 @@ class Issue2408IT extends BaseITNG {
         WebPage page = getPage("selectManyCheckboxInComposite.xhtml");
 
         // This will ensure JavaScript finishes before evaluating the page.
-        assertTrue(page.getPageSource().contains("Status: Pending"));
+        assertTrue(page.containsText("Status: Pending"));
 
         page.guardAjax(getCheckBoxes(page).get(0)::click);
-        assertTrue(page.isInPage("Status: mcheck-1"));
+        assertTrue(page.containsText("Status: mcheck-1"));
 
         page.guardAjax(getCheckBoxes(page).get(1)::click);
-        assertTrue(page.isInPage("Status: mcheck-1 mcheck-2"));
+        assertTrue(page.containsText("Status: mcheck-1 mcheck-2"));
 
         page.guardAjax(getCheckBoxes(page).get(2)::click);
-        assertTrue(page.isInPage("Status: mcheck-1 mcheck-2 mcheck-3"));
+        assertTrue(page.containsText("Status: mcheck-1 mcheck-2 mcheck-3"));
     }
 
   /**
@@ -68,19 +68,19 @@ class Issue2408IT extends BaseITNG {
         WebPage page = getPage("selectManyCheckboxIdsInComposite.xhtml");
 
         // This will ensure JavaScript finishes before evaluating the page.
-        assertTrue(page.getPageSource().contains("Status: Pending"));
+        assertTrue(page.containsText("Status: Pending"));
 
         WebElement cbox1 = page.findElement(By.id("form:compId:cbox:0"));
         page.guardAjax(cbox1::click);
-        assertTrue(page.isInPage("Status: mcheck-1"));
+        assertTrue(page.containsText("Status: mcheck-1"));
 
         WebElement cbox2 = page.findElement(By.id("form:compId:cbox:1"));
         page.guardAjax(cbox2::click);
-        assertTrue(page.isInPage("Status: mcheck-1 mcheck-2"));
+        assertTrue(page.containsText("Status: mcheck-1 mcheck-2"));
 
         WebElement cbox3 = page.findElement(By.id("form:compId:cbox:2"));
         page.guardAjax(cbox3::click);
-        assertTrue(page.isInPage("Status: mcheck-1 mcheck-2 mcheck-3"));
+        assertTrue(page.containsText("Status: mcheck-1 mcheck-2 mcheck-3"));
     }
 
   /**
@@ -91,16 +91,16 @@ class Issue2408IT extends BaseITNG {
         WebPage page = getPage("selectManyCheckboxNoComposite.xhtml");
 
         // This will ensure JavaScript finishes before evaluating the page.
-        assertTrue(page.getPageSource().contains("Status: Pending"));
+        assertTrue(page.containsText("Status: Pending"));
 
         page.guardAjax(getCheckBoxes(page).get(0)::click);
-        assertTrue(page.isInPage("Status: mcheck-1"));
+        assertTrue(page.containsText("Status: mcheck-1"));
 
         page.guardAjax(getCheckBoxes(page).get(1)::click);
-        assertTrue(page.isInPage("Status: mcheck-1 mcheck-2"));
+        assertTrue(page.containsText("Status: mcheck-1 mcheck-2"));
 
         page.guardAjax(getCheckBoxes(page).get(2)::click);
-        assertTrue(page.isInPage("Status: mcheck-1 mcheck-2 mcheck-3"));
+        assertTrue(page.containsText("Status: mcheck-1 mcheck-2 mcheck-3"));
     }
 
   /**
@@ -112,16 +112,16 @@ class Issue2408IT extends BaseITNG {
         WebPage page = getPage("selectOneRadioInComposite.xhtml");
 
         // This will ensure JavaScript finishes before evaluating the page.
-        assertTrue(page.isInPage("Status: Pending"));
+        assertTrue(page.containsText("Status: Pending"));
 
         page.guardAjax(getRadios(page).get(0)::click);
-        assertTrue(page.isInPage("Status: radio-1"));
+        assertTrue(page.containsText("Status: radio-1"));
 
         page.guardAjax(getRadios(page).get(1)::click);
-        assertTrue(page.isInPage("Status: radio-2"));
+        assertTrue(page.containsText("Status: radio-2"));
 
         page.guardAjax(getRadios(page).get(2)::click);
-        assertTrue(page.isInPage("Status: radio-3"));
+        assertTrue(page.containsText("Status: radio-3"));
     }
 
   /**
@@ -133,19 +133,19 @@ class Issue2408IT extends BaseITNG {
         WebPage page = getPage("selectOneRadioIdsInComposite.xhtml");
 
         // This will ensure JavaScript finishes before evaluating the page.
-        assertTrue(page.isInPage("Status: Pending"));
+        assertTrue(page.containsText("Status: Pending"));
 
         WebElement radio1 = page.findElement(By.id("form:compId:radio:0"));
         page.guardAjax(radio1::click);
-        assertTrue(page.isInPage("Status: radio-1"));
+        assertTrue(page.containsText("Status: radio-1"));
 
         WebElement radio2 = page.findElement(By.id("form:compId:radio:1"));
         page.guardAjax(radio2::click);
-        assertTrue(page.isInPage("Status: radio-2"));
+        assertTrue(page.containsText("Status: radio-2"));
 
         WebElement radio3 = page.findElement(By.id("form:compId:radio:2"));
         page.guardAjax(radio3::click);
-        assertTrue(page.isInPage("Status: radio-3"));
+        assertTrue(page.containsText("Status: radio-3"));
     }
 
   /**
@@ -156,16 +156,16 @@ class Issue2408IT extends BaseITNG {
         WebPage page = getPage("selectOneRadioNoComposite.xhtml");
 
         // This will ensure JavaScript finishes before evaluating the page.
-        assertTrue(page.isInPage("Status: Pending"));
+        assertTrue(page.containsText("Status: Pending"));
 
         page.guardAjax(getRadios(page).get(0)::click);
-        assertTrue(page.isInPage("Status: radio-1"));
+        assertTrue(page.containsText("Status: radio-1"));
 
         page.guardAjax(getRadios(page).get(1)::click);
-        assertTrue(page.isInPage("Status: radio-2"));
+        assertTrue(page.containsText("Status: radio-2"));
 
         page.guardAjax(getRadios(page).get(2)::click);
-        assertTrue(page.isInPage("Status: radio-3"));
+        assertTrue(page.containsText("Status: radio-3"));
     }
 
     private List<WebElement> getCheckBoxes(WebPage page) {

--- a/tck/faces22/ajax-inputs/src/test/java/ee/jakarta/tck/faces/test/servlet30/ajax_selenium/Issue2421IT.java
+++ b/tck/faces22/ajax-inputs/src/test/java/ee/jakarta/tck/faces/test/servlet30/ajax_selenium/Issue2421IT.java
@@ -43,7 +43,7 @@ class Issue2421IT extends BaseITNG {
         WebPage page = getPage("attributeNameIsDisabled.xhtml");
         WebElement input = page.findElement(By.id("form1:foo"));
         assertTrue(input.isEnabled());
-        assertTrue(page.isInPage("foo"));
+        assertTrue(page.containsSource("foo"));
         WebElement button = page.findElement(By.id("form1:button"));
         page.guardAjax(button::click);
         input = page.findElement(By.id("form1:foo"));

--- a/tck/faces22/ajax-inputs/src/test/java/ee/jakarta/tck/faces/test/servlet30/ajax_selenium/Issue2574IT.java
+++ b/tck/faces22/ajax-inputs/src/test/java/ee/jakarta/tck/faces/test/servlet30/ajax_selenium/Issue2574IT.java
@@ -38,6 +38,6 @@ class Issue2574IT extends BaseITNG {
         WebPage page = getPage("issue2574.xhtml");
         WebElement button1 = page.findElement(By.id("form:refresh"));
         page.guardAjax(button1::click);
-        assertTrue(page.isInPage("This script must not be eval'ed on ajax response."));
+        assertTrue(page.containsText("This script must not be eval'ed on ajax response."));
     }
 }

--- a/tck/faces22/ajax-inputs/src/test/java/ee/jakarta/tck/faces/test/servlet30/ajax_selenium/Issue2666IT.java
+++ b/tck/faces22/ajax-inputs/src/test/java/ee/jakarta/tck/faces/test/servlet30/ajax_selenium/Issue2666IT.java
@@ -41,6 +41,6 @@ class Issue2666IT extends BaseITNG {
 
         // Assert the page does not display the request parameter name 'button' that 
         // is in the page without a 'name' attribute.
-        assertTrue(page.isInPage("Request parameter name 'button' does not exist"));
+        assertTrue(page.containsText("Request parameter name 'button' does not exist"));
     }
 }

--- a/tck/faces22/ajax-inputs/src/test/java/ee/jakarta/tck/faces/test/servlet30/ajax_selenium/Issue2674IT.java
+++ b/tck/faces22/ajax-inputs/src/test/java/ee/jakarta/tck/faces/test/servlet30/ajax_selenium/Issue2674IT.java
@@ -37,6 +37,6 @@ class Issue2674IT extends BaseITNG {
     void programmaticAjaxBehavior() throws Exception {
         WebPage page = getPage("issue2674.xhtml");
         WebElement input1 = page.findElement(By.id("form:input1"));
-        assertFalse(getBehaviorScript(page, input1) == null, "input1 must have behavior script");
+        assertFalse(page.getBehaviorScript(input1) == null, "input1 must have behavior script");
     }
 }

--- a/tck/faces22/ajax-inputs/src/test/java/ee/jakarta/tck/faces/test/servlet30/ajax_selenium/Issue2749IT.java
+++ b/tck/faces22/ajax-inputs/src/test/java/ee/jakarta/tck/faces/test/servlet30/ajax_selenium/Issue2749IT.java
@@ -38,7 +38,7 @@ class Issue2749IT extends BaseITNG {
         WebPage page = getPage("attributeNameIsOn.xhtml");
         WebElement button = page.findElement(By.id("form1:button"));
         page.guardAjax(button::click);
-        assertTrue(page.isInPage("ONCLICK CALLED"));
+        assertTrue(page.containsText("ONCLICK CALLED"));
     }
 
 }

--- a/tck/faces22/ajax-inputs/src/test/java/ee/jakarta/tck/faces/test/servlet30/ajax_selenium/Issue2750IT.java
+++ b/tck/faces22/ajax-inputs/src/test/java/ee/jakarta/tck/faces/test/servlet30/ajax_selenium/Issue2750IT.java
@@ -39,7 +39,7 @@ class Issue2750IT extends BaseITNG {
         WebPage page = getPage("attributeNameIsChecked.xhtml");
         WebElement cbox = page.findElement(By.id("form1:foo"));
       assertEquals(false, cbox.isSelected());
-        assertTrue(page.isInPage("foo"));
+        assertTrue(page.containsSource("foo"));
         WebElement button = page.findElement(By.id("form1:button"));
         page.guardAjax(button::click);
         cbox = page.findElement(By.id("form1:foo"));

--- a/tck/faces22/ajax-inputs/src/test/java/ee/jakarta/tck/faces/test/servlet30/ajax_selenium/Issue2751IT.java
+++ b/tck/faces22/ajax-inputs/src/test/java/ee/jakarta/tck/faces/test/servlet30/ajax_selenium/Issue2751IT.java
@@ -37,10 +37,10 @@ class Issue2751IT extends BaseITNG {
   void updateAttributeNamedClass() throws Exception {
         WebPage page = getPage("attributeNameIsClass.xhtml");
         WebElement input = page.findElement(By.id("form1:foo"));
-        assertTrue(page.isInPage("foo"));
+        assertTrue(page.containsSource("foo"));
         WebElement button = page.findElement(By.id("form1:button"));
         page.guardAjax(button::click);
         input = page.findElement(By.id("form1:foo"));
-        assertTrue(page.isInPage("myclass"));
+        assertTrue(page.containsSource("myclass"));
     }
 }

--- a/tck/faces22/ajax-inputs/src/test/java/ee/jakarta/tck/faces/test/servlet30/ajax_selenium/Issue2767IT.java
+++ b/tck/faces22/ajax-inputs/src/test/java/ee/jakarta/tck/faces/test/servlet30/ajax_selenium/Issue2767IT.java
@@ -38,18 +38,18 @@ class Issue2767IT extends BaseITNG {
         WebPage page = getPage("issue2767.xhtml");
         WebElement anchor = page.findElement(By.id("testLink"));
         page.guardAjax(anchor::click);
-        assertTrue(page.isInPage("LINK ACTION"));
+        assertTrue(page.containsText("LINK ACTION"));
         WebElement radio1 = page.findElement(By.id("testRadio:0"));
         WebElement radio2 = page.findElement(By.id("testRadio:1"));
         WebElement radio3 = page.findElement(By.id("testRadio:2"));
 
         page.guardAjax(radio1::click);
-        assertTrue(page.isInPage("RADIO:red"));
+        assertTrue(page.containsText("RADIO:red"));
 
         page.guardAjax(radio2::click);
-        assertTrue(page.isInPage("RADIO:blue"));
+        assertTrue(page.containsText("RADIO:blue"));
 
         page.guardAjax(radio3::click);
-        assertTrue(page.isInPage("RADIO:white"));
+        assertTrue(page.containsText("RADIO:white"));
     }
 }

--- a/tck/faces22/ajax-inputs/src/test/java/ee/jakarta/tck/faces/test/servlet30/ajax_selenium/Issue3171IT.java
+++ b/tck/faces22/ajax-inputs/src/test/java/ee/jakarta/tck/faces/test/servlet30/ajax_selenium/Issue3171IT.java
@@ -36,15 +36,15 @@ class Issue3171IT extends BaseITNG {
   @Test
   void exceptionDuringRenderOk() throws Exception {
         WebPage page = getPage("exceptionDuringRender.xhtml");
-        String pageText = page.getPageSource();
+        String pageText = page.getSource();
 
         assertTrue(pageText.contains("not an ajax request"));
 
         WebElement button = page.findElement(By.id("submit"));
         page.guardAjax(button::click);
 
-        assertTrue(page.isInPageText("not an ajax request"));
-        assertTrue(page.isInPageText("Error from submit"));
+        assertTrue(page.containsText("not an ajax request"));
+        assertTrue(page.containsText("Error from submit"));
         
     }
 }

--- a/tck/faces22/ajax-inputs/src/test/java/ee/jakarta/tck/faces/test/servlet30/ajax_selenium/Issue3351IT.java
+++ b/tck/faces22/ajax-inputs/src/test/java/ee/jakarta/tck/faces/test/servlet30/ajax_selenium/Issue3351IT.java
@@ -37,11 +37,11 @@ class Issue3351IT extends BaseITNG {
   @Test
   void buttonOnlySubmitsOne() throws Exception {
         WebPage page = getPage("buttonOnlySubmitsOne.xhtml");
-        assertTrue(page.isInPage("value1,value2,"));
+        assertTrue(page.containsText("value1,value2,"));
         
         WebElement button = page.findElement(By.id("form:button1"));
         page.guardAjax(button::click);
-        assertTrue(page.isInPage("value2,"));
-        assertFalse(page.isInPage("value1,value2,"));
+        assertTrue(page.containsText("value2,"));
+        assertFalse(page.containsText("value1,value2,"));
     }
 }

--- a/tck/faces22/ajax-lifecycle/src/test/java/ee/jakarta/tck/faces/test/servlet30/ajax_selenium/Issue1817IT.java
+++ b/tck/faces22/ajax-lifecycle/src/test/java/ee/jakarta/tck/faces/test/servlet30/ajax_selenium/Issue1817IT.java
@@ -47,7 +47,7 @@ class Issue1817IT extends BaseITNG {
             WebElement anchor = page.findElement(By.id(id[0]));
             page.guardAjax(anchor::click);
             String expectedText = "Triggered item: " + id[1];
-            assertTrue(page.isInPage(expectedText));
+            assertTrue(page.containsText(expectedText));
         }
     }
 }

--- a/tck/faces22/ajax-lifecycle/src/test/java/ee/jakarta/tck/faces/test/servlet30/ajax_selenium/Issue2041IT.java
+++ b/tck/faces22/ajax-lifecycle/src/test/java/ee/jakarta/tck/faces/test/servlet30/ajax_selenium/Issue2041IT.java
@@ -40,19 +40,19 @@ class Issue2041IT extends BaseITNG {
   void issue2041() throws Exception {
         WebPage page = getPage("issue2041.xhtml");
 
-        assertTrue(page.isInPage("PAGE 1 BEGIN"));
-        assertTrue(page.isInPage("PAGE 1 END"));
+        assertTrue(page.containsText("PAGE 1 BEGIN"));
+        assertTrue(page.containsText("PAGE 1 END"));
 
         WebElement anchor =  page.findElement(By.id("commandLink"));
         page.guardAjax(anchor::click);
 
-        assertTrue(page.isInPage("PAGE 2 BEGIN"));
-        assertTrue(page.isInPage("PAGE 2 END"));
+        assertTrue(page.containsText("PAGE 2 BEGIN"));
+        assertTrue(page.containsText("PAGE 2 END"));
 
         anchor =  page.findElement(By.id("commandLink"));
         page.guardAjax(anchor::click);
 
-        assertTrue(page.getPageSource().indexOf("PAGE 1 BEGIN") != -1);
-        assertTrue(page.getPageSource().indexOf("PAGE 1 END") != -1);
+        assertTrue(page.containsText("PAGE 1 BEGIN"));
+        assertTrue(page.containsText("PAGE 1 END"));
     }
 }

--- a/tck/faces22/ajax-lifecycle/src/test/java/ee/jakarta/tck/faces/test/servlet30/ajax_selenium/Issue2162IT.java
+++ b/tck/faces22/ajax-lifecycle/src/test/java/ee/jakarta/tck/faces/test/servlet30/ajax_selenium/Issue2162IT.java
@@ -43,14 +43,14 @@ class Issue2162IT extends BaseITNG {
   void issue2162() throws Exception {
         WebPage page = getPage("issue2162.xhtml");
 
-        assertTrue(page.getPageSource().indexOf("Init called\n") != -1);
+        assertTrue(page.containsSource("Init called\n"));
 
         WebElement button = page.findElement(By.id("form:submit"));
         page.guardAjax(button::click);
 
         // init called not present probably a mojarra codebase issue
         // showing up in Chrome - works in htmlunit!
-        assertTrue(page.getPageSource().indexOf("Init called\nInit called\n") != -1);
-        assertFalse(page.getPageSource().indexOf("Init called\nInit called\nInit called") != -1);
+        assertTrue(page.containsSource("Init called\nInit called\n"));
+        assertFalse(page.containsSource("Init called\nInit called\nInit called"));
     }
 }

--- a/tck/faces22/ajax-lifecycle/src/test/java/ee/jakarta/tck/faces/test/servlet30/ajax_selenium/Issue2443IT.java
+++ b/tck/faces22/ajax-lifecycle/src/test/java/ee/jakarta/tck/faces/test/servlet30/ajax_selenium/Issue2443IT.java
@@ -35,7 +35,7 @@ class Issue2443IT extends BaseITNG {
   void quotesInScript() throws Exception {
         String expectedText = '"' + "<div></div>" + '"' + ";";
         WebPage page = getPage("scriptQuote.xhtml");
-        assertTrue(page.isInPage(expectedText));
+        assertTrue(page.containsSource(expectedText));
     }
 }
 

--- a/tck/faces22/ajax-lifecycle/src/test/java/ee/jakarta/tck/faces/test/servlet30/ajax_selenium/Issue2456IT.java
+++ b/tck/faces22/ajax-lifecycle/src/test/java/ee/jakarta/tck/faces/test/servlet30/ajax_selenium/Issue2456IT.java
@@ -36,10 +36,10 @@ class Issue2456IT extends BaseITNG {
   @Test
   void script() throws Exception {
         WebPage page = getPage("script.xhtml");
-        assertTrue(page.isInPage("SCRIPT EXECUTED!"));
+        assertTrue(page.containsText("SCRIPT EXECUTED!"));
         WebElement button = page.findElement(By.id("form1:button1"));
         page.guardAjax(button::click);
-        assertTrue(page.isInPage("SCRIPT EXECUTED!"));
+        assertTrue(page.containsText("SCRIPT EXECUTED!"));
     }
 }
 

--- a/tck/faces22/ajax-lifecycle/src/test/java/ee/jakarta/tck/faces/test/servlet30/ajax_selenium/Issue2500IT.java
+++ b/tck/faces22/ajax-lifecycle/src/test/java/ee/jakarta/tck/faces/test/servlet30/ajax_selenium/Issue2500IT.java
@@ -41,6 +41,6 @@ class Issue2500IT extends BaseITNG {
         WebElement button2 = page.findElement(By.id("button1"));
         page.guardAjax(button2::click);
         page.guardAjax(button2::click);
-        assertTrue(page.isInPage("jakarta.faces.ViewState Has One Value"));
+        assertTrue(page.containsText("jakarta.faces.ViewState Has One Value"));
     }
 }

--- a/tck/faces22/ajax-lifecycle/src/test/java/ee/jakarta/tck/faces/test/servlet30/ajax_selenium/Issue2636IT.java
+++ b/tck/faces22/ajax-lifecycle/src/test/java/ee/jakarta/tck/faces/test/servlet30/ajax_selenium/Issue2636IT.java
@@ -41,20 +41,20 @@ class Issue2636IT extends BaseITNG {
 
         WebElement anchor1 = anchors.get(0);
         page.guardAjax(anchor1::click);
-        assertTrue(page.isInPage("linkAction1"));
+        assertTrue(page.containsText("linkAction1"));
 
         anchors = page.getAnchors();
 
         WebElement anchor2 = anchors.get(1);
         page.guardAjax(anchor2::click);
 
-        assertTrue(page.isInPage("linkAction2"));
+        assertTrue(page.containsText("linkAction2"));
 
         anchors = page.getAnchors();
 
         anchor1 = anchors.get(0);
         page.guardAjax(anchor1::click);
 
-        assertTrue(page.isInPage("linkAction1"));
+        assertTrue(page.containsText("linkAction1"));
     }
 }

--- a/tck/faces22/ajax-lifecycle/src/test/java/ee/jakarta/tck/faces/test/servlet30/ajax_selenium/Issue2697IT.java
+++ b/tck/faces22/ajax-lifecycle/src/test/java/ee/jakarta/tck/faces/test/servlet30/ajax_selenium/Issue2697IT.java
@@ -42,10 +42,10 @@ class Issue2697IT extends BaseITNG {
 
         button =  page.findElement(By.id("form:ajax"));
         page.guardAjax(button::click);
-        assertTrue(page.isInPage("VIEWSCOPEBEAN() CALLED"));
+        assertTrue(page.containsSource("VIEWSCOPEBEAN() CALLED"));
         button = page.findElement(By.id("form:reset"));
         // Assert that second Ajax request does not execute the bean constructor again.
         page.guardAjax(button::click);
-      assertFalse(page.isInPage("VIEWSCOPEBEAN() CALLED VIEWSCOPEBEAN() CALLED"));
+      assertFalse(page.containsSource("VIEWSCOPEBEAN() CALLED VIEWSCOPEBEAN() CALLED"));
     }
 }

--- a/tck/faces22/ajax-lifecycle/src/test/java/ee/jakarta/tck/faces/test/servlet30/ajax_selenium/Issue2752IT.java
+++ b/tck/faces22/ajax-lifecycle/src/test/java/ee/jakarta/tck/faces/test/servlet30/ajax_selenium/Issue2752IT.java
@@ -38,10 +38,10 @@ class Issue2752IT extends BaseITNG {
         WebPage page = getPage("insertElement.xhtml");
          WebElement beforeButton = page.findElement(By.id("beforeButton"));
          page.guardAjax(beforeButton::click);
-        assertTrue(page.isInPageText("This is before textalpha"));
+        assertTrue(page.containsText("This is before textalpha"));
         WebElement afterButton = page.findElement(By.id("afterButton"));
         page.guardAjax(afterButton::click);
-        assertTrue(page.isInPageText("This is before textalphaThis is after text"));
+        assertTrue(page.containsText("This is before textalphaThis is after text"));
     }
 
 }

--- a/tck/faces22/ajax-lifecycle/src/test/java/ee/jakarta/tck/faces/test/servlet30/ajax_selenium/Issue2906IT.java
+++ b/tck/faces22/ajax-lifecycle/src/test/java/ee/jakarta/tck/faces/test/servlet30/ajax_selenium/Issue2906IT.java
@@ -40,41 +40,41 @@ class Issue2906IT extends BaseITNG {
         WebPage page = getPage("issue2906.xhtml");
 
 
-        assertTrue(page.matchesPageTextReduced(".*(2\\s+){9}2.*"));
+        assertTrue(page.matchesText(".*(2\\s+){9}2.*"));
 
         List<WebElement> anchors = page.getAnchors();
         WebElement anchor = anchors.get(9);
         page.guardAjax(anchor::click);
         anchors = page.getAnchors();
-        assertTrue(page.matchesPageTextReduced(".*(3\\s+){8}3.*"));
+        assertTrue(page.matchesText(".*(3\\s+){8}3.*"));
       assertEquals(9, anchors.size());
 
         anchor = anchors.get(8);
         page.guardAjax(anchor::click);
 
         anchors = page.getAnchors();
-        assertTrue(page.matchesPageTextReduced(".*(4\\s+){7}4.*"));
+        assertTrue(page.matchesText(".*(4\\s+){7}4.*"));
       assertEquals(8, anchors.size());
 
         anchor = anchors.get(7);
         page.guardAjax(anchor::click);
 
         anchors = page.getAnchors();
-        assertTrue(page.matchesPageTextReduced(".*(5\\s+){6}5.*"));
+        assertTrue(page.matchesText(".*(5\\s+){6}5.*"));
       assertEquals(7, anchors.size());
 
         anchor = anchors.get(0);
         page.guardAjax(anchor::click);
 
         anchors = page.getAnchors();
-        assertTrue(page.matchesPageTextReduced(".*(6\\s+){5}6.*"));
+        assertTrue(page.matchesText(".*(6\\s+){5}6.*"));
       assertEquals(6, anchors.size());
 
         anchor = anchors.get(2);
         page.guardAjax(anchor::click);
 
         anchors = page.getAnchors();
-        assertTrue(page.matchesPageTextReduced(".*(7\\s+){4}7.*"));
+        assertTrue(page.matchesText(".*(7\\s+){4}7.*"));
       assertEquals(5, anchors.size());
     }
 }

--- a/tck/faces22/ajax-lifecycle/src/test/java/ee/jakarta/tck/faces/test/servlet30/ajax_selenium/Issue3097IT.java
+++ b/tck/faces22/ajax-lifecycle/src/test/java/ee/jakarta/tck/faces/test/servlet30/ajax_selenium/Issue3097IT.java
@@ -37,14 +37,14 @@ class Issue3097IT extends BaseITNG {
   void viewExpired1() throws Exception {
         WebPage page = getPage("viewExpired1.xhtml");
 
-        if (page.getPageSource().indexOf("State Saving Method: server") != -1) {
+        if (page.containsText("State Saving Method: server")) {
             WebElement expireButton = page.findElement(By.id("form:expireSessionSoon"));
             page.guardAjax(expireButton::click);
 
             WebElement submitButton = page.findElement(By.id("form:submit"));
             page.guardAjax(submitButton::click);
 
-            assertTrue(page.isInPageText("jakarta.faces.application.ViewExpiredException"));
+            assertTrue(page.containsText("jakarta.faces.application.ViewExpiredException"));
         }
     }
 }

--- a/tck/faces22/ajax-lifecycle/src/test/java/ee/jakarta/tck/faces/test/servlet30/ajax_selenium/Issue3106IT.java
+++ b/tck/faces22/ajax-lifecycle/src/test/java/ee/jakarta/tck/faces/test/servlet30/ajax_selenium/Issue3106IT.java
@@ -46,6 +46,6 @@ class Issue3106IT extends BaseITNG {
         //2 requests after that we have to move forward
         page = getPage("multiPart1b.xhtml");
 
-        assertTrue(page.isInPageText("Count is 2"));
+        assertTrue(page.containsText("Count is 2"));
     }
 }

--- a/tck/faces22/ajax-lifecycle/src/test/java/ee/jakarta/tck/faces/test/servlet30/ajax_selenium/Issue3344IT.java
+++ b/tck/faces22/ajax-lifecycle/src/test/java/ee/jakarta/tck/faces/test/servlet30/ajax_selenium/Issue3344IT.java
@@ -40,6 +40,6 @@ class Issue3344IT extends BaseITNG {
         WebElement button = page.findElement(By.id("button"));
         page.guardAjax(button::click);
         
-        assertTrue(page.isInPage("&lt;?xml version=\"1.0\" encoding=\"UTF-8\"?&gt;"));
+        assertTrue(page.containsSource("&lt;?xml version=\"1.0\" encoding=\"UTF-8\"?&gt;"));
     }
 }

--- a/tck/faces22/ajax-lifecycle/src/test/java/ee/jakarta/tck/faces/test/servlet30/ajax_selenium/Issue3473IT.java
+++ b/tck/faces22/ajax-lifecycle/src/test/java/ee/jakarta/tck/faces/test/servlet30/ajax_selenium/Issue3473IT.java
@@ -38,6 +38,6 @@ class Issue3473IT extends BaseITNG {
         WebPage page = getPage("ajaxScriptError.xhtml");
         WebElement button = page.findElement(By.id("form:commandButton"));
         page.guardAjax(button::click);
-        assertTrue(page.isInPage("Error from form:commandButton"));
+        assertTrue(page.containsText("Error from form:commandButton"));
     }
 }

--- a/tck/faces22/ajax-lifecycle/src/test/java/ee/jakarta/tck/faces/test/servlet30/ajax_selenium/Spec220IT.java
+++ b/tck/faces22/ajax-lifecycle/src/test/java/ee/jakarta/tck/faces/test/servlet30/ajax_selenium/Spec220IT.java
@@ -44,7 +44,7 @@ class Spec220IT extends BaseITNG {
         
         WebElement button = page.findElement(By.id("submitAjax"));
         page.guardAjax(button::click);
-        String pageText = page.getPageSource();
+        String pageText = page.getSource();
         assertTrue(pageText.contains("|ajaxFirstName|"));
 
         textField = new ExtendedTextInput(getWebDriver(), page.findElement(By.id("firstName")));
@@ -52,7 +52,7 @@ class Spec220IT extends BaseITNG {
         
         button = new ExtendedTextInput(getWebDriver(), page.findElement(By.id("submitNonAjax")));
         page.guardAjax(button::click);
-        pageText = page.getPageSource();
+        pageText = page.getSource();
         assertTrue(pageText.contains("|nonAjaxFirstName|"));
     }
 }

--- a/tck/faces22/cdiBeanValidator/src/test/java/ee/jakarta/tck/faces/test/javaee7/cdibeanvalidator/cdibeanvalidator/Issue3014IT.java
+++ b/tck/faces22/cdiBeanValidator/src/test/java/ee/jakarta/tck/faces/test/javaee7/cdibeanvalidator/cdibeanvalidator/Issue3014IT.java
@@ -41,6 +41,6 @@ public class Issue3014IT extends BaseITNG {
         WebElement button = page.findElement(By.id("button"));
         button.click();
 
-        assertFalse(page.getPageSource().contains("my message"));
+        assertFalse(page.containsText("my message"));
     }
 }

--- a/tck/faces22/cdiInitDestroyEvent/src/test/java/ee/jakarta/tck/faces/test/javaee7/cdiinitdestroyevent/cdiinitdestroyevent/Issue2997IT.java
+++ b/tck/faces22/cdiInitDestroyEvent/src/test/java/ee/jakarta/tck/faces/test/javaee7/cdiinitdestroyevent/cdiinitdestroyevent/Issue2997IT.java
@@ -45,14 +45,14 @@ public class Issue2997IT extends BaseITNG {
         WebElement button = page.findElement(By.id("flow-with-templates"));
         button.click();
 
-        String pageText = page.getPageSource();
+        String pageText = page.getSource();
         assertTrue(pageText.contains("Bottom From Template"));
         assertTrue(pageText.contains("issue2997Bean"));
 
         button = page.findElement(By.id("issue2997Home"));
         button.click();
 
-        pageText = page.getPageSource();
+        pageText = page.getSource();
         assertTrue(pageText.contains("Issue2997Home"));
         assertTrue(pageText.contains("flow-with-templates"));
         assertTrue(pageText.contains("issue2997Bean"));
@@ -62,13 +62,13 @@ public class Issue2997IT extends BaseITNG {
         button = page.findElement(By.id("flow-with-templates"));
         button.click();
 
-        pageText = page.getPageSource();
+        pageText = page.getSource();
         assertTrue(pageText.contains("Bottom From Template"));
 
         button = page.findElement(By.id("issue2997UserList"));
         button.click();
 
-        pageText = page.getPageSource();
+        pageText = page.getSource();
         assertTrue(pageText.contains("Issue2997UserList"));
         assertTrue(pageText.contains("flow-with-templates"));
         assertTrue(pageText.contains("issue2997Bean"));
@@ -78,13 +78,13 @@ public class Issue2997IT extends BaseITNG {
         button = page.findElement(By.id("flow-with-templates"));
         button.click();
 
-        pageText = page.getPageSource();
+        pageText = page.getSource();
         assertTrue(pageText.contains("Bottom From Template"));
 
         button = page.findElement(By.id("issue2997PageInFacesConfig"));
         button.click();
 
-        pageText = page.getPageSource();
+        pageText = page.getSource();
         assertTrue(pageText.contains("Issue2997PageInFacesConfig"));
         assertTrue(pageText.contains("flow-with-templates"));
         assertTrue(pageText.contains("issue2997Bean"));

--- a/tck/faces22/cdiMethodValidation/src/test/java/ee/jakarta/tck/faces/test/javaee7/cdimethodvalidation/cdimethodvalidation/MethodValidationIT.java
+++ b/tck/faces22/cdiMethodValidation/src/test/java/ee/jakarta/tck/faces/test/javaee7/cdimethodvalidation/cdimethodvalidation/MethodValidationIT.java
@@ -44,7 +44,7 @@ public class MethodValidationIT extends BaseITNG {
 
         WebElement button = page.findElement(By.id("button"));
         button.click();
-        String text = page.getPageSource();
+        String text = page.getSource();
 
         assertTrue(text.contains("FooConstraint"));
         assertTrue(text.contains("my message"));
@@ -63,7 +63,7 @@ public class MethodValidationIT extends BaseITNG {
 
         WebElement button = page.findElement(By.id("button"));
         button.click();
-        String text = page.getPageSource();
+        String text = page.getSource();
 
         assertFalse(text.contains("FooConstraint"));
         assertTrue(text.contains("my message"));
@@ -82,7 +82,7 @@ public class MethodValidationIT extends BaseITNG {
 
         WebElement button = page.findElement(By.id("button"));
         button.click();
-        String text = page.getPageSource();
+        String text = page.getSource();
 
         assertTrue(text.contains("FooConstraint"));
         assertTrue(text.contains("my message"));

--- a/tck/faces22/cdiMultiTenantSetsTccl/src/test/java/ee/jakarta/tck/faces/test/javaee7/cdimultitenantsetstccl/cdimultitenantsetstccl/Issue3341IT.java
+++ b/tck/faces22/cdiMultiTenantSetsTccl/src/test/java/ee/jakarta/tck/faces/test/javaee7/cdimultitenantsetstccl/cdimultitenantsetstccl/Issue3341IT.java
@@ -37,7 +37,7 @@ public class Issue3341IT extends BaseITNG {
   void tcclReplacementResilience() throws Exception {
         WebPage page = getPage("");
 
-        String pageText = page.getPageSource();
+        String pageText = page.getSource();
 
         // If the BeforeFilter is configured to
         if (pageText.matches("(?s).*SUCCESS.*")) {

--- a/tck/faces22/childCountTest/src/test/java/ee/jakarta/tck/faces/test/javaee7/childCountTest/ChildCountTestIT.java
+++ b/tck/faces22/childCountTest/src/test/java/ee/jakarta/tck/faces/test/javaee7/childCountTest/ChildCountTestIT.java
@@ -38,11 +38,11 @@ public class ChildCountTestIT extends BaseITNG {
     @Test
     void childCountTest() throws Exception {
         WebPage page = getPage("childCountTest");
-        if (!page.getPageSource().contains("Test PASSED")) {
-            logger.warning(page.getPageSource());
+        if (!page.containsText("Test PASSED")) {
+            logger.warning(page.getSource());
         }
 
-        assertTrue(page.getPageSource().contains("Test PASSED"));
+        assertTrue(page.containsText("Test PASSED"));
     }
 
 }

--- a/tck/faces22/expressionLanguageLambda/src/test/java/ee/jakarta/tck/faces/test/javaee7/el/BasicLambdaIT.java
+++ b/tck/faces22/expressionLanguageLambda/src/test/java/ee/jakarta/tck/faces/test/javaee7/el/BasicLambdaIT.java
@@ -64,8 +64,8 @@ public class BasicLambdaIT extends BaseITNG {
     @Test
     void bookTable() throws Exception {
         WebPage page = getPage("faces/bookTable.xhtml");
-        assertTrue(page.getPageSource().contains("At Swim Two Birds"));
-        assertTrue(page.getPageSource().contains("The Third Policeman"));
+        assertTrue(page.containsText("At Swim Two Birds"));
+        assertTrue(page.containsText("The Third Policeman"));
 
         WebElement out = page.findElement(By.id("output2"));
         assertEquals("The Picture of Dorian Gray", out.getText());

--- a/tck/faces22/faceletsTemplate/src/test/java/ee/jakarta/tck/faces/test/javaee7/facelets/VerifyTemplateUIIT.java
+++ b/tck/faces22/faceletsTemplate/src/test/java/ee/jakarta/tck/faces/test/javaee7/facelets/VerifyTemplateUIIT.java
@@ -32,7 +32,7 @@ public class VerifyTemplateUIIT extends BaseITNG {
     @Test
     void ul() throws Exception {
         WebPage page = getPage("");
-        String pageXml = page.getPageSource();
+        String pageXml = page.getSource();
 
         assertTrue(pageXml.matches("(?s).*<li>\\s*a\\s*</li>.*"));
         assertTrue(pageXml.matches("(?s).*<li>\\s*b\\s*</li>.*"));

--- a/tck/faces22/multiFieldValidation/src/test/java/ee/jakarta/tck/faces/test/javaee7/multiFieldValidation/Spec1IT.java
+++ b/tck/faces22/multiFieldValidation/src/test/java/ee/jakarta/tck/faces/test/javaee7/multiFieldValidation/Spec1IT.java
@@ -48,7 +48,7 @@ public class Spec1IT extends BaseITNG {
 
         button.click();
 
-        String pageText = page.getPageSource();
+        String pageText = page.getSource();
         assertFalse(pageText.contains("[foofoofoo]"));
         assertTrue(pageText.contains("[bar]"));
 
@@ -79,7 +79,7 @@ public class Spec1IT extends BaseITNG {
 
         button.click();
 
-        String pageText = page.getPageSource();
+        String pageText = page.getSource();
         assertTrue(pageText.contains("[foo]"));
         assertTrue(pageText.contains("[bar]"));
 
@@ -110,7 +110,7 @@ public class Spec1IT extends BaseITNG {
 
         button.click();
 
-        String pageText = page.getPageSource();
+        String pageText = page.getSource();
         assertFalse(pageText.contains("[foofoofoo]"));
         assertFalse(pageText.contains("[barbarbar]"));
 
@@ -142,7 +142,7 @@ public class Spec1IT extends BaseITNG {
 
         button.click();
 
-        String pageText = page.getPageSource();
+        String pageText = page.getSource();
         assertFalse(pageText.contains("[foofoofoo]"));
         assertFalse(pageText.contains("[barbarbar]"));
 

--- a/tck/faces22/protectedView/src/test/java/ee/jakarta/tck/faces/test/javaee7/protectedview/Bug22995287IT.java
+++ b/tck/faces22/protectedView/src/test/java/ee/jakarta/tck/faces/test/javaee7/protectedview/Bug22995287IT.java
@@ -38,7 +38,7 @@ public class Bug22995287IT extends BaseITNG {
         WebElement link = page.findElement(By.id("get_parameter_fparam"));
         link.click();
 
-        String pageXml = page.getPageSource();
+        String pageXml = page.getSource();
         assertTrue(pageXml.contains("foo bar"));
     }
 
@@ -53,7 +53,7 @@ public class Bug22995287IT extends BaseITNG {
 
         link.click();
 
-        String pageXml = page.getPageSource();
+        String pageXml = page.getSource();
         assertTrue(pageXml.contains("foo bar"));
     }
 
@@ -68,7 +68,7 @@ public class Bug22995287IT extends BaseITNG {
 
         link.click();
 
-        String pageXml = page.getPageSource();
+        String pageXml = page.getSource();
         assertTrue(pageXml.contains("Welcome to Page2"));
     }
 
@@ -82,7 +82,7 @@ public class Bug22995287IT extends BaseITNG {
         WebElement button = page.findElement(By.id("button_to_page2"));
         button.click();
 
-        String pageXml = page.getPageSource();
+        String pageXml = page.getSource();
         assertTrue(pageXml.contains("Welcome to Page2"));
     }
 
@@ -96,7 +96,7 @@ public class Bug22995287IT extends BaseITNG {
         WebElement link = page.findElement(By.id("page3_get_parameter_fparam"));
         link.click();
 
-        String pageXml = page.getPageSource();
+        String pageXml = page.getSource();
         assertTrue(pageXml.contains("foo bar"));
     }
 
@@ -111,7 +111,7 @@ public class Bug22995287IT extends BaseITNG {
 
         link.click();
 
-        String pageXml = page.getPageSource();
+        String pageXml = page.getSource();
         assertTrue(pageXml.contains("foo bar"));
     }
 
@@ -126,7 +126,7 @@ public class Bug22995287IT extends BaseITNG {
 
         link.click();
 
-        String pageXml = page.getPageSource();
+        String pageXml = page.getSource();
         assertTrue(pageXml.contains("Welcome to Page2"));
     }
 
@@ -140,7 +140,7 @@ public class Bug22995287IT extends BaseITNG {
         WebElement button = page.findElement(By.id("page3_button_to_page2"));
         button.click();
 
-        String pageXml = page.getPageSource();
+        String pageXml = page.getSource();
         assertTrue(pageXml.contains("Welcome to Page2"));
     }
 }

--- a/tck/faces22/viewActionCdiViewScoped/src/test/java/ee/jakarta/tck/faces/test/javaee7/viewActionCdiViewScoped/ViewActionCdiViewScopedIT.java
+++ b/tck/faces22/viewActionCdiViewScoped/src/test/java/ee/jakarta/tck/faces/test/javaee7/viewActionCdiViewScoped/ViewActionCdiViewScopedIT.java
@@ -38,7 +38,7 @@ public class ViewActionCdiViewScopedIT extends BaseITNG {
   void noQueryParam() throws Exception {
         WebPage page = getPage("");
 
-        assertTrue(page.getPageSource().indexOf("First Page") != -1);
+        assertTrue(page.containsText("First Page"));
     }
 
   /**
@@ -50,6 +50,6 @@ public class ViewActionCdiViewScopedIT extends BaseITNG {
   void withQueryParam() throws Exception {
         WebPage page = getPage("?page=2");
 
-        assertTrue(page.getPageSource().indexOf("Second Page") != -1);
+        assertTrue(page.containsText("Second Page"));
     }
 }

--- a/tck/faces22/viewExpired/src/test/java/ee/jakarta/tck/faces/test/javaee6web/el/Issue3194IT.java
+++ b/tck/faces22/viewExpired/src/test/java/ee/jakarta/tck/faces/test/javaee6web/el/Issue3194IT.java
@@ -63,10 +63,10 @@ public class Issue3194IT extends BaseITNG {
         getPage("faces/viewExpired.xhtml");
         getPage("faces/viewExpired.xhtml");
         WebPage page = getPage("faces/viewExpired.xhtml");
-        assertTrue(page.getPageSource().contains("1"));
+        assertTrue(page.containsText("1"));
         page = getPage("faces/viewExpired.xhtml");
-        assertTrue(page.getPageSource().contains("2"));
+        assertTrue(page.containsText("2"));
         page = getPage("faces/viewExpired.xhtml");
-        assertTrue(page.getPageSource().contains("3"));
+        assertTrue(page.containsText("3"));
     }
 }

--- a/tck/faces22/viewParamNullValueAjax/src/test/java/ee/jakarta/tck/faces/test/javaee6/viewParamNullValueAjax_selenium/Issue4550IT.java
+++ b/tck/faces22/viewParamNullValueAjax/src/test/java/ee/jakarta/tck/faces/test/javaee6/viewParamNullValueAjax_selenium/Issue4550IT.java
@@ -27,7 +27,6 @@ import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
 
 import ee.jakarta.tck.faces.test.util.selenium.BaseITNG;
-import ee.jakarta.tck.faces.test.util.selenium.ExtendedWebDriver;
 import ee.jakarta.tck.faces.test.util.selenium.WebPage;
 
 class Issue4550IT extends BaseITNG {
@@ -43,23 +42,22 @@ class Issue4550IT extends BaseITNG {
         WebPage page = getPage("faces/viewparam-nullvalue-ajax.xhtml");
 
         // Ajax submit click
-        ExtendedWebDriver webDriver = getWebDriver();
-        WebElement submit = webDriver.findElement(By.id("form:ajaxCommandButton"));
+        WebElement submit = page.findElement(By.id("form:ajaxCommandButton"));
         assertNotNull(submit);
         page.guardAjax(submit::click);
-        assertTrue(webDriver.getPageTextReduced().contains(TEST_STRING));
+        assertTrue(page.containsText(TEST_STRING));
 
         // Ajax submit click
-        submit =  webDriver.findElement(By.id("form:ajaxCommandButton"));
+        submit =  page.findElement(By.id("form:ajaxCommandButton"));
         assertNotNull(submit);
         page.guardAjax(submit::click);
-        assertTrue(webDriver.getPageTextReduced().contains(TEST_STRING));
+        assertTrue(page.containsText(TEST_STRING));
 
         // Non Ajax submit click
-        submit =  webDriver.findElement(By.id("form:commandButton"));
+        submit =  page.findElement(By.id("form:commandButton"));
         assertNotNull(submit);
         page.guardAjax(submit::click);
-        assertTrue(webDriver.getPageTextReduced().contains(TEST_STRING));
+        assertTrue(page.containsText(TEST_STRING));
     }
 
 }

--- a/tck/faces22/viewScope/src/test/java/ee/jakarta/tck/faces/test/javaee6web/viewscope/Issue2641IT.java
+++ b/tck/faces22/viewScope/src/test/java/ee/jakarta/tck/faces/test/javaee6web/viewscope/Issue2641IT.java
@@ -93,10 +93,10 @@ public class Issue2641IT extends BaseITNG {
   void invalidatedSession() throws Exception {
         WebPage page = getPage("faces/invalidatedSession.xhtml");
 
-        assertTrue(page.getPageSource().contains("This is from the @PostConstruct"));
+        assertTrue(page.containsText("This is from the @PostConstruct"));
         getPage("faces/invalidatedPerform.xhtml");
         page = getPage("faces/invalidatedVerify.xhtml");
-        assertTrue(page.getPageSource().contains("true"));
+        assertTrue(page.containsText("true"));
     }
 
   /**

--- a/tck/faces23/ajax/src/test/java/ee/jakarta/tck/faces/test/javaee8/ajax_selenium/Spec1412IT.java
+++ b/tck/faces23/ajax/src/test/java/ee/jakarta/tck/faces/test/javaee8/ajax_selenium/Spec1412IT.java
@@ -40,14 +40,14 @@ class Spec1412IT extends BaseITNG {
     void spec1412() throws Exception {
 
         WebPage page = getPage("spec1412.xhtml");
-        assertFalse(page.getPageSource().contains("Success!"));
+        assertFalse(page.containsText("Success!"));
 
         WebElement button = page.findElement(By.id("form:button"));
 
         assertEquals("foo", button.getDomProperty("value"));
 
         page.guardAjax(button::click);
-        assertTrue(page.isInPage("Success!"));
+        assertTrue(page.containsText("Success!"));
 
         button = page.findElement(By.id("form:button"));
         assertEquals("bar", button.getDomProperty("value"));

--- a/tck/faces23/ajax/src/test/java/ee/jakarta/tck/faces/test/javaee8/ajax_selenium/Spec1423IT.java
+++ b/tck/faces23/ajax/src/test/java/ee/jakarta/tck/faces/test/javaee8/ajax_selenium/Spec1423IT.java
@@ -86,7 +86,6 @@ class Spec1423IT extends BaseITNG {
 
         button = page.findElement(By.id("form1:addProgrammatically"));
         page.guardAjax(button::click);
-        // wait for condition implictly also handles the
 
         page.waitForCondition(wd -> page.findElement(By.id("stylesheetResult")).getText().trim().equals("rgb(0, 255, 0)") &&
                     page.findElement(By.id("scriptResult")).getText().trim().equals("addedProgrammatically"));

--- a/tck/faces23/cdi/src/test/java/ee/jakarta/tck/faces/test/javaee8/cdi/Issue3722IT.java
+++ b/tck/faces23/cdi/src/test/java/ee/jakarta/tck/faces/test/javaee8/cdi/Issue3722IT.java
@@ -36,6 +36,6 @@ public class Issue3722IT extends BaseITNG {
   @Test
   void injectApplicationMap2() throws Exception {
         WebPage page = getPage("faces/injectApplicationMap2.xhtml");
-        assertTrue(page.getPageSource().contains("true"));
+        assertTrue(page.containsText("true"));
     }
 }

--- a/tck/faces23/cdi/src/test/java/ee/jakarta/tck/faces/test/javaee8/cdi/Issue3729IT.java
+++ b/tck/faces23/cdi/src/test/java/ee/jakarta/tck/faces/test/javaee8/cdi/Issue3729IT.java
@@ -36,6 +36,6 @@ public class Issue3729IT extends BaseITNG {
   @Test
   void injectRequestCookieMap2() throws Exception {
         WebPage page = getPage("faces/injectRequestCookieMap2.xhtml");
-        assertTrue(page.getPageSource().contains("{}"));
+        assertTrue(page.containsText("{}"));
     }
 }

--- a/tck/faces23/cdi/src/test/java/ee/jakarta/tck/faces/test/javaee8/cdi/Issue3730IT.java
+++ b/tck/faces23/cdi/src/test/java/ee/jakarta/tck/faces/test/javaee8/cdi/Issue3730IT.java
@@ -36,6 +36,6 @@ public class Issue3730IT extends BaseITNG {
   @Test
   void injectSessionMap2() throws Exception {
         WebPage page = getPage("faces/injectSessionMap2.xhtml");
-        assertTrue(page.getPageSource().contains("key=value"));
+        assertTrue(page.containsText("key=value"));
     }
 }

--- a/tck/faces23/cdi/src/test/java/ee/jakarta/tck/faces/test/javaee8/cdi/Issue3731IT.java
+++ b/tck/faces23/cdi/src/test/java/ee/jakarta/tck/faces/test/javaee8/cdi/Issue3731IT.java
@@ -36,6 +36,6 @@ public class Issue3731IT extends BaseITNG {
   @Test
   void injectViewMap2() throws Exception {
         WebPage page = getPage("faces/injectViewMap2.xhtml");
-        assertTrue(page.getPageSource().contains("{}"));
+        assertTrue(page.containsText("{}"));
     }
 }

--- a/tck/faces23/cdi/src/test/java/ee/jakarta/tck/faces/test/javaee8/cdi/Issue3793IT.java
+++ b/tck/faces23/cdi/src/test/java/ee/jakarta/tck/faces/test/javaee8/cdi/Issue3793IT.java
@@ -35,6 +35,6 @@ public class Issue3793IT extends BaseITNG {
   void facesConfig23() throws Exception {
         WebPage page = getPage("faces/mojarraFacesConfigVersion.xhtml");
 
-      assertFalse(page.getPageSource().contains("2.3"));
+      assertFalse(page.containsText("2.3"));
     }
 }

--- a/tck/faces23/cdi/src/test/java/ee/jakarta/tck/faces/test/javaee8/cdi/Issue4551IT.java
+++ b/tck/faces23/cdi/src/test/java/ee/jakarta/tck/faces/test/javaee8/cdi/Issue4551IT.java
@@ -39,7 +39,7 @@ public class Issue4551IT extends BaseITNG {
         WebPage page = getPage("faces/issue4551.xhtml");
         WebElement submit = page.findElement(By.id("form:submit"));
         submit.click();
-        assertTrue(page.getPageSource().contains("CustomValidator1 was validated"));
-        assertTrue(page.getPageSource().contains("CustomValidator2 was validated"));
+        assertTrue(page.containsText("CustomValidator1 was validated"));
+        assertTrue(page.containsText("CustomValidator2 was validated"));
     }
 }

--- a/tck/faces23/cdi/src/test/java/ee/jakarta/tck/faces/test/javaee8/cdi/Spec1327IT.java
+++ b/tck/faces23/cdi/src/test/java/ee/jakarta/tck/faces/test/javaee8/cdi/Spec1327IT.java
@@ -36,6 +36,6 @@ public class Spec1327IT extends BaseITNG {
   @Test
   void injectSessionBean() throws Exception {
         WebPage page = getPage("faces/injectSession.xhtml");
-        assertTrue(page.getPageSource().contains("Session"));
+        assertTrue(page.containsText("Session"));
     }
 }

--- a/tck/faces23/cdi/src/test/java/ee/jakarta/tck/faces/test/javaee8/cdi/Spec1333IT.java
+++ b/tck/faces23/cdi/src/test/java/ee/jakarta/tck/faces/test/javaee8/cdi/Spec1333IT.java
@@ -36,6 +36,6 @@ public class Spec1333IT extends BaseITNG {
   @Test
   void injectView() throws Exception {
         WebPage page = getPage("faces/injectView.xhtml");
-        assertTrue(page.getPageSource().contains("UIViewRoot"));
+        assertTrue(page.containsText("UIViewRoot"));
     }
 }

--- a/tck/faces23/cdi/src/test/java/ee/jakarta/tck/faces/test/javaee8/cdi/Spec1349IT.java
+++ b/tck/faces23/cdi/src/test/java/ee/jakarta/tck/faces/test/javaee8/cdi/Spec1349IT.java
@@ -54,7 +54,7 @@ public class Spec1349IT extends BaseITNG {
         WebPage page = getPage("faces/injectConverter2.xhtml");
         WebElement submit = page.findElement(By.id("form:submit"));
         submit.click();
-        assertTrue(page.getPageSource().contains("InjectConverter2 was called"));
+        assertTrue(page.containsText("InjectConverter2 was called"));
     }
 
     /**
@@ -67,6 +67,6 @@ public class Spec1349IT extends BaseITNG {
         WebPage page = getPage("faces/injectConverter3.xhtml");
         WebElement submit = page.findElement(By.id("form:submit"));
         submit.click();
-        assertTrue(page.getPageSource().contains("InjectConverter3 was called"));
+        assertTrue(page.containsText("InjectConverter3 was called"));
     }
 }

--- a/tck/faces23/cdi/src/test/java/ee/jakarta/tck/faces/test/javaee8/cdi/Spec1350IT.java
+++ b/tck/faces23/cdi/src/test/java/ee/jakarta/tck/faces/test/javaee8/cdi/Spec1350IT.java
@@ -40,6 +40,6 @@ public class Spec1350IT extends BaseITNG {
         WebPage page = getPage("faces/injectValidator.xhtml");
         WebElement submit = page.findElement(By.id("form:submit"));
         submit.click();
-        assertTrue(page.getPageSource().contains("InjectValidator was called"));
+        assertTrue(page.containsText("InjectValidator was called"));
     }
 }

--- a/tck/faces23/cdi/src/test/java/ee/jakarta/tck/faces/test/javaee8/cdi/Spec1385IT.java
+++ b/tck/faces23/cdi/src/test/java/ee/jakarta/tck/faces/test/javaee8/cdi/Spec1385IT.java
@@ -48,12 +48,12 @@ public class Spec1385IT extends BaseITNG {
         // Next request processes cookie, should render value put in Flash and set "deletion" cookie
         WebPage page = getPage("faces/injectFlash.xhtml?getFlash=true");
 
-        assertTrue(page.getPageSource().contains("foo:bar"));
+        assertTrue(page.containsText("foo:bar"));
 
         // No cookie anymore and the value put in Flash previously should not be rendered anymore
         page = getPage("faces/injectFlash.xhtml?getFlash=true");
 
-        assertFalse(page.getPageSource().contains("foo:bar"));
+        assertFalse(page.containsText("foo:bar"));
     }
 
 }

--- a/tck/faces23/cdi/src/test/java/ee/jakarta/tck/faces/test/javaee8/cdi/Spec1387IT.java
+++ b/tck/faces23/cdi/src/test/java/ee/jakarta/tck/faces/test/javaee8/cdi/Spec1387IT.java
@@ -45,7 +45,7 @@ public class Spec1387IT extends BaseITNG {
         WebPage page = getPage("injectHeaderMap.xhtml");
 
         // Header value should be printed on the page
-        assertTrue(page.getPageSource().contains("foo:bar"));
+        assertTrue(page.containsText("foo:bar"));
     }
 
 }

--- a/tck/faces23/cdi/src/test/java/ee/jakarta/tck/faces/test/javaee8/cdi/Spec1388IT.java
+++ b/tck/faces23/cdi/src/test/java/ee/jakarta/tck/faces/test/javaee8/cdi/Spec1388IT.java
@@ -45,7 +45,7 @@ public class Spec1388IT extends BaseITNG {
         WebPage page = getPage("injectHeaderValuesMap.xhtml");
 
         // Header value should be printed on the page
-        assertTrue(page.getPageSource().contains("foo-0:bar"));
+        assertTrue(page.containsText("foo-0:bar"));
     }
 
 }

--- a/tck/faces23/cdi/src/test/java/ee/jakarta/tck/faces/test/javaee8/cdi/Spec1389IT.java
+++ b/tck/faces23/cdi/src/test/java/ee/jakarta/tck/faces/test/javaee8/cdi/Spec1389IT.java
@@ -42,7 +42,7 @@ public class Spec1389IT extends BaseITNG {
         WebPage page = getPage("injectInitParameterMap.xhtml");
 
         // Init parameter value should be printed on the page
-        assertTrue(page.getPageSource().contains("MY_TEST_PARAMETER:IS_THERE"));
+        assertTrue(page.containsText("MY_TEST_PARAMETER:IS_THERE"));
     }
 
 }

--- a/tck/faces23/cdi/src/test/java/ee/jakarta/tck/faces/test/javaee8/cdi/Spec1390IT.java
+++ b/tck/faces23/cdi/src/test/java/ee/jakarta/tck/faces/test/javaee8/cdi/Spec1390IT.java
@@ -42,7 +42,7 @@ public class Spec1390IT extends BaseITNG {
         WebPage page = getPage("injectRequestParameterMap.xhtml?foo=bar");
 
         // Request parameter value should be printed on the page
-        assertTrue(page.getPageSource().contains("foo:bar"));
+        assertTrue(page.containsText("foo:bar"));
     }
 
 }

--- a/tck/faces23/cdi/src/test/java/ee/jakarta/tck/faces/test/javaee8/cdi/Spec1391IT.java
+++ b/tck/faces23/cdi/src/test/java/ee/jakarta/tck/faces/test/javaee8/cdi/Spec1391IT.java
@@ -42,8 +42,8 @@ public class Spec1391IT extends BaseITNG {
         WebPage page = getPage("injectRequestParameterValuesMap.xhtml?foo=bar0&foo=bar1");
 
         // Both request parameter values should be printed on the page (order is not guaranteed)
-        assertTrue(page.getPageSource().contains("foo:bar0"));
-        assertTrue(page.getPageSource().contains("foo:bar1"));
+        assertTrue(page.containsText("foo:bar0"));
+        assertTrue(page.containsText("foo:bar1"));
     }
 
 }

--- a/tck/faces23/cdi/src/test/java/ee/jakarta/tck/faces/test/javaee8/cdi/Spec1393IT.java
+++ b/tck/faces23/cdi/src/test/java/ee/jakarta/tck/faces/test/javaee8/cdi/Spec1393IT.java
@@ -43,7 +43,7 @@ public class Spec1393IT extends BaseITNG {
         WebPage page = getPage("injectRequestMap.xhtml");
 
         // Request attribute is set in AttributeFilter
-        assertTrue(page.getPageSource().contains("fooAttribute:bar"));
+        assertTrue(page.containsText("fooAttribute:bar"));
     }
 
 }

--- a/tck/faces23/cdi/src/test/java/ee/jakarta/tck/faces/test/javaee8/cdi/Spec1394IT.java
+++ b/tck/faces23/cdi/src/test/java/ee/jakarta/tck/faces/test/javaee8/cdi/Spec1394IT.java
@@ -41,7 +41,7 @@ public class Spec1394IT extends BaseITNG {
   void resourceHandler() throws Exception {
         WebPage page = getPage("injectResourceHandler.xhtml");
 
-        assertTrue(page.getPageSource().contains("jsfLibraryExists:true"));
+        assertTrue(page.containsText("jsfLibraryExists:true"));
     }
 
 }

--- a/tck/faces23/cdi/src/test/java/ee/jakarta/tck/faces/test/javaee8/cdi/Spec1418IT.java
+++ b/tck/faces23/cdi/src/test/java/ee/jakarta/tck/faces/test/javaee8/cdi/Spec1418IT.java
@@ -41,9 +41,9 @@ public class Spec1418IT extends BaseITNG {
   void managedPropertyInteger() throws Exception {
         WebPage page = getPage("injectManagedProperty.xhtml");
 
-        assertTrue(page.getPageSource().contains("integer1:42"));
-        assertTrue(page.getPageSource().contains("integer2:99"));
-        assertTrue(page.getPageSource().contains("integer3:123"));
+        assertTrue(page.containsText("integer1:42"));
+        assertTrue(page.containsText("integer2:99"));
+        assertTrue(page.containsText("integer3:123"));
     }
 
   /**
@@ -55,7 +55,7 @@ public class Spec1418IT extends BaseITNG {
   void managedPropertyString() throws Exception {
         WebPage page = getPage("injectManagedProperty.xhtml?test=foo");
 
-        assertTrue(page.getPageSource().contains("testParam:foo"));
+        assertTrue(page.containsText("testParam:foo"));
     }
 
   /**
@@ -67,8 +67,8 @@ public class Spec1418IT extends BaseITNG {
   void managedPropertyGenericMap() throws Exception {
         WebPage page = getPage("injectManagedProperty.xhtml");
 
-        assertTrue(page.getPageSource().contains("stringMap:bar"));
-        assertTrue(page.getPageSource().contains("integerMap:10"));
+        assertTrue(page.containsText("stringMap:bar"));
+        assertTrue(page.containsText("integerMap:10"));
     }
 
 }

--- a/tck/faces23/cdi/src/test/java/ee/jakarta/tck/faces/test/javaee8/cdi_selenium/Spec1351IT.java
+++ b/tck/faces23/cdi/src/test/java/ee/jakarta/tck/faces/test/javaee8/cdi_selenium/Spec1351IT.java
@@ -16,6 +16,8 @@
 
 package ee.jakarta.tck.faces.test.javaee8.cdi_selenium;
 
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import jakarta.faces.component.behavior.FacesBehavior;
 import jakarta.inject.Inject;
 
@@ -35,6 +37,6 @@ class Spec1351IT extends BaseITNG {
   @Test
   void injectValidator() throws Exception {
         WebPage page = getPage("faces/injectBehavior.xhtml");
-        page.waitForCondition(webDriver -> page.isInPage("injectBehavior"));
+        assertTrue(page.containsSource("injectBehavior"));
     }
 }

--- a/tck/faces23/cdi/src/test/java/ee/jakarta/tck/faces/test/javaee8/cdi_selenium/Spec1386IT.java
+++ b/tck/faces23/cdi/src/test/java/ee/jakarta/tck/faces/test/javaee8/cdi_selenium/Spec1386IT.java
@@ -16,6 +16,8 @@
 
 package ee.jakarta.tck.faces.test.javaee8.cdi_selenium;
 
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import jakarta.faces.annotation.FlowMap;
 import jakarta.inject.Inject;
 
@@ -23,7 +25,6 @@ import org.junit.jupiter.api.Test;
 import org.openqa.selenium.By;
 
 import ee.jakarta.tck.faces.test.util.selenium.BaseITNG;
-import ee.jakarta.tck.faces.test.util.selenium.ExtendedWebDriver;
 import ee.jakarta.tck.faces.test.util.selenium.WebPage;
 
 /**
@@ -44,37 +45,36 @@ class Spec1386IT extends BaseITNG {
         WebPage page = getPage("injectFlowMap.xhtml");
 
         // Enter main flow
-        ExtendedWebDriver webDriver = getWebDriver();
-        page.guardAjax(webDriver.findElement(By.id("form:enter"))::click);
+        page.guardAjax(page.findElement(By.id("form:enter"))::click);
 
         // Put value in flow scope map
-        page.guardAjax(webDriver.findElement(By.id("form:init"))::click);
+        page.guardAjax(page.findElement(By.id("form:init"))::click);
 
         // Navigate to next page in flow
-        page.guardAjax(webDriver.findElement(By.id("form:next"))::click);
+        page.guardAjax(page.findElement(By.id("form:next"))::click);
 
 
         // Value should be available from flow map now
-        page.waitForCondition(webDriver1 -> page.isInPage("foo:bar"));
+        assertTrue(page.containsText("foo:bar"));
 
 
         // Enter nested flow
-        page.guardAjax(webDriver.findElement(By.id("form:nested"))::click);
+        page.guardAjax(page.findElement(By.id("form:nested"))::click);
 
         // Put (different) value in flow map using same key
-        page.guardAjax(webDriver.findElement(By.id("form:init"))::click);
+        page.guardAjax(page.findElement(By.id("form:init"))::click);
 
         // Navigate to next page in nested flow
-        page.guardAjax(webDriver.findElement(By.id("form:next"))::click);
+        page.guardAjax(page.findElement(By.id("form:next"))::click);
         // Different value should be available from flow map now
-        page.waitForCondition(webDriver1 -> page.isInPage("foo:barx"));
+        assertTrue(page.containsText("foo:barx"));
 
 
         // Exit nested flow
-        page.guardAjax(webDriver.findElement(By.id("form:exit"))::click);
+        page.guardAjax(page.findElement(By.id("form:exit"))::click);
 
         // Original value should be available from flow map again
-        page.waitForCondition(webDriver1 -> page.isInPage("foo:bar"));
+        assertTrue(page.containsText("foo:bar"));
 
     }
 

--- a/tck/faces23/commandScript/src/test/java/ee/jakarta/tck/faces/test/javaee8/commandScript_selenium/Spec613IT.java
+++ b/tck/faces23/commandScript/src/test/java/ee/jakarta/tck/faces/test/javaee8/commandScript_selenium/Spec613IT.java
@@ -19,15 +19,12 @@ package ee.jakarta.tck.faces.test.javaee8.commandScript_selenium;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import java.time.Duration;
-
 import jakarta.faces.component.html.HtmlCommandScript;
 
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.By;
 
 import ee.jakarta.tck.faces.test.util.selenium.BaseITNG;
-import ee.jakarta.tck.faces.test.util.selenium.ExtendedWebDriver;
 import ee.jakarta.tck.faces.test.util.selenium.WebPage;
 
 
@@ -44,12 +41,13 @@ public class Spec613IT extends BaseITNG {
 
     public void testCommandScript() throws Exception {
         WebPage page = getPage("spec613.xhtml");
-        page.wait(Duration.ofMillis(3000));
-        ExtendedWebDriver webDriver = getWebDriver();
-      assertEquals("foo", webDriver.findElement(By.id("result")).getText());
+        // h:commandScript foo has autorun="true" — its ajax fires on document
+        // ready, before we get control here, so guardAjax can't wrap it; poll.
+        // The render=":result" replaces the result element each cycle, so re-find
+        // it inside the predicate to dodge StaleElementReferenceException.
+        page.waitForCondition($ -> "foo".equals(page.findElement(By.id("result")).getText()));
 
-        webDriver.getJSExecutor().executeScript("bar()");
-        page.wait(Duration.ofMillis(3000));
-      assertEquals("bar", webDriver.findElement(By.id("result")).getText());
+        page.guardAjax(() -> page.executeScript("bar()"));
+        assertEquals("bar", page.findElement(By.id("result")).getText());
     }
 }

--- a/tck/faces23/disableFaceletToXhtmlMapping/src/test/java/ee/jakarta/tck/faces/test/javaee8/disablefacelettoxhtmlmapping/DisableFaceletToXhtmlIT.java
+++ b/tck/faces23/disableFaceletToXhtmlMapping/src/test/java/ee/jakarta/tck/faces/test/javaee8/disablefacelettoxhtmlmapping/DisableFaceletToXhtmlIT.java
@@ -29,7 +29,7 @@ class DisableFaceletToXhtmlIT extends BaseITNG {
   @Test
   void doTest() throws Exception {
         WebPage page = getPage("index.xhtml");
-      assertEquals(-1, page.getPageSource().indexOf("ViewState"));
+      assertEquals(-1, page.getSource().indexOf("ViewState"));
     }
 
 }

--- a/tck/faces23/el/src/test/java/ee/jakarta/tck/faces/test/servlet40/el/Spec1337IT.java
+++ b/tck/faces23/el/src/test/java/ee/jakarta/tck/faces/test/servlet40/el/Spec1337IT.java
@@ -35,7 +35,7 @@ public class Spec1337IT extends BaseITNG {
     @Test
     void resourceEL1() throws Exception {
         WebPage page = getPage("faces/resourceEL1.xhtml");
-        assertTrue(page.getPageSource().contains("/jakarta.faces.resource/resourceEL1.gif"));
+        assertTrue(page.containsText("/jakarta.faces.resource/resourceEL1.gif"));
     }
 
     /**
@@ -45,8 +45,8 @@ public class Spec1337IT extends BaseITNG {
     @Test
     void resourceEL2() throws Exception {
         WebPage page = getPage("faces/resourceEL2.xhtml");
-        assertTrue(page.getPageSource().contains("/jakarta.faces.resource/resourceEL2.gif"));
-        assertTrue(page.getPageSource().contains("?ln=resourceEL2"));
+        assertTrue(page.containsText("/jakarta.faces.resource/resourceEL2.gif"));
+        assertTrue(page.containsText("?ln=resourceEL2"));
     }
 
     /**
@@ -56,6 +56,6 @@ public class Spec1337IT extends BaseITNG {
     @Test
     void resourceEL3() throws Exception {
         WebPage page = getPage("faces/resourceEL3.xhtml");
-        assertTrue(page.getPageSource().contains("jakarta.el.ELException"));
+        assertTrue(page.containsText("jakarta.el.ELException"));
     }
 }

--- a/tck/faces23/exactMapping/src/test/java/ee/jakarta/tck/faces/test/servlet40/exactmapping_selenium/Spec1260IT.java
+++ b/tck/faces23/exactMapping/src/test/java/ee/jakarta/tck/faces/test/servlet40/exactmapping_selenium/Spec1260IT.java
@@ -42,10 +42,9 @@ class Spec1260IT extends BaseITNG {
   @Test
   void exactMappedViewLoads() throws Exception {
         WebPage page = getPage("foo");
-        String content = getWebDriver().getPageSource();
 
         // Basic test that if the FacesServlet is mapped to /foo, the right view "foo.xhtml" is loaded.
-        assertTrue(content.contains("This is page foo"));
+        assertTrue(page.containsText("This is page foo"));
     }
 
   /**
@@ -58,9 +57,8 @@ class Spec1260IT extends BaseITNG {
   void postBackToExactMappedView() throws Exception {
         WebPage page = getPage("foo");
 
-        getWebDriver().findElement(By.id("form:commandButton")).click();
-        page.waitForCondition(webDriver -> getWebDriver().getPageTextReduced().contains("foo method invoked"));
-
+        page.guardHttp(page.findElement(By.id("form:commandButton"))::click);
+        assertTrue(page.containsText("foo method invoked"));
 
         // If page /foo postbacks to itself, the new URL should be /foo again
         assertTrue(page.getCurrentUrl().split("\\?")[0].endsWith("/foo"));
@@ -76,11 +74,11 @@ class Spec1260IT extends BaseITNG {
   void linkToNonExactMappedView() throws Exception {
         WebPage page = getPage("foo");
 
-        page.waitForCondition(webDriver -> getWebDriver().getPageTextReduced().contains("This is page foo"));
+        assertTrue(page.containsText("This is page foo"));
 
-        getWebDriver().findElement(By.id("form:button")).click();
+        page.guardHttp(page.findElement(By.id("form:button"))::click);
 
-        page.waitForCondition(webDriver -> getWebDriver().getPageTextReduced().contains("This is page bar"));
+        assertTrue(page.containsText("This is page bar"));
 
         // view "bar" is not exact mapped, so should be loaded via the suffix
         // or prefix the FacesServlet is mapped to when coming from /foo
@@ -101,11 +99,11 @@ class Spec1260IT extends BaseITNG {
 
         // Navigate from /foo to /bar.jsf
         WebPage page = getPage("foo");
-        page.guardAjax(getWebDriver().findElement(By.id("form:button"))::click);
+        page.guardAjax(page.findElement(By.id("form:button"))::click);
 
         // After navigating to a non-exact mapped view, a postback should stil work
-        getWebDriver().findElement(By.id("form:commandButton")).click();
-        page.waitForCondition(webDriver -> getWebDriver().getPageTextReduced().contains("foo method invoked"));
+        page.guardHttp(page.findElement(By.id("form:commandButton"))::click);
+        assertTrue(page.containsText("foo method invoked"));
 
         // Check we're indeed on bar.jsf or faces/bar
         String path = page.getCurrentUrl().split("\\?")[0];
@@ -123,14 +121,10 @@ class Spec1260IT extends BaseITNG {
 
         WebPage page = getPage("foo");
 
-        page.waitForCondition(webDriver -> {
-            String content = getWebDriver().getPageSource();
-            return content.contains("jakarta.faces.resource/faces.js.jsf") || content.contains("jakarta.faces.resource/faces/faces.js");
-        });
-
         // Runtime must have found out the mappings of the FacesServlet and used one of the prefix or suffix
         // mappings to render the reference to "faces.js", which is not exactly mapped.
-        // otherwise a timeout exception would have been thrown and the test would have failed
+        assertTrue(page.containsSource("jakarta.faces.resource/faces.js.jsf")
+                || page.containsSource("jakarta.faces.resource/faces/faces.js"));
     }
 
   /**
@@ -143,12 +137,12 @@ class Spec1260IT extends BaseITNG {
   void ajaxFromExactMappedView() throws Exception {
         WebPage page = getPage("foo");
 
-        page.guardAjax(getWebDriver().findElement(By.id("form:commandButtonAjax"))::click);
+        page.guardAjax(page.findElement(By.id("form:commandButtonAjax"))::click);
         // AJAX from an exact-mapped view should work
-        page.waitForCondition(webDriver -> getWebDriver().getPageTextReduced().contains("partial request = true"));
+        assertTrue(page.containsText("partial request = true"));
 
       // Part of page not updated via AJAX so should not show
-      assertFalse(getWebDriver().getPageTextReduced().contains("should not see this"));
+      assertFalse(page.containsText("should not see this"));
     }
 
 

--- a/tck/faces23/faceletCacheFactory/src/test/java/ee/jakarta/tck/faces/test/servlet40/faceletCacheFactory/Issue3755IT.java
+++ b/tck/faces23/faceletCacheFactory/src/test/java/ee/jakarta/tck/faces/test/servlet40/faceletCacheFactory/Issue3755IT.java
@@ -43,7 +43,7 @@ public class Issue3755IT extends BaseITNG {
         WebElement submit = page.findElement(By.id("submit"));
         submit.click();
 
-        String pageText = page.getPageSource();
+        String pageText = page.getSource();
         assertTrue(pageText.contains("output: " + inputText));
         assertTrue(pageText.matches("(?s).*message.\\d+.*"));
     }

--- a/tck/faces23/facelets/src/test/java/ee/jakarta/tck/faces/test/servlet40/facelets/Spec1103IT.java
+++ b/tck/faces23/facelets/src/test/java/ee/jakarta/tck/faces/test/servlet40/facelets/Spec1103IT.java
@@ -39,7 +39,7 @@ public class Spec1103IT extends BaseITNG {
   @Test
   void dataTableIterable() throws Exception {
         WebPage page = getPage("faces/datatableIterable.xhtml");
-        assertTrue(Pattern.matches("(?s).*START.*0.*1.*2.*END.*", page.getPageSource()));
+        assertTrue(Pattern.matches("(?s).*START.*0.*1.*2.*END.*", page.getSource()));
     }
 
   /**
@@ -50,7 +50,7 @@ public class Spec1103IT extends BaseITNG {
   @Test
   void uIRepeatIterable() throws Exception {
         WebPage page = getPage("faces/uirepeatIterable.xhtml");
-        assertTrue(Pattern.matches("(?s).*START.*0.*1.*2.*END.*", page.getPageSource()));
+        assertTrue(Pattern.matches("(?s).*START.*0.*1.*2.*END.*", page.getSource()));
     }
 
   /**
@@ -61,6 +61,6 @@ public class Spec1103IT extends BaseITNG {
   @Test
   void uIRepeatCollection() throws Exception {
         WebPage page = getPage("faces/uirepeatCollection.xhtml");
-        assertTrue(Pattern.matches("(?s).*START.*1.*2.*3.*END.*", page.getPageSource()));
+        assertTrue(Pattern.matches("(?s).*START.*1.*2.*3.*END.*", page.getSource()));
     }
 }

--- a/tck/faces23/facelets/src/test/java/ee/jakarta/tck/faces/test/servlet40/facelets/Spec1364IT.java
+++ b/tck/faces23/facelets/src/test/java/ee/jakarta/tck/faces/test/servlet40/facelets/Spec1364IT.java
@@ -39,7 +39,7 @@ public class Spec1364IT extends BaseITNG {
   @Test
   void dataTableMap() throws Exception {
         WebPage page = getPage("faces/datatableMap.xhtml");
-        assertTrue(Pattern.matches("(?s).*START.*Amsterdam.*821702.*Rotterdam.*624799.*Den Haag.*514782.*END.*", page.getPageSource()));
+        assertTrue(Pattern.matches("(?s).*START.*Amsterdam.*821702.*Rotterdam.*624799.*Den Haag.*514782.*END.*", page.getSource()));
     }
 
   /**
@@ -50,7 +50,7 @@ public class Spec1364IT extends BaseITNG {
   @Test
   void uIRepeatMap() throws Exception {
         WebPage page = getPage("faces/uirepeatMap.xhtml");
-        assertTrue(Pattern.matches("(?s).*START.*Amsterdam-821702.*Rotterdam-624799.*Den Haag-514782.*END.*", page.getPageSource()));
+        assertTrue(Pattern.matches("(?s).*START.*Amsterdam-821702.*Rotterdam-624799.*Den Haag-514782.*END.*", page.getSource()));
     }
 
 }

--- a/tck/faces23/facelets/src/test/java/ee/jakarta/tck/faces/test/servlet40/facelets_selenium/Issue4830IT.java
+++ b/tck/faces23/facelets/src/test/java/ee/jakarta/tck/faces/test/servlet40/facelets_selenium/Issue4830IT.java
@@ -27,7 +27,6 @@ import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
 
 import ee.jakarta.tck.faces.test.util.selenium.BaseITNG;
-import ee.jakarta.tck.faces.test.util.selenium.ExtendedWebDriver;
 import ee.jakarta.tck.faces.test.util.selenium.WebPage;
 
 class Issue4830IT extends BaseITNG {
@@ -41,11 +40,9 @@ class Issue4830IT extends BaseITNG {
   @Test
   void uIRepeatResetValues() throws Exception {
         WebPage page = getPage("faces/issue4830.xhtml");
-        ExtendedWebDriver webDriver = getWebDriver();
-        WebElement button = webDriver.findElement(By.id("form:button"));
+        WebElement button = page.findElement(By.id("form:button"));
         page.guardAjax(button::click);
-        page.waitForCondition(webDriver1 -> webDriver.findElement(By.id("form:value")));
-        assertTrue(webDriver.findElement(By.id("form:value")).getText().isEmpty());
+        assertTrue(page.findElement(By.id("form:value")).getText().isEmpty());
     }
 
 }

--- a/tck/faces23/facelets/src/test/java/ee/jakarta/tck/faces/test/servlet40/facelets_selenium/Issue5078IT.java
+++ b/tck/faces23/facelets/src/test/java/ee/jakarta/tck/faces/test/servlet40/facelets_selenium/Issue5078IT.java
@@ -16,16 +16,16 @@
  */
 
 package ee.jakarta.tck.faces.test.servlet40.facelets_selenium;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import jakarta.faces.component.UIComponent;
 import jakarta.faces.component.UIViewRoot;
 
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.By;
-import org.openqa.selenium.StaleElementReferenceException;
 import org.openqa.selenium.WebElement;
 
 import ee.jakarta.tck.faces.test.util.selenium.BaseITNG;
-import ee.jakarta.tck.faces.test.util.selenium.ExtendedWebDriver;
 import ee.jakarta.tck.faces.test.util.selenium.WebPage;
 
 class Issue5078IT extends BaseITNG {
@@ -39,18 +39,9 @@ class Issue5078IT extends BaseITNG {
   @Test
   void uIRepeatVisitTreeDuringInvokeApplication() throws Exception {
         WebPage page = getPage("faces/issue5078.xhtml");
-        ExtendedWebDriver webDriver = getWebDriver();
-        WebElement button = webDriver.findElement(By.id("form:repeat:1:button"));
-        button.click();
-        page.waitForCondition(webDriver1 -> {
-            try {
-                WebElement element = webDriver.findElement(By.id("form:value"));
-                return element != null && element.getText().equals("2");
-            } catch (StaleElementReferenceException ex) {
-                //element has been replaced mid check
-                return false;
-            }
-        });
+        WebElement button = page.findElement(By.id("form:repeat:1:button"));
+        page.guardAjax(button::click);
+        assertEquals("2", page.findElement(By.id("form:value")).getText());
     }
 
 }

--- a/tck/faces23/facesDataModel/src/test/java/ee/jakarta/tck/faces/test/javaee8/facelets/DataTableCustomDataModelIT.java
+++ b/tck/faces23/facesDataModel/src/test/java/ee/jakarta/tck/faces/test/javaee8/facelets/DataTableCustomDataModelIT.java
@@ -47,7 +47,7 @@ class DataTableCustomDataModelIT extends BaseITNG {
         // handle a Child11, but these should NOT be picked up and the exact match
         // should be preferred.
         WebPage page = getPage("datatableCustomDataModel11.xhtml");
-        assertTrue(matches("(?s).*START.*11-member 1.*11-member 2.*END.*", page.getPageSource()));
+        assertTrue(matches("(?s).*START.*11-member 1.*11-member 2.*END.*", page.getSource()));
     }
 
   /**
@@ -66,6 +66,6 @@ class DataTableCustomDataModelIT extends BaseITNG {
         // should be chosen, which in this test is the DataModel that handles
         // a Child11.
         WebPage page = getPage("datatableCustomDataModel111.xhtml");
-        assertTrue(matches("(?s).*START.*111-member 1.*111-member 2.*END.*", page.getPageSource()));
+        assertTrue(matches("(?s).*START.*111-member 1.*111-member 2.*END.*", page.getSource()));
     }
 }

--- a/tck/faces23/facesDataModel/src/test/java/ee/jakarta/tck/faces/test/javaee8/facelets/UIRepeatCustomDataModelIT.java
+++ b/tck/faces23/facesDataModel/src/test/java/ee/jakarta/tck/faces/test/javaee8/facelets/UIRepeatCustomDataModelIT.java
@@ -46,7 +46,7 @@ class UIRepeatCustomDataModelIT extends BaseITNG {
         // handle a Child11, but these should NOT be picked up and the exact match
         // should be preferred.
         WebPage page = getPage("uirepeatCustomDataModel11.xhtml");
-        assertTrue(matches("(?s).*START.*11-member 1.*11-member 2.*END.*", page.getPageSource()));
+        assertTrue(matches("(?s).*START.*11-member 1.*11-member 2.*END.*", page.getSource()));
     }
 
   /**
@@ -65,6 +65,6 @@ class UIRepeatCustomDataModelIT extends BaseITNG {
         // should be chosen, which in this test is the DataModel that handles
         // a Child11.
         WebPage page = getPage("uirepeatCustomDataModel111.xhtml");
-        assertTrue(matches("(?s).*START.*111-member 1.*111-member 2.*END.*", page.getPageSource()));
+        assertTrue(matches("(?s).*START.*111-member 1.*111-member 2.*END.*", page.getSource()));
     }
 }

--- a/tck/faces23/getViews/src/test/java/ee/jakarta/tck/faces/test/servlet40/getviews/Spec1435IT.java
+++ b/tck/faces23/getViews/src/test/java/ee/jakarta/tck/faces/test/servlet40/getviews/Spec1435IT.java
@@ -41,7 +41,7 @@ public class Spec1435IT extends BaseITNG {
   @Test
   void getAllViews() throws Exception {
         WebPage page = getPage("getViews.jsf");
-        String content = page.getPageSource();
+        String content = page.getSource();
 
         assertTrue(content.contains("/getViews.xhtml"));
         assertTrue(content.contains("view: /foo.xhtml")); // include marker since is also subset of "/level2/foo.xhtml" etc
@@ -61,7 +61,7 @@ public class Spec1435IT extends BaseITNG {
   @Test
   void getViewsForPath() throws Exception {
         WebPage page = getPage("getViews.jsf?path=%2Flevel2%2F");
-        String content = page.getPageSource();
+        String content = page.getSource();
 
         assertFalse(content.contains("/getViews.xhtml"));
         assertFalse(content.contains("view: /foo.xhtml"));
@@ -82,7 +82,7 @@ public class Spec1435IT extends BaseITNG {
   @Test
   void getAllViewsAsImplicit() throws Exception {
         WebPage page = getPage("getViews.jsf?implicit=true");
-        String content = page.getPageSource();
+        String content = page.getSource();
 
         assertTrue(content.contains("/getViews"));
         assertTrue(content.contains("view: /foo"));
@@ -112,7 +112,7 @@ public class Spec1435IT extends BaseITNG {
   @Test
   void getAllViewsWithLimit2() throws Exception {
         WebPage page = getPage("getViews.jsf?maxDepth=2");
-        String content = page.getPageSource();
+        String content = page.getSource();
 
         assertTrue(content.contains("/getViews.xhtml"));
         assertTrue(content.contains("view: /foo.xhtml")); // include marker since is also subset of "/level2/foo.xhtml" etc
@@ -133,7 +133,7 @@ public class Spec1435IT extends BaseITNG {
   @Test
   void getViewsForPathImplicit() throws Exception {
         WebPage page = getPage("getViews.jsf?path=%2Flevel2%2F&implicit=true");
-        String content = page.getPageSource();
+        String content = page.getSource();
 
         assertFalse(content.contains("/getViews"));
         assertFalse(content.contains("view: /foo"));
@@ -162,7 +162,7 @@ public class Spec1435IT extends BaseITNG {
   @Test
   void getViewsForPathImplicitWithLimit2() throws Exception {
         WebPage page = getPage("getViews.jsf?path=%2Flevel2%2F&implicit=true&maxDepth=2");
-        String content = page.getPageSource();
+        String content = page.getSource();
 
         assertFalse(content.contains("/getViews"));
         assertFalse(content.contains("view: /foo"));
@@ -193,7 +193,7 @@ public class Spec1435IT extends BaseITNG {
   @Test
   void getViewsForPathImplicitWithLimit3() throws Exception {
         WebPage page = getPage("getViews.jsf?path=%2Flevel2%2F&implicit=true&maxDepth=3");
-        String content = page.getPageSource();
+        String content = page.getSource();
 
         assertFalse(content.contains("/getViews"));
         assertFalse(content.contains("view: /foo"));
@@ -224,7 +224,7 @@ public class Spec1435IT extends BaseITNG {
   @Test
   void getViewsForPathImplicitWithLimit0() throws Exception {
         WebPage page = getPage("getViews.jsf?path=%2Flevel2%2F&implicit=true&maxDepth=0");
-        String content = page.getPageSource();
+        String content = page.getSource();
 
         assertFalse(content.contains("/getViews"));
         assertFalse(content.contains("view: /foo"));
@@ -260,7 +260,7 @@ public class Spec1435IT extends BaseITNG {
   @Test
   void getAllViewsVDL() throws Exception {
         WebPage page = getPage("getViews.jsf?fromVDL=true");
-        String content = page.getPageSource();
+        String content = page.getSource();
 
         assertTrue(content.contains("/getViews.xhtml"));
         assertTrue(content.contains("view: /foo.xhtml")); // include marker since is also subset of "/level2/foo.xhtml" etc
@@ -280,7 +280,7 @@ public class Spec1435IT extends BaseITNG {
   @Test
   void getViewsForPathVDL() throws Exception {
         WebPage page = getPage("getViews.jsf?path=%2Flevel2%2F&fromVDL=true");
-        String content = page.getPageSource();
+        String content = page.getSource();
 
         assertFalse(content.contains("/getViews.xhtml"));
         assertFalse(content.contains("view: /foo.xhtml"));
@@ -301,7 +301,7 @@ public class Spec1435IT extends BaseITNG {
   @Test
   void getAllViewsAsImplicitVDL() throws Exception {
         WebPage page = getPage("getViews.jsf?implicit=true&fromVDL=true");
-        String content = page.getPageSource();
+        String content = page.getSource();
 
         assertTrue(content.contains("/getViews"));
         assertTrue(content.contains("view: /foo"));
@@ -331,7 +331,7 @@ public class Spec1435IT extends BaseITNG {
   @Test
   void getAllViewsWithLimit2VDL() throws Exception {
         WebPage page = getPage("getViews.jsf?maxDepth=2&fromVDL=true");
-        String content = page.getPageSource();
+        String content = page.getSource();
 
         assertTrue(content.contains("/getViews.xhtml"));
         assertTrue(content.contains("view: /foo.xhtml")); // include marker since is also subset of "/level2/foo.xhtml" etc
@@ -352,7 +352,7 @@ public class Spec1435IT extends BaseITNG {
   @Test
   void getViewsForPathImplicitVDL() throws Exception {
         WebPage page = getPage("getViews.jsf?path=%2Flevel2%2F&implicit=true&fromVDL=true");
-        String content = page.getPageSource();
+        String content = page.getSource();
 
         assertFalse(content.contains("/getViews"));
         assertFalse(content.contains("view: /foo"));
@@ -381,7 +381,7 @@ public class Spec1435IT extends BaseITNG {
   @Test
   void getViewsForPathImplicitWithLimit2VDL() throws Exception {
         WebPage page = getPage("getViews.jsf?path=%2Flevel2%2F&implicit=true&maxDepth=2&fromVDL=true");
-        String content = page.getPageSource();
+        String content = page.getSource();
 
         assertFalse(content.contains("/getViews"));
         assertFalse(content.contains("view: /foo"));
@@ -412,7 +412,7 @@ public class Spec1435IT extends BaseITNG {
   @Test
   void getViewsForPathImplicitWithLimit3VDL() throws Exception {
         WebPage page = getPage("getViews.jsf?path=%2Flevel2%2F&implicit=true&maxDepth=3&fromVDL=true");
-        String content = page.getPageSource();
+        String content = page.getSource();
 
         assertFalse(content.contains("/getViews"));
         assertFalse(content.contains("view: /foo"));
@@ -443,7 +443,7 @@ public class Spec1435IT extends BaseITNG {
   @Test
   void getViewsForPathImplicitWithLimit0VDL() throws Exception {
         WebPage page = getPage("getViews.jsf?path=%2Flevel2%2F&implicit=true&maxDepth=0&fromVDL=true");
-        String content = page.getPageSource();
+        String content = page.getSource();
 
         assertFalse(content.contains("/getViews"));
         assertFalse(content.contains("view: /foo"));
@@ -478,7 +478,7 @@ public class Spec1435IT extends BaseITNG {
   @Test
   void getAllViewResources() throws Exception {
         WebPage page = getPage("getViewResources.jsf");
-        String content = page.getPageSource();
+        String content = page.getSource();
 
         assertTrue(content.contains("/getViews.xhtml"));
         assertTrue(content.contains("resource name: /foo.xhtml")); // include marker since is also subset of "/level2/foo.xhtml" etc
@@ -498,7 +498,7 @@ public class Spec1435IT extends BaseITNG {
   @Test
   void getViewResourcesForPath() throws Exception {
         WebPage page = getPage("getViewResources.jsf?path=%2Flevel2%2F");
-        String content = page.getPageSource();
+        String content = page.getSource();
 
         assertFalse(content.contains("/getViews.xhtml"));
         assertFalse(content.contains("view: /foo.xhtml"));
@@ -519,7 +519,7 @@ public class Spec1435IT extends BaseITNG {
   @Test
   void getAllViewResourcesTopLevel() throws Exception {
         WebPage page = getPage("getViewResources.jsf?topLevel=true");
-        String content = page.getPageSource();
+        String content = page.getSource();
 
         assertTrue(content.contains("/getViews.xhtml"));
         assertTrue(content.contains("resource name: /foo.xhtml")); // include marker since is also subset of "/level2/foo.xhtml" etc
@@ -539,7 +539,7 @@ public class Spec1435IT extends BaseITNG {
   @Test
   void getAllViewResourcesWithLimit2() throws Exception {
         WebPage page = getPage("getViewResources.jsf?maxDepth=2");
-        String content = page.getPageSource();
+        String content = page.getSource();
 
         assertTrue(content.contains("/getViews.xhtml"));
         assertTrue(content.contains("resource name: /foo.xhtml")); // include marker since is also subset of "/level2/foo.xhtml" etc
@@ -561,7 +561,7 @@ public class Spec1435IT extends BaseITNG {
   @Test
   void getViewResourcesForPathWithLimit3() throws Exception {
         WebPage page = getPage("getViewResources.jsf?path=%2Flevel2%2F&maxDepth=3");
-        String content = page.getPageSource();
+        String content = page.getSource();
 
         assertFalse(content.contains("/getViews.xhtml"));
         assertFalse(content.contains("resource name: /foo.xhtml"));
@@ -584,7 +584,7 @@ public class Spec1435IT extends BaseITNG {
   @Test
   void getAllViewResourcesForPathWithLimit0() throws Exception {
         WebPage page = getPage("getViewResources.jsf?path=%2Flevel2%2F&maxDepth=0");
-        String content = page.getPageSource();
+        String content = page.getSource();
 
         assertFalse(content.contains("/getViews.xhtml"));
         assertFalse(content.contains("resource name: /foo.xhtml")); // include marker since is also subset of "/level2/foo.xhtml" etc

--- a/tck/faces23/localizedComposite/src/test/java/ee/jakarta/tck/faces/test/localizedComposite/Issue5160IT.java
+++ b/tck/faces23/localizedComposite/src/test/java/ee/jakarta/tck/faces/test/localizedComposite/Issue5160IT.java
@@ -38,6 +38,11 @@ public class Issue5160IT extends BaseITNG {
     @Override
     @AfterEach
     protected void tearDown() {
+        // Each test sets a different Accept-Language via addRequestHeader, which
+        // is additive on the underlying Chrome instance; reusing the driver would
+        // make subsequent tests send all previously-set languages stacked together
+        // and the wrong locale would win. Discard the driver so the next test
+        // starts with a clean header set.
         driverPool.quitInstance(getWebDriver());
     }
 

--- a/tck/faces23/namespacedView/src/test/java/ee/jakarta/tck/faces/test/javaee8/namespacedView_selenium/Spec790WithNamespacedViewIT.java
+++ b/tck/faces23/namespacedView/src/test/java/ee/jakarta/tck/faces/test/javaee8/namespacedView_selenium/Spec790WithNamespacedViewIT.java
@@ -66,8 +66,7 @@ class Spec790WithNamespacedViewIT extends BaseITNG {
         assertFalse(form3ViewState.getDomProperty("value").isEmpty());
 
         WebElement form2Link = page.findElement(By.id(namingContainerPrefix + "form2:link"));
-        form2Link.click();
-        page.waitForPageToLoad();
+        page.guardHttp(form2Link::click);
         namingContainerPrefix = getNamingContainerId(page);
         form1 = page.findElement(By.id(namingContainerPrefix + "form1"));
         form1ViewState = form1.findElement(By.name(namingContainerPrefix + "jakarta.faces.ViewState"));
@@ -80,8 +79,7 @@ class Spec790WithNamespacedViewIT extends BaseITNG {
         assertFalse(form3ViewState.getDomProperty("value").isEmpty());
 
         WebElement form3Link = page.findElement(By.id(namingContainerPrefix + "form3:link"));
-        form3Link.click();
-        page.waitForPageToLoad();
+        page.guardHttp(form3Link::click);
         namingContainerPrefix = getNamingContainerId(page);
         form1 = page.findElement(By.id(namingContainerPrefix + "form1"));
         form1ViewState = form1.findElement(By.name(namingContainerPrefix + "jakarta.faces.ViewState"));

--- a/tck/faces23/passthrough/src/test/java/ee/jakarta/tck/faces/test/javaee8/passthrough/Issue4093IT.java
+++ b/tck/faces23/passthrough/src/test/java/ee/jakarta/tck/faces/test/javaee8/passthrough/Issue4093IT.java
@@ -49,7 +49,7 @@ public class Issue4093IT extends BaseITNG {
 
         button.click();
 
-        String output = page.getPageSource();
+        String output = page.getSource();
 
         assertTrue(output.contains("requiredwithoutpassthrough:value: Validation Error: Value is required."));
     }
@@ -67,7 +67,7 @@ public class Issue4093IT extends BaseITNG {
 
         button.click();
 
-        String output = page.getPageSource();
+        String output = page.getSource();
 
         assertFalse(output.contains("Please fill out this field"));
     }
@@ -85,7 +85,7 @@ public class Issue4093IT extends BaseITNG {
 
         button.click();
 
-        String output = page.getPageSource();
+        String output = page.getSource();
 
         assertTrue(output.contains("validatewithoutpassthrough:value: Validation Error: Value is required."));
     }
@@ -105,7 +105,7 @@ public class Issue4093IT extends BaseITNG {
 
         button.click();
 
-        String output = page.getPageSource();
+        String output = page.getSource();
 
         assertFalse(output.contains("Please fill out this field"));
     }
@@ -125,7 +125,7 @@ public class Issue4093IT extends BaseITNG {
 
         button.click();
 
-        String output = page.getPageSource();
+        String output = page.getSource();
 
         assertFalse(output.contains("Please fill out this field"));
     }

--- a/tck/faces23/refreshPeriodExplicit/src/test/java/ee/jakarta/tck/faces/test/servlet40/refreshperiodexplicit/Issue3787IT.java
+++ b/tck/faces23/refreshPeriodExplicit/src/test/java/ee/jakarta/tck/faces/test/servlet40/refreshperiodexplicit/Issue3787IT.java
@@ -37,6 +37,6 @@ public class Issue3787IT extends BaseITNG {
     @Test
     public void testGetRefreshPeriod() throws Exception {
         WebPage page = getPage("index.xhtml");
-        assertTrue(page.getPageSource().contains("30000"));
+        assertTrue(page.containsText("30000"));
     }
 }

--- a/tck/faces23/refreshPeriodProduction/src/test/java/ee/jakarta/tck/faces/test/servlet40/refreshperiodproduction/Issue3787IT.java
+++ b/tck/faces23/refreshPeriodProduction/src/test/java/ee/jakarta/tck/faces/test/servlet40/refreshperiodproduction/Issue3787IT.java
@@ -37,6 +37,6 @@ public class Issue3787IT extends BaseITNG {
     @Test
     public void testGetRefreshPeriod() throws Exception {
         WebPage page = getPage("index.xhtml");
-        assertTrue(page.getPageSource().indexOf("-1") != -1);
+        assertTrue(page.containsText("-1"));
     }
 }

--- a/tck/faces23/searchExpression/src/test/java/ee/jakarta/tck/faces/test/javaee8/searchExpression_selenium/Issue4331IT.java
+++ b/tck/faces23/searchExpression/src/test/java/ee/jakarta/tck/faces/test/javaee8/searchExpression_selenium/Issue4331IT.java
@@ -45,9 +45,9 @@ public class Issue4331IT extends BaseITNG {
     public void testCustomSearchKeywordResolverAddedViaFacesConfig() throws Exception {
         WebPage page = getPage("issue4331.xhtml");
 
-        WebElement input = getWebDriver().findElement(By.id("issue4331ITInput1"));
+        WebElement input = page.findElement(By.id("issue4331ITInput1"));
 
-        String behaviorScript = getBehaviorScript(page, input);
+        String behaviorScript = page.getBehaviorScript(input);
 
         assertFalse(behaviorScript.contains("@custom"));
         assertTrue(behaviorScript.contains("issue4331ITInput1"));

--- a/tck/faces23/searchExpression/src/test/java/ee/jakarta/tck/faces/test/javaee8/searchExpression_selenium/Spec1238IT.java
+++ b/tck/faces23/searchExpression/src/test/java/ee/jakarta/tck/faces/test/javaee8/searchExpression_selenium/Spec1238IT.java
@@ -20,8 +20,6 @@ package ee.jakarta.tck.faces.test.javaee8.searchExpression_selenium;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.time.Duration;
-
 import jakarta.faces.component.search.SearchKeywordResolver;
 
 import org.junit.jupiter.api.Test;
@@ -29,7 +27,6 @@ import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
 
 import ee.jakarta.tck.faces.test.util.selenium.BaseITNG;
-import ee.jakarta.tck.faces.test.util.selenium.ExtendedWebDriver;
 import ee.jakarta.tck.faces.test.util.selenium.WebPage;
 
 public class Spec1238IT extends BaseITNG {
@@ -45,15 +42,13 @@ public class Spec1238IT extends BaseITNG {
 
     public void testSearchExpression() throws Exception {
         WebPage page = getPage("spec1238.xhtml");
-        page.wait(Duration.ofMillis(3000));
 
-        ExtendedWebDriver webDriver = getWebDriver();
-        WebElement label = webDriver.findElement(By.id("label"));
-        WebElement input = webDriver.findElement(By.id("spec1238ITinput1"));
+        WebElement label = page.findElement(By.id("label"));
+        WebElement input = page.findElement(By.id("spec1238ITinput1"));
 
         assertEquals(label.getDomAttribute("for"), input.getDomAttribute("id"));
 
-        String behaviorScript = getBehaviorScript(page, input);
+        String behaviorScript = page.getBehaviorScript(input);
 
         if (behaviorScript.contains("@this")) {
             assertTrue(behaviorScript.contains("@this spec1238ITinput2"));

--- a/tck/faces23/uiinput-required-true/src/test/java/ee/jakarta/tck/faces/test/javaee8/uiinput/Spec1433IT.java
+++ b/tck/faces23/uiinput-required-true/src/test/java/ee/jakarta/tck/faces/test/javaee8/uiinput/Spec1433IT.java
@@ -38,15 +38,14 @@ class Spec1433IT extends BaseITNG {
     void spec1433() throws Exception {
         WebPage page = getPage("spec1433.xhtml");
         WebElement input = page.findElement(By.id("form:input"));
-        getWebDriver().getJSExecutor()
-                .executeScript("var input = document.getElementById('form:input');input.setAttribute('id', '');input.setAttribute('name', '');");
+        page.executeScript("var input = document.getElementById('form:input');input.setAttribute('id', '');input.setAttribute('name', '');");
         input.sendKeys("non-empty value");
 
         WebElement button = page.findElement(By.id("form:submit"));
 
         button.click();
 
-        String output = page.getPageSource();
+        String output = page.getSource();
 
         assertTrue(output.contains("Spec1433Bean Validator Message"));
 

--- a/tck/faces23/uiinput/src/test/java/ee/jakarta/tck/faces/test/javaee8/uiinput_selenium/Issue5081IT.java
+++ b/tck/faces23/uiinput/src/test/java/ee/jakarta/tck/faces/test/javaee8/uiinput_selenium/Issue5081IT.java
@@ -17,6 +17,7 @@
 package ee.jakarta.tck.faces.test.javaee8.uiinput_selenium;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import jakarta.faces.component.UIInput;
 import jakarta.faces.component.UISelectMany;
@@ -27,7 +28,6 @@ import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
 
 import ee.jakarta.tck.faces.test.util.selenium.BaseITNG;
-import ee.jakarta.tck.faces.test.util.selenium.ExtendedWebDriver;
 import ee.jakarta.tck.faces.test.util.selenium.WebPage;
 
 class Issue5081IT extends BaseITNG {
@@ -42,29 +42,27 @@ class Issue5081IT extends BaseITNG {
   void issue4734() throws Exception {
         WebPage page = getPage("issue5081.xhtml");
 
-        ExtendedWebDriver webDriver = getWebDriver();
 
-        WebElement input1 = webDriver.findElement(By.id("form:input"));
+        WebElement input1 = page.findElement(By.id("form:input"));
         page.guardAjax(() -> {
             input1.sendKeys("text");
             // \t key equals to blur
             input1.sendKeys("\t");
         });
-        WebElement submit = webDriver.findElement(By.id("form:submit"));
-        submit.click();
-        page.waitForCondition(webDriver1 ->
-                page.getPageSource().contains("Validation Error"));
-        WebElement message = webDriver.findElement(By.id("form:message_for_selectmany"));
+        WebElement submit = page.findElement(By.id("form:submit"));
+        page.guardHttp(submit::click);
+        assertTrue(page.containsText("Validation Error"));
+        WebElement message = page.findElement(By.id("form:message_for_selectmany"));
         assertEquals("form:selectmany: Validation Error: Value is required.", message.getText(), "There is a required message");
 
-        WebElement input2 = webDriver.findElement(By.id("form:input"));
+        WebElement input2 = page.findElement(By.id("form:input"));
         page.guardAjax(() -> {
             input2.sendKeys("more");
             input2.sendKeys("\t"); // Before the fix, the second blur failed with java.lang.ClassCastException: class java.lang.String cannot be cast to class [Ljava.lang.Object;
         });
-        submit = webDriver.findElement(By.id("form:submit"));
+        submit = page.findElement(By.id("form:submit"));
         page.guardAjax(submit::click);
-        message = webDriver.findElement(By.id("form:message_for_selectmany"));
+        message = page.findElement(By.id("form:message_for_selectmany"));
         assertEquals("form:selectmany: Validation Error: Value is required.", message.getText(), "There is a still required message");
     }
 

--- a/tck/faces23/websocket/src/test/java/ee/jakarta/tck/faces/test/javaee8/websocket/Spec1396IT.java
+++ b/tck/faces23/websocket/src/test/java/ee/jakarta/tck/faces/test/javaee8/websocket/Spec1396IT.java
@@ -55,7 +55,7 @@ class Spec1396IT extends BaseITNG {
   void defaultWebsocket() throws Exception {
         WebPage page = getPage("spec1396DefaultWebsocket.xhtml");
 
-        String pageSource = page.getPageSource();
+        String pageSource = page.getSource();
         assertTrue(pageSource.contains("faces.push.init("));
         assertTrue(pageSource.contains("/jakarta.faces.push/push?"));
 
@@ -75,7 +75,7 @@ class Spec1396IT extends BaseITNG {
   void userScopedWebsocket() throws Exception {
         WebPage page = getPage("spec1396UserScopedWebsocket.xhtml");
 
-        String pageSource = page.getPageSource();
+        String pageSource = page.getSource();
         assertTrue(pageSource.contains("faces.push.init("));
         assertTrue(pageSource.contains("/jakarta.faces.push/user?"));
 
@@ -95,7 +95,7 @@ class Spec1396IT extends BaseITNG {
   void viewScopedWebsocket() throws Exception {
         WebPage page = getPage("spec1396ViewScopedWebsocket.xhtml");
 
-        String pageSource = page.getPageSource();
+        String pageSource = page.getSource();
         assertTrue(pageSource.contains("faces.push.init("));
         assertTrue(pageSource.contains("/jakarta.faces.push/view?"));
 
@@ -115,17 +115,16 @@ class Spec1396IT extends BaseITNG {
   void websocketAfterPostback() throws Exception {
         WebPage page = getPage("issue4332.xhtml");
 
-        String pageSource = page.getPageSource();
+        String pageSource = page.getSource();
         assertTrue(pageSource.contains("faces.push.init("));
         assertTrue(pageSource.contains("/jakarta.faces.push/push?"));
 
         waitUntilWebsocketIsOpened(getWebDriver(), page);
 
         WebElement postback = page.findElement(By.id("form:postback"));
-        postback.click();
-        page.waitForPageToLoad();
+        page.guardHttp(postback::click);
 
-        pageSource = page.getPageSource();
+        pageSource = page.getSource();
         assertTrue(pageSource.contains("faces.push.init("));
         assertTrue(pageSource.contains("/jakarta.faces.push/push?"));
 

--- a/tck/faces23/xhtmlMappingToFaceletByDefault/src/test/java/ee/jakarta/tck/faces/test/javaee8/xhtmlmappingtofaceletbydefault/XhtmlMappingToFaceletIT.java
+++ b/tck/faces23/xhtmlMappingToFaceletByDefault/src/test/java/ee/jakarta/tck/faces/test/javaee8/xhtmlmappingtofaceletbydefault/XhtmlMappingToFaceletIT.java
@@ -29,13 +29,13 @@ public class XhtmlMappingToFaceletIT extends BaseITNG {
   void verifyFacesMappingtoXhtmlByDefault() throws Exception {
         WebPage page = getPage("index.xhtml");
 
-        assertTrue(page.getPageSource().indexOf("ViewState") != -1);
+        assertTrue(page.containsSource("ViewState"));
     }
 
   @Test
   void verifyMinimalXhtmlWithoutXmlProlog() throws Exception {
         WebPage page = getPage("withoutxmlprolog.xhtml");
 
-        assertTrue(page.getPageSource().indexOf("This is a minimal") != -1);
+        assertTrue(page.containsSource("This is a minimal"));
     }
 }

--- a/tck/faces23/xhtmlNamespaces/src/test/java/ee/jakarta/tck/faces/test/javaee8/xhtmlNamespaces/Issue4281IT.java
+++ b/tck/faces23/xhtmlNamespaces/src/test/java/ee/jakarta/tck/faces/test/javaee8/xhtmlNamespaces/Issue4281IT.java
@@ -39,7 +39,7 @@ class Issue4281IT extends BaseITNG {
         assertTrue(outputText != null, "outputText does exist");
         assertTrue(panelGroup.getText().contains("paragraph"), "panelGroup does contain parargaph");
         assertFalse(panelGroup.getText().contains("outputText"), "panelGroup may not contain outputText");
-        assertTrue(page.getPageSource().contains("outputText"), "body does contain outputText");
+        assertTrue(page.containsText("outputText"), "body does contain outputText");
     }
 
 }

--- a/tck/faces40/api/src/test/java/ee/jakarta/tck/faces/test/faces40/javapagewithmetadata/Spec1581IT.java
+++ b/tck/faces40/api/src/test/java/ee/jakarta/tck/faces/test/faces40/javapagewithmetadata/Spec1581IT.java
@@ -39,7 +39,7 @@ public class Spec1581IT extends BaseITNG {
   void test() throws Exception {
         WebPage page = getPage("javapagewithmetadata.xhtml?id=foo");
 
-        assertTrue(page.getPageSource().contains("Id is:foo"));
+        assertTrue(page.containsText("Id is:foo"));
     }
 
 }

--- a/tck/faces40/api/src/test/java/ee/jakarta/tck/faces/test/javaee8/cdi/Spec1582ApplicationMap2IT.java
+++ b/tck/faces40/api/src/test/java/ee/jakarta/tck/faces/test/javaee8/cdi/Spec1582ApplicationMap2IT.java
@@ -36,6 +36,6 @@ public class Spec1582ApplicationMap2IT extends BaseITNG {
   @Test
   void injectApplicationMap2() throws Exception {
         WebPage page = getPage("injectApplicationMap2.xhtml");
-        assertTrue(page.getPageSource().contains("true"));
+        assertTrue(page.containsText("true"));
     }
 }

--- a/tck/faces40/api/src/test/java/ee/jakarta/tck/faces/test/javaee8/cdi/Spec1582HeaderMapIT.java
+++ b/tck/faces40/api/src/test/java/ee/jakarta/tck/faces/test/javaee8/cdi/Spec1582HeaderMapIT.java
@@ -45,7 +45,7 @@ public class Spec1582HeaderMapIT extends BaseITNG {
         WebPage page = getPage("injectHeaderMap.xhtml");
 
         // Header value should be printed on the page
-        assertTrue(page.getPageSource().contains("foo:bar"));
+        assertTrue(page.containsText("foo:bar"));
     }
 
 }

--- a/tck/faces40/api/src/test/java/ee/jakarta/tck/faces/test/javaee8/cdi/Spec1582HeaderValuesMapIT.java
+++ b/tck/faces40/api/src/test/java/ee/jakarta/tck/faces/test/javaee8/cdi/Spec1582HeaderValuesMapIT.java
@@ -45,7 +45,7 @@ public class Spec1582HeaderValuesMapIT extends BaseITNG {
         WebPage page = getPage("injectHeaderValuesMap.xhtml");
 
         // Header value should be printed on the page
-        assertTrue(page.getPageSource().contains("foo-0:bar"));
+        assertTrue(page.containsText("foo-0:bar"));
     }
 
 }

--- a/tck/faces40/api/src/test/java/ee/jakarta/tck/faces/test/javaee8/cdi/Spec1582InitParameterMapIT.java
+++ b/tck/faces40/api/src/test/java/ee/jakarta/tck/faces/test/javaee8/cdi/Spec1582InitParameterMapIT.java
@@ -42,7 +42,7 @@ public class Spec1582InitParameterMapIT extends BaseITNG {
         WebPage page = getPage("injectInitParameterMap.xhtml");
 
         // Init parameter value should be printed on the page
-        assertTrue(page.getPageSource().contains("MY_TEST_PARAMETER:IS_THERE"));
+        assertTrue(page.containsText("MY_TEST_PARAMETER:IS_THERE"));
     }
 
 }

--- a/tck/faces40/api/src/test/java/ee/jakarta/tck/faces/test/javaee8/cdi/Spec1582RequestCookieMap2IT.java
+++ b/tck/faces40/api/src/test/java/ee/jakarta/tck/faces/test/javaee8/cdi/Spec1582RequestCookieMap2IT.java
@@ -36,6 +36,6 @@ public class Spec1582RequestCookieMap2IT extends BaseITNG {
   @Test
   void injectRequestCookieMap2() throws Exception {
         WebPage page = getPage("injectRequestCookieMap2.xhtml");
-        assertTrue(page.getPageSource().contains("{}"));
+        assertTrue(page.containsText("{}"));
     }
 }

--- a/tck/faces40/api/src/test/java/ee/jakarta/tck/faces/test/javaee8/cdi/Spec1582RequestMapIT.java
+++ b/tck/faces40/api/src/test/java/ee/jakarta/tck/faces/test/javaee8/cdi/Spec1582RequestMapIT.java
@@ -43,7 +43,7 @@ public class Spec1582RequestMapIT extends BaseITNG {
         WebPage page = getPage("injectRequestMap.xhtml");
 
         // Request attribute is set in AttributeFilter
-        assertTrue(page.getPageSource().contains("fooAttribute:bar"));
+        assertTrue(page.containsText("fooAttribute:bar"));
     }
 
 }

--- a/tck/faces40/api/src/test/java/ee/jakarta/tck/faces/test/javaee8/cdi/Spec1582RequestParameterMapIT.java
+++ b/tck/faces40/api/src/test/java/ee/jakarta/tck/faces/test/javaee8/cdi/Spec1582RequestParameterMapIT.java
@@ -42,7 +42,7 @@ public class Spec1582RequestParameterMapIT extends BaseITNG {
         WebPage page = getPage("injectRequestParameterMap.xhtml?foo=bar");
 
         // Request parameter value should be printed on the page
-        assertTrue(page.getPageSource().contains("foo:bar"));
+        assertTrue(page.containsText("foo:bar"));
     }
 
 }

--- a/tck/faces40/api/src/test/java/ee/jakarta/tck/faces/test/javaee8/cdi/Spec1582RequestParametersValuesMapIT.java
+++ b/tck/faces40/api/src/test/java/ee/jakarta/tck/faces/test/javaee8/cdi/Spec1582RequestParametersValuesMapIT.java
@@ -42,8 +42,8 @@ public class Spec1582RequestParametersValuesMapIT extends BaseITNG {
         WebPage page = getPage("injectRequestParameterValuesMap.xhtml?foo=bar0&foo=bar1");
 
         // Both request parameter values should be printed on the page (order is not guaranteed)
-        assertTrue(page.getPageSource().contains("foo:bar0"));
-        assertTrue(page.getPageSource().contains("foo:bar1"));
+        assertTrue(page.containsText("foo:bar0"));
+        assertTrue(page.containsText("foo:bar1"));
     }
 
 }

--- a/tck/faces40/api/src/test/java/ee/jakarta/tck/faces/test/javaee8/cdi/Spec1582ViewMap2IT.java
+++ b/tck/faces40/api/src/test/java/ee/jakarta/tck/faces/test/javaee8/cdi/Spec1582ViewMap2IT.java
@@ -36,6 +36,6 @@ public class Spec1582ViewMap2IT extends BaseITNG {
   @Test
   void injectViewMap2() throws Exception {
         WebPage page = getPage("injectViewMap2.xhtml");
-        assertTrue(page.getPageSource().contains("{}"));
+        assertTrue(page.containsText("{}"));
     }
 }

--- a/tck/faces40/doctype/src/test/java/ee/jakarta/tck/faces/test/servlet50/doctype/Spec1568IT.java
+++ b/tck/faces40/doctype/src/test/java/ee/jakarta/tck/faces/test/servlet50/doctype/Spec1568IT.java
@@ -63,7 +63,7 @@ public class Spec1568IT extends BaseITNG {
     }
 
     private static String getDoctype(WebPage page) {
-        return (String) page.getWebDriver().getJSExecutor().executeScript("return new XMLSerializer().serializeToString(document.doctype);");
+        return (String) page.executeScript("return new XMLSerializer().serializeToString(document.doctype);");
     }
 
 }

--- a/tck/faces40/extensionless-mapping/src/test/java/org/javaee8/cdi/dynamic/bean/ExtensionlessMappingIT.java
+++ b/tck/faces40/extensionless-mapping/src/test/java/org/javaee8/cdi/dynamic/bean/ExtensionlessMappingIT.java
@@ -45,7 +45,7 @@ public class ExtensionlessMappingIT extends BaseITNG {
     @RunAsClient
     void extensionlessMappingFoo() throws IOException {
         WebPage page = getPage("foo");
-        String content = page.getPageSource();
+        String content = page.getSource();
         assertTrue(content.contains("This is page foo"));
         assertTrue(page.findElement(By.id("barxhtmllink")).getDomAttribute("href").endsWith("/bar"));
         assertTrue(page.findElement(By.id("barlink")).getDomAttribute("href").endsWith("/bar"));
@@ -60,7 +60,7 @@ public class ExtensionlessMappingIT extends BaseITNG {
     @RunAsClient
     void extensionlessMappingBar() throws IOException {
         WebPage page = getPage("bar");
-        String content = page.getPageSource();
+        String content = page.getSource();
         assertTrue(content.contains("This is page bar"));
     }
 
@@ -73,7 +73,7 @@ public class ExtensionlessMappingIT extends BaseITNG {
     @RunAsClient
     void extensionlessMappingSubBar() throws IOException {
         WebPage page = getPage("sub/bar");
-        String content = page.getPageSource();
+        String content = page.getSource();
         assertTrue(content.contains("This is page sub-bar"));
     }
 

--- a/tck/faces40/input/src/test/java/ee/jakarta/tck/faces/test/servlet50/inputfile_selenium/Spec1555IT.java
+++ b/tck/faces40/input/src/test/java/ee/jakarta/tck/faces/test/servlet50/inputfile_selenium/Spec1555IT.java
@@ -32,7 +32,6 @@ import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
 
 import ee.jakarta.tck.faces.test.util.selenium.BaseITNG;
-import ee.jakarta.tck.faces.test.util.selenium.ExtendedWebDriver;
 import ee.jakarta.tck.faces.test.util.selenium.WebPage;
 
 class Spec1555IT extends BaseITNG {
@@ -57,8 +56,7 @@ class Spec1555IT extends BaseITNG {
 
     private void testSingleSelection(String form) throws Exception {
         WebPage page = getPage("spec1555IT.xhtml");
-        ExtendedWebDriver webDriver = getWebDriver();
-        WebElement input = webDriver.findElement(By.id(form + ":input"));
+        WebElement input = page.findElement(By.id(form + ":input"));
 
         assertNull(input.getDomAttribute("multiple"), "Multiple attribute is NOT set");
 
@@ -66,10 +64,10 @@ class Spec1555IT extends BaseITNG {
         // Selenium allows to send the file name as key input
         input.sendKeys(file.getAbsolutePath());
 
-        page.guardAjax(webDriver.findElement(By.id(form + ":submit"))::click);
-        assertEquals("", webDriver.findElement(By.id(form + ":input")).getDomProperty("value"), "Value attribute is NOT set");
+        page.guardAjax(page.findElement(By.id(form + ":submit"))::click);
+        assertEquals("", page.findElement(By.id(form + ":input")).getDomProperty("value"), "Value attribute is NOT set");
 
-        WebElement messages = webDriver.findElement(By.id("messages"));
+        WebElement messages = page.findElement(By.id("messages"));
 
         List<WebElement> messagesElements = messages.findElements(By.cssSelector("*"));
         assertEquals(1, messagesElements.size(), "There is 1 message");
@@ -99,8 +97,7 @@ class Spec1555IT extends BaseITNG {
 
     private void testMultipleSelection(String form) throws Exception {
         WebPage page = getPage("spec1555IT.xhtml");
-        ExtendedWebDriver webDriver = getWebDriver();
-        WebElement input = webDriver.findElement(By.id(form + ":input"));
+        WebElement input = page.findElement(By.id(form + ":input"));
 
         assertEquals("true", input.getDomAttribute("multiple"), "Multiple attribute is set");
 
@@ -112,11 +109,11 @@ class Spec1555IT extends BaseITNG {
 
         String files = String.join("\n", fileNames);
         input.sendKeys(files);
-        page.guardAjax(webDriver.findElement(By.id(form + ":submit"))::click);
+        page.guardAjax(page.findElement(By.id(form + ":submit"))::click);
 
-        assertEquals("", webDriver.findElement(By.id(form + ":input")).getDomProperty("value"), "Value attribute is NOT set");
+        assertEquals("", page.findElement(By.id(form + ":input")).getDomProperty("value"), "Value attribute is NOT set");
 
-        WebElement messages = webDriver.findElement(By.id("messages"));
+        WebElement messages = page.findElement(By.id("messages"));
         List childElements = messages.findElements(By.cssSelector("*"));
 
         assertEquals(3, childElements.size(), "There are 3 messages");

--- a/tck/faces50/csp/src/test/java/ee/jakarta/tck/faces/test/faces50/csp/Spec1590IT.java
+++ b/tck/faces50/csp/src/test/java/ee/jakarta/tck/faces/test/faces50/csp/Spec1590IT.java
@@ -75,7 +75,7 @@ class Spec1590IT extends BaseITNG {
         var page = getPage("spec1590.xhtml");
         var nonce = getNonce(page);
         assertNotNull(nonce);
-        assertEquals(nonce, getBehaviorScriptElement(page, commandLink).getAttribute("nonce"));
+        assertEquals(nonce, page.getBehaviorScriptElement(commandLink).getAttribute("nonce"));
         assertEquals("false", commandLinkExecuted.getText());
         page.guardHttp(commandLink::click);
         assertEquals("true", commandLinkExecuted.getText());
@@ -92,8 +92,8 @@ class Spec1590IT extends BaseITNG {
         var page = getPage("spec1590.xhtml");
         var nonce = getNonce(page);
         assertNotNull(nonce);
-        assertEquals(nonce, getBehaviorScriptElement(page, ajaxInput).getAttribute("nonce"));
-        assertEquals(nonce, getBehaviorScriptElement(page, ajaxButton).getAttribute("nonce"));
+        assertEquals(nonce, page.getBehaviorScriptElement(ajaxInput).getAttribute("nonce"));
+        assertEquals(nonce, page.getBehaviorScriptElement(ajaxButton).getAttribute("nonce"));
         assertEquals("", ajaxOutput.getText());
         ajaxInput.sendKeys("first");
         page.guardAjax(ajaxButton::click);
@@ -113,7 +113,7 @@ class Spec1590IT extends BaseITNG {
         var page = getPage("spec1590.xhtml");
         var nonce = getNonce(page);
         assertNotNull(nonce);
-        assertEquals(nonce, getBehaviorScriptElement(page, commandScript).getAttribute("nonce"));
+        assertEquals(nonce, page.getBehaviorScriptElement(commandScript).getAttribute("nonce"));
         assertEquals("false", commandScriptExecuted.getText());
         page.guardAjax(() -> page.getJSExecutor().executeScript("commandScript()"));
         assertEquals("true", commandScriptExecuted.getText());
@@ -128,7 +128,7 @@ class Spec1590IT extends BaseITNG {
         var page = getPage("spec1590.xhtml");
         var nonce = getNonce(page);
         assertNotNull(nonce);
-        assertEquals(nonce, getBehaviorScriptElement(page, facesUtilChain).getAttribute("nonce"));
+        assertEquals(nonce, page.getBehaviorScriptElement(facesUtilChain).getAttribute("nonce"));
         assertEquals("false", facesUtilChainExecuted.getText());
         page.guardAjax(facesUtilChain::click);
         assertEquals("true", facesUtilChainExecuted.getText());
@@ -143,17 +143,17 @@ class Spec1590IT extends BaseITNG {
         var page = getPage("spec1590.xhtml");
         var nonce = getNonce(page);
         assertNotNull(nonce);
-        assertEquals(nonce, getBehaviorScriptElement(page, refreshButton).getAttribute("nonce"));
+        assertEquals(nonce, page.getBehaviorScriptElement(refreshButton).getAttribute("nonce"));
         page.guardHttp(refreshButton::click);
-        assertNotEquals(nonce, getBehaviorScriptElement(page, refreshButton).getAttribute("nonce"));
+        assertNotEquals(nonce, page.getBehaviorScriptElement(refreshButton).getAttribute("nonce"));
 
         var nonceAfterRefresh = getNonce(page);
-        assertEquals(nonceAfterRefresh, getBehaviorScriptElement(page, commandLink).getAttribute("nonce"));
-        assertEquals(nonceAfterRefresh, getBehaviorScriptElement(page, ajaxInput).getAttribute("nonce"));
-        assertEquals(nonceAfterRefresh, getBehaviorScriptElement(page, ajaxButton).getAttribute("nonce"));
-        assertEquals(nonceAfterRefresh, getBehaviorScriptElement(page, commandScript).getAttribute("nonce"));
-        assertEquals(nonceAfterRefresh, getBehaviorScriptElement(page, facesUtilChain).getAttribute("nonce"));
-        assertEquals(nonceAfterRefresh, getBehaviorScriptElement(page, refreshButton).getAttribute("nonce"));
+        assertEquals(nonceAfterRefresh, page.getBehaviorScriptElement(commandLink).getAttribute("nonce"));
+        assertEquals(nonceAfterRefresh, page.getBehaviorScriptElement(ajaxInput).getAttribute("nonce"));
+        assertEquals(nonceAfterRefresh, page.getBehaviorScriptElement(ajaxButton).getAttribute("nonce"));
+        assertEquals(nonceAfterRefresh, page.getBehaviorScriptElement(commandScript).getAttribute("nonce"));
+        assertEquals(nonceAfterRefresh, page.getBehaviorScriptElement(facesUtilChain).getAttribute("nonce"));
+        assertEquals(nonceAfterRefresh, page.getBehaviorScriptElement(refreshButton).getAttribute("nonce"));
     }
 
     /**

--- a/tck/faces50/uiinput/src/test/java/ee/jakarta/tck/faces/test/faces50/uiinput/Spec1507IT.java
+++ b/tck/faces50/uiinput/src/test/java/ee/jakarta/tck/faces/test/faces50/uiinput/Spec1507IT.java
@@ -19,8 +19,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.time.Duration;
-
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.Keys;
 import org.openqa.selenium.WebElement;
@@ -93,9 +91,10 @@ class Spec1507IT extends BaseITNG {
 
         assertEquals("", output1.getText());
 
+        // Pure JS oninput handler updates output1 directly in the browser —
+        // no XHR fires, so guardAjax doesn't apply. Wait for the DOM mutation.
         input1.sendKeys("abc" + Keys.TAB);
-
-        page.waitForCondition($ -> "abc".equals(output1.getText()), Duration.ofSeconds(3));
+        page.waitForCondition($ -> "abc".equals(output1.getText()));
     }
 
     @Test
@@ -108,7 +107,7 @@ class Spec1507IT extends BaseITNG {
 
         page.guardAjax(() -> input2.sendKeys("abc" + Keys.TAB));
 
-        page.waitForCondition($ -> "abc".equals(output2.getText()), Duration.ofSeconds(3));
+        assertEquals("abc", output2.getText());
     }
 
     @Test
@@ -122,8 +121,8 @@ class Spec1507IT extends BaseITNG {
 
         page.guardAjax(() -> input3.sendKeys("abc" + Keys.TAB));
 
-        page.waitForCondition($ -> "abc".equals(output3a.getText()), Duration.ofSeconds(3));
-        page.waitForCondition($ -> "abc".equals(output3b.getText()), Duration.ofSeconds(3));
+        assertEquals("abc", output3a.getText());
+        assertEquals("abc", output3b.getText());
     }
 
     @Test
@@ -138,10 +137,10 @@ class Spec1507IT extends BaseITNG {
 
         page.guardAjax(() -> input4.sendKeys("abc" + Keys.TAB));
 
-        page.waitForCondition($ -> "abc".equals(output4a.getText()), Duration.ofSeconds(3));
-        page.waitForCondition($ -> "abc".equals(output4b.getText()), Duration.ofSeconds(3));
-        page.waitForCondition($ -> "abc".equals(output4c.getText()), Duration.ofSeconds(3));
-        page.waitForCondition($ -> "abc".equals(output4d.getText()), Duration.ofSeconds(3));
+        assertEquals("abc", output4a.getText());
+        assertEquals("abc", output4b.getText());
+        assertEquals("abc", output4c.getText());
+        assertEquals("abc", output4d.getText());
     }
 
     @Test
@@ -158,9 +157,9 @@ class Spec1507IT extends BaseITNG {
 
         page.guardAjax(() -> input5.sendKeys("abc" + Keys.TAB));
 
-        page.waitForCondition($ -> "abc".equals(output5a.getText()), Duration.ofSeconds(3));
-        page.waitForCondition($ -> "abc".equals(output5b.getText()), Duration.ofSeconds(3));
-        page.waitForCondition($ -> "abc".equals(output5c.getText()), Duration.ofSeconds(3));
+        assertEquals("abc", output5a.getText());
+        assertEquals("abc", output5b.getText());
+        assertEquals("abc", output5c.getText());
     }
 
     @Test
@@ -175,11 +174,11 @@ class Spec1507IT extends BaseITNG {
     void testUnsupportedAjaxEvent() {
         var page = getPage("spec1507.xhtml?renderInputWithUnsupportedAjaxEvent=true");
 
-        assertTrue(page.getPageSource().contains("500"));
+        assertTrue(page.containsText("500"));
     }
 
     private void assertBehaviorScriptRendered(WebPage page, WebElement input, String behaviorEventName) {
-        var scripts = getBehaviorScripts(page, input);
+        var scripts = page.getBehaviorScripts(input);
         assertTrue(scripts.stream().anyMatch(script -> script.contains("'" + behaviorEventName + "'") || script.contains("\"" + behaviorEventName + "\"")), scripts.toString());
     }
 

--- a/tck/util/src/main/java/ee/jakarta/tck/faces/test/util/selenium/BaseITNG.java
+++ b/tck/util/src/main/java/ee/jakarta/tck/faces/test/util/selenium/BaseITNG.java
@@ -29,9 +29,6 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URL;
 import java.net.http.HttpClient;
-import java.time.Duration;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.regex.Pattern;
 
 import org.apache.commons.lang3.exception.UncheckedException;
@@ -113,25 +110,13 @@ public abstract class BaseITNG implements ExecutionCondition {
             webDriver.get(url);
         }
         WebPage webPage = new WebPage(webDriver);
-        // Sometimes it takes longer until the first page is loaded after container startup
-        webPage.waitForPageToLoad(Duration.ofSeconds(120));
         PageFactory.initElements(webDriver, this);
         return webPage;
     }
 
-    /**
-     * Selenium does not automatically update the page handles if a link is clicked without ajax
-     */
-    protected void updatePage() {
-        webDriver.switchToWindowWithUrl(webDriver.getCurrentUrl());
-    }
-
     protected int getStatusCode(String page) {
         webDriver.get(webUrl.toString() + page);
-        WebPage webPage = new WebPage(webDriver);
-        webPage.waitForPageToLoad();
-
-        return webPage.getResponseStatus();
+        return new WebPage(webDriver).getResponseStatus();
     }
 
     protected String getResponseBody(String resource) {
@@ -212,35 +197,4 @@ public abstract class BaseITNG implements ExecutionCondition {
         return webUrl.getPath().replaceAll("/$", "");
     }
 
-    protected List<WebElement> getBehaviorScriptElements(WebPage page, WebElement input) {
-        var id = input.getAttribute("id");
-        var elements = new ArrayList<WebElement>();
-
-        for (var script : page.findElements(By.tagName("script"))) {
-            var src = script.getAttribute("src");
-            if (src == null || src.isEmpty()) {
-                var content = script.getDomProperty("textContent");
-
-                if (content.contains("'" + id + "'") || content.contains("\"" + id + "\"")) {
-                    elements.add(script);
-                }
-            }
-        }
-
-        return elements;
-    }
-
-    protected List<String> getBehaviorScripts(WebPage page, WebElement input) {
-        return getBehaviorScriptElements(page, input).stream().map(script -> script.getDomProperty("textContent")).toList();
-    }
-
-    protected WebElement getBehaviorScriptElement(WebPage page, WebElement input) {
-        var elements = getBehaviorScriptElements(page, input);
-        return elements.isEmpty() ? null : elements.get(0);
-    }
-
-    protected String getBehaviorScript(WebPage page, WebElement input) {
-        var scripts = getBehaviorScripts(page, input);
-        return scripts.isEmpty() ? null : scripts.get(0);
-    }
 }

--- a/tck/util/src/main/java/ee/jakarta/tck/faces/test/util/selenium/WebPage.java
+++ b/tck/util/src/main/java/ee/jakarta/tck/faces/test/util/selenium/WebPage.java
@@ -15,97 +15,54 @@
  */
 package ee.jakarta.tck.faces.test.util.selenium;
 
-import java.lang.System.Logger;
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.List;
-import java.util.Set;
 import java.util.UUID;
 import java.util.function.Function;
 
 import org.openqa.selenium.By;
 import org.openqa.selenium.JavascriptExecutor;
-import org.openqa.selenium.TimeoutException;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
-import org.openqa.selenium.support.ui.ExpectedCondition;
 import org.openqa.selenium.support.ui.WebDriverWait;
 
-import static java.lang.System.Logger.Level.TRACE;
-
 /**
- * Mimics the html unit webpage
+ * High-level facade over {@link ExtendedWebDriver} for integration tests.
+ * Adds settle/poll primitives ({@link #guardHttp}, {@link #guardAjax},
+ * {@link #waitForCondition}) and assertion-friendly content checks
+ * ({@link #containsText}, {@link #containsSource}, {@link #matchesText}).
  */
 public class WebPage {
-    private static final Logger LOG = System.getLogger(WebPage.class.getName());
 
-    public static final Duration STD_TIMEOUT = Duration.ofMillis(Integer.parseInt(System.getProperty("ee.jakarta.tck.faces.timeout", "10000")));
-    public static final Duration LONG_TIMEOUT = STD_TIMEOUT.multipliedBy(3);
+    static final Duration STD_TIMEOUT = Duration.ofMillis(Integer.parseInt(System.getProperty("ee.jakarta.tck.faces.timeout", "10000")));
 
-    protected ExtendedWebDriver webDriver;
+    private ExtendedWebDriver webDriver;
 
     public WebPage(ExtendedWebDriver webDriver) {
         this.webDriver = webDriver;
     }
 
-    public ExtendedWebDriver getWebDriver() {
-        return webDriver;
-    }
-
-    public void setWebDriver(ExtendedWebDriver webDriver) {
-        this.webDriver = webDriver;
-    }
-
     /**
-     * waits for a certain condition is met, until a timeout is hit. In case of exceeding the condition, a runtime exception
-     * is thrown!
-     *
-     * @param isTrue the condition lambda to check
-     * @param timeout timeout duration
-     */
-    public <V> void waitForCondition(Function<? super WebDriver, V> isTrue, Duration timeout) {
-        synchronized (webDriver) {
-            WebDriverWait wait = new WebDriverWait(webDriver, timeout);
-            wait.until(isTrue);
-        }
-    }
-
-    /**
-     * The same as before, but with the long default timeout of LONG_TIMEOUT
-     *
-     * @param isTrue condition lambda
+     * Polls until {@code isTrue} returns truthy or {@link #STD_TIMEOUT} elapses.
+     * Throws {@link org.openqa.selenium.TimeoutException} on timeout. Tests
+     * that need a non-default timeout should construct {@link WebDriverWait}
+     * directly off the inherited {@code getWebDriver()}.
      */
     public <V> void waitForCondition(Function<? super WebDriver, V> isTrue) {
-        synchronized (webDriver) {
-            WebDriverWait wait = new WebDriverWait(webDriver, LONG_TIMEOUT);
-            wait.until(isTrue);
-        }
+        new WebDriverWait(webDriver, STD_TIMEOUT).until(isTrue);
     }
 
     /**
-     * Wait for a certain period of time
+     * Run {@code action} and block until the resulting non-Ajax navigation has
+     * completed (i.e. the new page's {@code document.readyState} is {@code complete}).
      *
-     * @param timeout the timeout to wait (note due to the asynchronous nature of the web drivers, any code running on the
-     * browser itself will proceed (aka javascript) only the client operations are stalled.
-     */
-    public void wait(Duration timeout) {
-        synchronized (webDriver) {
-            try {
-                webDriver.wait(timeout.toMillis());
-            } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
-                throw new RuntimeException(e);
-            }
-        }
-    }
-
-    /**
-     * wait until the current non-Ajax request targeting the same page has completed
-     *
-     * @param the non-ajax action to execute, usually {@code WebElement::click}
+     * @param action the non-ajax action to execute, usually {@code WebElement::click}
      */
     public void guardHttp(Runnable action) {
         action.run();
-        waitForPageToLoad();
+        new WebDriverWait(webDriver, STD_TIMEOUT).until(
+                $ -> "complete".equals(executeScript("return document.readyState")));
     }
 
     /**
@@ -115,13 +72,12 @@ public class WebPage {
      */
     public void guardAjax(Runnable action) {
         var uuid = UUID.randomUUID().toString();
-        webDriver.getJSExecutor().executeScript(
-                "window.$ajax=true;"
+        executeScript("window.$ajax=true;"
                 + "faces.ajax.addOnEvent(data=>{if(data.status=='success')window.$ajax='" + uuid + "'});"
                 + "faces.ajax.addOnError(()=>window.$ajax='" + uuid + "')");
         action.run();
         webDriver.waitForFaces(STD_TIMEOUT);
-        waitForCondition($ -> webDriver.getJSExecutor().executeScript("return window.$ajax=='" + uuid + "' || (!window.$ajax && document.readyState=='complete')"));
+        waitForCondition($ -> executeScript("return window.$ajax=='" + uuid + "' || (!window.$ajax && document.readyState=='complete')"));
     }
 
     /**
@@ -131,143 +87,43 @@ public class WebPage {
      *         {@code false} if an Ajax response did complete.
      */
     public boolean assertNoAjax(Runnable action) {
-        webDriver.getJSExecutor().executeScript("window.$ajaxFired=false;faces.ajax.addOnEvent(()=>window.$ajaxFired=true)");
+        executeScript("window.$ajaxFired=false;faces.ajax.addOnEvent(()=>window.$ajaxFired=true)");
         action.run();
         try {
             Thread.sleep(500);
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
         }
-        return Boolean.FALSE.equals(webDriver.getJSExecutor().executeScript("return window.$ajaxFired"));
+        return Boolean.FALSE.equals(executeScript("return window.$ajaxFired"));
     }
 
     /**
-     * waits for backgrounds processes on the browser to complete
-     *
-     * @param timeOut the timeout duration until the wait can proceed before being interupopted
+     * Returns true if the page's visible text (whitespace-collapsed) contains
+     * the given text. Synchronous: assumes the caller already settled the page
+     * via guardHttp, guardAjax, or getPage. If you need to wait for the text
+     * to appear, use {@link #waitForCondition} explicitly.
      */
-    public void waitForPageToLoad(Duration timeOut) {
-        ExpectedCondition<Boolean> expectation =
-            driver -> webDriver.getJSExecutor()
-                               .executeScript("return document.readyState")
-                               .equals("complete");
-
-        synchronized (webDriver) {
-            WebDriverWait wait = new WebDriverWait(webDriver, timeOut);
-            wait.until(expectation);
-        }
+    public boolean containsText(String text) {
+        return getText().contains(text);
     }
 
     /**
-     * wait until the page load is finished
+     * Returns true if the page's full HTML markup contains the given text.
+     * Synchronous; same precondition as {@link #containsText}. Use this only
+     * when the asserted text lives in markup-only context (HTML attributes,
+     * encoded entities, script content) — for visible page content prefer
+     * {@link #containsText}.
      */
-    public void waitForPageToLoad() {
-        waitForPageToLoad(STD_TIMEOUT);
+    public boolean containsSource(String text) {
+        return getSource().contains(text);
     }
 
     /**
-     * conditional waiter and checker which checks whether the page text is present we add our own waiter internally,
-     * because pageSource always delivers
-     *
-     * @param text to check
-     * @return true in case of found false in case of found after our standard timeout is reached
+     * Returns true if the page's visible text (whitespace-collapsed) matches
+     * the given regex. Synchronous; same precondition as {@link #containsText}.
      */
-    public boolean isInPageText(String text) {
-        try {
-            // values are not returned by getPageText
-            String values = getInputValues();
-
-            waitForCondition(webDriver1 -> (webDriver.getPageText() + values).contains(text), STD_TIMEOUT);
-            return true;
-        } catch (TimeoutException ex) {
-            // timeout is wanted in this case and should result in a false
-            return false;
-        }
-    }
-
-    public boolean matchesPageText(String regexp) {
-        try {
-            waitForCondition(webDriver1 -> webDriver.getPageText().matches(regexp), STD_TIMEOUT);
-            return true;
-        } catch (TimeoutException ex) {
-            // timeout is wanted in this case and should result in a false
-            return false;
-        }
-    }
-
-    /**
-     * adds the reduced page text functionality to the regexp match
-     *
-     * @param regexp
-     * @return
-     */
-    public boolean matchesPageTextReduced(String regexp) {
-        try {
-            waitForCondition(webDriver1 -> webDriver.getPageTextReduced().matches(regexp), STD_TIMEOUT);
-            return true;
-        } catch (TimeoutException ex) {
-            // timeout is wanted in this case and should result in a false
-            return false;
-        }
-    }
-
-    /**
-     * conditional waiter and checker which checks whether a text is in the page we add our own waiter internally, because
-     * pageSource always delivers this version of isInPage checks explicitly the full markup not only the text
-     *
-     * @param text to check
-     * @return true in case of found false in case of found after our standard timeout is reached
-     */
-    public boolean isInPage(String text) {
-        try {
-            String values = getInputValues();
-            waitForCondition(webDriver1 -> (webDriver.getPageSource() + values).contains(text), STD_TIMEOUT);
-            return true;
-        } catch (TimeoutException ex) {
-            // timeout is wanted in this case and should result in a false
-            return false;
-        }
-    }
-
-    /**
-     * conditional waiter and checker which checks whether a text is in the page we add our own waiter internally, because
-     * pageSource always delivers we need to add two different condition checkers herte because a timeout automatically
-     * throws internally an error which is mapped to false We therefore cannot simply wait for the condition either being
-     * met or timeout with one method
-     *
-     * @param text to check
-     * @return true in case of found false in case of found after our standard timeout is reached
-     */
-    public boolean isInPage(String text, boolean allowExceptions) {
-        try {
-            String values = getInputValues();
-            waitForCondition(webDriver1 -> (webDriver.getPageSource() + values).contains(text), STD_TIMEOUT);
-            return true;
-        } catch (TimeoutException exception) {
-            if (allowExceptions) {
-                throw exception;
-            }
-            exception.printStackTrace();
-            return false;
-        }
-    }
-
-    /**
-     * is condition reached or not reached after until a STD_TIMEOUT is reached if the timeout is exceeded the condition is
-     * not met
-     *
-     * @param isTrue the isTrue condition lambda
-     * @return true if it is met until STD_TIMEOUT, otherwise false
-     */
-    public <V> boolean isCondition(Function<? super WebDriver, V> isTrue) {
-        try {
-            waitForCondition(isTrue, STD_TIMEOUT);
-            return true;
-        } catch (TimeoutException ex) {
-            // timeout is wanted in this case and should result in a false
-            LOG.log(TRACE, "This exception was expected.", ex);
-            return false;
-        }
+    public boolean matchesText(String regex) {
+        return getText().matches(regex);
     }
 
     public WebElement findElement(By by) {
@@ -286,24 +142,15 @@ public class WebPage {
         return webDriver.getResponseBody();
     }
 
-    public String getRequestData() {
-        return webDriver.getRequestData();
-    }
-
-    public void postInit() {
-        webDriver.postInit();
-    }
-
     public JavascriptExecutor getJSExecutor() {
         return webDriver.getJSExecutor();
     }
 
-    public void printProcessedResponses() {
-        webDriver.printProcessedResponses();
-    }
-
-    public void get(String url) {
-        webDriver.get(url);
+    /**
+     * Convenience shorthand for {@code getJSExecutor().executeScript(script, args)}.
+     */
+    public Object executeScript(String script, Object... args) {
+        return webDriver.getJSExecutor().executeScript(script, args);
     }
 
     public String getCurrentUrl() {
@@ -314,44 +161,23 @@ public class WebPage {
         return webDriver.getTitle();
     }
 
-    public String getPageSource() {
+    /**
+     * Returns the full HTML markup of the current page. Escape hatch for
+     * tests that need to fetch the page once and run multiple operations
+     * (regex, substring, repeated lookups) on the same snapshot. For simple
+     * "does X appear?" checks use {@link #containsSource}.
+     */
+    public String getSource() {
         return webDriver.getPageSource();
     }
 
-    public String getPageText() {
-        return webDriver.getPageText();
-    }
-
-    public String getPageTextReduced() {
+    /**
+     * Returns the page's visible text with all whitespace collapsed to single
+     * spaces (head + body innerText, runs of whitespace and non-breaking
+     * spaces normalised). Callers should prefer {@link #containsText} and {@link #matchesText}.
+     */
+    private String getText() {
         return webDriver.getPageTextReduced();
-    }
-
-    public void close() {
-        webDriver.close();
-    }
-
-    public void quit() {
-        webDriver.quit();
-    }
-
-    public Set<String> getWindowHandles() {
-        return webDriver.getWindowHandles();
-    }
-
-    public String getWindowHandle() {
-        return webDriver.getWindowHandle();
-    }
-
-    public WebDriver.TargetLocator switchTo() {
-        return webDriver.switchTo();
-    }
-
-    public WebDriver.Navigation navigate() {
-        return webDriver.navigate();
-    }
-
-    public WebDriver.Options manage() {
-        return webDriver.manage();
     }
 
     /**
@@ -363,8 +189,46 @@ public class WebPage {
         return webDriver.findElements(By.cssSelector("a[href]"));
     }
 
-    public String getInputValues() {
-        return webDriver.findElements(By.cssSelector("input, textarea, select")).stream()
-                .map(webElement -> webElement.getAttribute("value")).reduce("", (str1, str2) -> str1 + " " + str2);
+    /**
+     * Returns inline (non-{@code src}) {@code <script>} elements whose textContent
+     * mentions the given input's id (single- or double-quoted) — i.e. the JSF
+     * client-behavior scripts wired up to that input.
+     */
+    public List<WebElement> getBehaviorScriptElements(WebElement input) {
+        var id = input.getAttribute("id");
+        var elements = new ArrayList<WebElement>();
+        for (var script : findElements(By.tagName("script"))) {
+            var src = script.getAttribute("src");
+            if (src == null || src.isEmpty()) {
+                var content = script.getDomProperty("textContent");
+                if (content.contains("'" + id + "'") || content.contains("\"" + id + "\"")) {
+                    elements.add(script);
+                }
+            }
+        }
+        return elements;
+    }
+
+    /**
+     * Same as {@link #getBehaviorScriptElements} but returns the script bodies as strings.
+     */
+    public List<String> getBehaviorScripts(WebElement input) {
+        return getBehaviorScriptElements(input).stream().map(script -> script.getDomProperty("textContent")).toList();
+    }
+
+    /**
+     * Returns the first script element wired to {@code input}, or {@code null} if none.
+     */
+    public WebElement getBehaviorScriptElement(WebElement input) {
+        var elements = getBehaviorScriptElements(input);
+        return elements.isEmpty() ? null : elements.get(0);
+    }
+
+    /**
+     * Returns the body of the first script wired to {@code input}, or {@code null} if none.
+     */
+    public String getBehaviorScript(WebElement input) {
+        var scripts = getBehaviorScripts(input);
+        return scripts.isEmpty() ? null : scripts.get(0);
     }
 }


### PR DESCRIPTION
Removes patterns inherited from the HtmlUnit-era TCK (defensive polling, deep getter chains, dead passthroughs) and tightens the WebPage facade. WebPage's public surface drops from ~30 methods to 17, with 12 unused WebDriver passthroughs deleted outright and several internal-only helpers made package-private or private. Total test run time unaffected (4 minutes at -T8).

waitForCondition / waitForPageToLoad
- all solved with guardAjax and guardHttp, great example in Issue5078IT.
- 24 of 28 waitForCondition callsites eliminated: ones following guardAjax/guardHttp/getPage dropped the wait entirely (page already settled); ones with bare click()/sendKeys() before the wait migrated to guardHttp/guardAjax + synchronous assertion. The 4 Spec1423IT cases that wait for ajax-injected stylesheet/script side-effects are kept — guardAjax tracks the XHR but not the browser-side resource loading.
- waitForCondition's no-arg overload now defaults to STD_TIMEOUT (was LONG_TIMEOUT = 30s, asymmetric with guardAjax's 10s); the (Function, Duration) overload is dropped (the single Spec1507IT caller that passed Duration.ofSeconds(3) had no rule-stated reason for the shorter timeout). The LONG_TIMEOUT has been dropped, users should use -Dee.jakarta.tck.faces.timeout=30 instead.
- waitForPageToLoad inlined into guardHttp; both overloads removed. BaseITNG.getStatusCode dropped its redundant call (webDriver.get() already waited for document.readyState=='complete'); BaseITNG.getPage similarly dropped its 120s waitForPageToLoad workaround that pre-dated gf-pool's slot health probe.

Polling helpers
- isInPage / isInPageText / isNotInPage / isInPageTextReduced: all four wrapped a contains() check in a 10s WebDriverWait. After guardHttp / guardAjax / getPage settled the page, the polling adds nothing on the green path and just delays failures by 10s. Renamed and inlined to synchronous containsText (visible body innerText, whitespace collapsed) and containsSource (full markup); 130+ callsites migrated, with 8 markup-only sites narrowed to containsSource (encoded HTML, attribute values, <script> content) and the rest defaulting to containsText.
- matchesPageText / matchesPageTextReduced: same polling wrapper around String.matches(); consolidated into a single synchronous matchesText using the reduced (whitespace-collapsed) text. 9 callsites migrated.

Raw-access getters
- getPageSource / getPageText / getPageTextReduced renamed to getSource / getText (the latter now private — backs containsText/matchesText only). Callers using .contains(X) on the result migrated to containsText/ containsSource; the snapshot-then-multi-search pattern keeps using getSource().
- getInputValues removed: the three "(getPageText() + getInputValues()) .contains(X)" defensive-absence patterns in flow tests collapsed to containsText(X). The single test that legitimately read a textarea's live value (Issue1957IT/Issue2179IT/Issue2749IT) had its xhtml's textarea-as-status-log changed to a div with innerText, so getText() now sees the rendered events directly.

Other migrations
- wait(Duration) removed: 3 callers were 3-second raw sleeps after a JS action; replaced by waitForCondition for the actual signal (or just dropped where there was no async update to wait for).
- isCondition removed: 2 callers in Issue2407IT were poll-and-assert on an ajax button; replaced by guardAjax(button::click) + synchronous assertEquals.
- getWebDriver removed from WebPage: only caller (Spec1568IT) migrated to a new page.executeScript(script, args...) helper. Tests that need the raw ExtendedWebDriver still have the inherited BaseITNG.getWebDriver().
- updatePage() removed from BaseITNG: zero callers, and the impl (switchToWindowWithUrl(getCurrentUrl()) — switch to the window I'm already on) didn't do what its doc claimed.
- getBehaviorScript / getBehaviorScripts / getBehaviorScriptElement(s) moved from BaseITNG to WebPage: 14 callsites become page.getBehaviorScript(input) instead of getBehaviorScript(page, input). Eliminates 4 BaseITNG protected helpers in favour of natural OO style.
- 12 unused WebDriver passthroughs removed (setWebDriver, postInit, getRequestData, printProcessedResponses, get, close, quit, getWindowHandles, getWindowHandle, switchTo, navigate, manage).

Visibility / simplification
- STD_TIMEOUT: public → package-private (only ChromeDevtoolsDriver imports it via static import; same package).
- LONG_TIMEOUT removed (no longer used anywhere).
- WebPage.webDriver field: protected → private (no subclasses).
- synchronized (webDriver) blocks dropped from waitForCondition and waitForPageToLoad: each test JVM owns one driver, no real contention.
- 5 tests with "ExtendedWebDriver webDriver = getWebDriver(); ... webDriver.findElement(...)" simplified to page.findElement(...) and the local var dropped (Issue5081IT, Issue5078IT, Issue4830IT, Spec1386IT, Issue4550IT, Spec1555IT). Spec1260IT's 5 getWebDriver().findElement(...) chains likewise simplified.

Misc
- Issue5160IT: added comment explaining why driverPool.quitInstance is needed in tearDown — addRequestHeader is additive on the underlying Chrome instance, so reusing the driver across tests would stack Accept-Language headers and the wrong locale would win.