### PR TITLE
Drop unused deps, align timeouts, clean HtmlUnit-era leftovers

### DIFF
--- a/tck/faces22/ajax-lifecycle/src/test/java/ee/jakarta/tck/faces/faces22/ajax_lifecycle/Issue2166IT.java
+++ b/tck/faces22/ajax-lifecycle/src/test/java/ee/jakarta/tck/faces/faces22/ajax_lifecycle/Issue2166IT.java
@@ -31,23 +31,22 @@ import ee.jakarta.tck.faces.util.selenium.WebPage;
 
 class Issue2166IT extends BaseITNG {
 
-  /**
-   * @see PreRenderViewEvent
-     * @see AjaxBehavior
-     * @see https://github.com/eclipse-ee4j/mojarra/issues/2166
-   */
-  @Test
-  void preRenderViewListenerFiresOncePerInit() throws Exception {
-        WebPage page = getPage("issue2166.xhtml");
+	/**
+	 * @see PreRenderViewEvent
+	 * @see AjaxBehavior
+	 * @see https://github.com/eclipse-ee4j/mojarra/issues/2166
+	 */
+	@Test
+	void preRenderViewListenerFiresOncePerInit() throws Exception {
+		WebPage page = getPage("issue2166.xhtml");
 
-        assertTrue(page.containsSource("Init called\n"));
+		assertTrue(page.containsSource("Init called\n"));
+		assertFalse(page.containsSource("Init called\nInit called\n"));
 
-        WebElement button = page.findElement(By.id("form:submit"));
-        page.guardAjax(button::click);
+		WebElement button = page.findElement(By.id("form:submit"));
+		page.guardAjax(button::click);
 
-        // init called not present probably a mojarra codebase issue
-        // showing up in Chrome - works in htmlunit!
-        assertTrue(page.containsSource("Init called\nInit called\n"));
-        assertFalse(page.containsSource("Init called\nInit called\nInit called"));
-    }
+		assertTrue(page.containsSource("Init called\nInit called\n"));
+		assertFalse(page.containsSource("Init called\nInit called\nInit called"));
+	}
 }

--- a/tck/faces23/websocket/src/test/java/ee/jakarta/tck/faces/faces23/websocket/Spec1396IT.java
+++ b/tck/faces23/websocket/src/test/java/ee/jakarta/tck/faces/faces23/websocket/Spec1396IT.java
@@ -16,7 +16,6 @@
  */
 package ee.jakarta.tck.faces.faces23.websocket;
 
-import static java.time.Duration.ofSeconds;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -24,126 +23,124 @@ import jakarta.faces.component.UIWebsocket;
 
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.By;
-import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
-import org.openqa.selenium.support.ui.WebDriverWait;
 
 import ee.jakarta.tck.faces.util.selenium.BaseITNG;
 import ee.jakarta.tck.faces.util.selenium.WebPage;
 
 class Spec1396IT extends BaseITNG {
 
-  /**
-   * @see UIWebsocket
-     * @see https://github.com/jakartaee/faces/issues/1396
-   */
-  @Test
-  void enableWebsocketEndpoint() throws Exception {
-        WebPage page = getPage("spec1396-1.xhtml");
-        assertEquals("true", page.findElement(By.id("param")).getText());
-    }
+	/**
+	 * @see UIWebsocket
+	 * @see https://github.com/jakartaee/faces/issues/1396
+	 */
+	@Test
+	void enableWebsocketEndpoint() throws Exception {
+		WebPage page = getPage("spec1396-1.xhtml");
+		assertEquals("true", page.findElement(By.id("param")).getText());
+	}
 
-  /**
-   * @see UIWebsocket
-     * @see https://github.com/jakartaee/faces/issues/1396
-   */
-  @Test
-  void defaultWebsocket() throws Exception {
-        WebPage page = getPage("spec1396-2.xhtml");
+	/**
+	 * @see UIWebsocket
+	 * @see https://github.com/jakartaee/faces/issues/1396
+	 */
+	@Test
+	void defaultWebsocket() throws Exception {
+		WebPage page = getPage("spec1396-2.xhtml");
 
-        String pageSource = page.getSource();
-        assertTrue(pageSource.contains("faces.push.init("));
-        assertTrue(pageSource.contains("/jakarta.faces.push/push?"));
+		String pageSource = page.getSource();
+		assertTrue(pageSource.contains("faces.push.init("));
+		assertTrue(pageSource.contains("/jakarta.faces.push/push?"));
 
-        waitUntilWebsocketIsOpened(getWebDriver(), page);
+		waitUntilWebsocketIsOpened(page);
 
-        WebElement button = page.findElement(By.id("form:button"));
-        button.click();
+		WebElement button = page.findElement(By.id("form:button"));
+		button.click();
 
-        waitUntilWebsocketIsPushed(getWebDriver(), page);
-    }
+		waitUntilWebsocketIsPushed(page);
+	}
 
-  /**
-   * @see UIWebsocket#setUser(java.io.Serializable)
-     * @see https://github.com/jakartaee/faces/issues/1396
-   */
-  @Test
-  void userScopedWebsocket() throws Exception {
-        WebPage page = getPage("spec1396-3.xhtml");
+	/**
+	 * @see UIWebsocket#setUser(java.io.Serializable)
+	 * @see https://github.com/jakartaee/faces/issues/1396
+	 */
+	@Test
+	void userScopedWebsocket() throws Exception {
+		WebPage page = getPage("spec1396-3.xhtml");
 
-        String pageSource = page.getSource();
-        assertTrue(pageSource.contains("faces.push.init("));
-        assertTrue(pageSource.contains("/jakarta.faces.push/user?"));
+		String pageSource = page.getSource();
+		assertTrue(pageSource.contains("faces.push.init("));
+		assertTrue(pageSource.contains("/jakarta.faces.push/user?"));
 
-        waitUntilWebsocketIsOpened(getWebDriver(), page);
+		waitUntilWebsocketIsOpened(page);
 
-        WebElement button = page.findElement(By.id("form:button"));
-        button.click();
+		WebElement button = page.findElement(By.id("form:button"));
+		button.click();
 
-        waitUntilWebsocketIsPushed(getWebDriver(), page);
-    }
+		waitUntilWebsocketIsPushed(page);
+	}
 
-  /**
-   * @see UIWebsocket#setScope(String)
-     * @see https://github.com/jakartaee/faces/issues/1396
-   */
-  @Test
-  void viewScopedWebsocket() throws Exception {
-        WebPage page = getPage("spec1396-4.xhtml");
+	/**
+	 * @see UIWebsocket#setScope(String)
+	 * @see https://github.com/jakartaee/faces/issues/1396
+	 */
+	@Test
+	void viewScopedWebsocket() throws Exception {
+		WebPage page = getPage("spec1396-4.xhtml");
 
-        String pageSource = page.getSource();
-        assertTrue(pageSource.contains("faces.push.init("));
-        assertTrue(pageSource.contains("/jakarta.faces.push/view?"));
+		String pageSource = page.getSource();
+		assertTrue(pageSource.contains("faces.push.init("));
+		assertTrue(pageSource.contains("/jakarta.faces.push/view?"));
 
-        waitUntilWebsocketIsOpened(getWebDriver(), page);
+		waitUntilWebsocketIsOpened(page);
 
-        WebElement button = page.findElement(By.id("form:button"));
-        button.click();
+		WebElement button = page.findElement(By.id("form:button"));
+		button.click();
 
-        waitUntilWebsocketIsPushed(getWebDriver(), page);
-    }
+		waitUntilWebsocketIsPushed(page);
+	}
 
-  /**
-   * @see UIWebsocket
-     * @see https://github.com/eclipse-ee4j/mojarra/issues/4332
-   */
-  @Test
-  void websocketAfterPostback() throws Exception {
-        WebPage page = getPage("spec1396-5.xhtml");
+	/**
+	 * @see UIWebsocket
+	 * @see https://github.com/eclipse-ee4j/mojarra/issues/4332
+	 */
+	@Test
+	void websocketAfterPostback() throws Exception {
+		WebPage page = getPage("spec1396-5.xhtml");
 
-        String pageSource = page.getSource();
-        assertTrue(pageSource.contains("faces.push.init("));
-        assertTrue(pageSource.contains("/jakarta.faces.push/push?"));
+		String pageSource = page.getSource();
+		assertTrue(pageSource.contains("faces.push.init("));
+		assertTrue(pageSource.contains("/jakarta.faces.push/push?"));
 
-        waitUntilWebsocketIsOpened(getWebDriver(), page);
+		waitUntilWebsocketIsOpened(page);
 
-        WebElement postback = page.findElement(By.id("form:postback"));
-        page.guardHttp(postback::click);
+		WebElement postback = page.findElement(By.id("form:postback"));
+		page.guardHttp(postback::click);
 
-        pageSource = page.getSource();
-        assertTrue(pageSource.contains("faces.push.init("));
-        assertTrue(pageSource.contains("/jakarta.faces.push/push?"));
+		pageSource = page.getSource();
+		assertTrue(pageSource.contains("faces.push.init("));
+		assertTrue(pageSource.contains("/jakarta.faces.push/push?"));
 
-        waitUntilWebsocketIsOpened(getWebDriver(), page);
+		waitUntilWebsocketIsOpened(page);
 
-        WebElement button = page.findElement(By.id("form:button"));
-        button.click();
+		WebElement button = page.findElement(By.id("form:button"));
+		button.click();
 
-        waitUntilWebsocketIsPushed(getWebDriver(), page);
-    }
+		waitUntilWebsocketIsPushed(page);
+	}
 
-    /**
-     * HtmlUnit is not capable of waiting until WS is opened. Hence this work around.
-     */
-    private static void waitUntilWebsocketIsOpened(WebDriver browser, WebPage page) throws Exception {
-        new WebDriverWait(browser, ofSeconds(3)).until($ -> "yes".equals(page.findElement(By.id("opened")).getText()));
-    }
+	/**
+	 * WebDriver doesn't expose WebSocket lifecycle events; the page's JS sets #opened on onopen, which we poll here.
+	 */
+	private static void waitUntilWebsocketIsOpened(WebPage page) throws Exception {
+		page.waitForCondition($ -> "yes".equals(page.findElement(By.id("opened")).getText()));
+	}
 
-    /**
-     * HtmlUnit is not capable of waiting until WS is pushed. Hence this work around.
-     */
-    private static void waitUntilWebsocketIsPushed(WebDriver browser, WebPage page) throws Exception {
-        new WebDriverWait(browser, ofSeconds(3)).until($ -> "pushed!".equals(page.findElement(By.id("message")).getText()));
-    }
+	/**
+	 * WebDriver doesn't expose WebSocket message events; the page's JS sets #message on onmessage, which we poll here.
+	 */
+	private static void waitUntilWebsocketIsPushed(WebPage page) throws Exception {
+		page.waitForCondition($ -> "pushed!".equals(page.findElement(By.id("message")).getText()));
+	}
 
 }

--- a/tck/faces40/input/src/test/java/ee/jakarta/tck/faces/faces40/input/Spec1556IT.java
+++ b/tck/faces40/input/src/test/java/ee/jakarta/tck/faces/faces40/input/Spec1556IT.java
@@ -41,15 +41,12 @@ public class Spec1556IT extends BaseITNG {
         WebElement inputFileWithAccept = page.findElement(By.id("form:inputFileWithAccept"));
         assertEquals("image/*", inputFileWithAccept.getDomAttribute("accept"), "Specified 'accept' attribute on h:inputFile is rendered");
 
-        // It's for Mojarra also explicitly tested on h:inputText because they share the same renderer.
+        // It's also explicitly tested on h:inputText because they share the same renderer.
         WebElement inputTextWithoutAccept = page.findElement(By.id("form:inputTextWithoutAccept"));
         assertEquals(null, inputTextWithoutAccept.getDomAttribute("accept"), "Unspecified 'accept' attribute on h:inputText is NOT rendered");
 
         WebElement inputTextWithAccept = page.findElement(By.id("form:inputTextWithAccept"));
         assertEquals(null, inputTextWithAccept.getDomAttribute("accept"), "Specified 'accept' attribute on h:inputText is NOT rendered");
-
-        // NOTE: HtmlUnit doesn't support filtering files by accept attribute. So the upload part is not tested to keep it simple (it's nonetheless already
-        // tested in Spec1555IT).
     }
 
 }

--- a/tck/pom.xml
+++ b/tck/pom.xml
@@ -69,7 +69,6 @@
         <arquillian-suite-extension.version>1.2.2</arquillian-suite-extension.version>
         <chromedriver.version>139</chromedriver.version>
         <faces.version>5.0.0-SNAPSHOT</faces.version>
-        <htmlunit.version>4.13.0</htmlunit.version>
         <junit.version>5.13.4</junit.version>
         <selenium.version>4.35.0</selenium.version>
         <shrinkwrap-resolver.version>3.3.4</shrinkwrap-resolver.version>
@@ -121,12 +120,6 @@
                 <groupId>org.jboss.arquillian.container</groupId>
                 <artifactId>arquillian-container-test-api</artifactId>
                 <version>${arquillian.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>junit</groupId>
-                <artifactId>junit</artifactId>
-                <version>4.13.2</version>
-                <scope>test</scope>
             </dependency>
 
             <dependency>
@@ -205,42 +198,6 @@
                 <version>${jakarta.validation-api.version}</version>
                 <scope>provided</scope>
             </dependency>
-            <dependency>
-                <groupId>org.htmlunit</groupId>
-                <artifactId>htmlunit</artifactId>
-                <version>${htmlunit.version}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.htmlunit</groupId>
-                <artifactId>htmlunit-core-js</artifactId>
-                <version>${htmlunit.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.htmlunit</groupId>
-                <artifactId>neko-htmlunit</artifactId>
-                <version>${htmlunit.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.htmlunit</groupId>
-                <artifactId>htmlunit-cssparser</artifactId>
-                <version>${htmlunit.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.htmlunit</groupId>
-                <artifactId>htmlunit-xpath</artifactId>
-                <version>${htmlunit.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.htmlunit</groupId>
-                <artifactId>htmlunit-csp</artifactId>
-                <version>${htmlunit.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.htmlunit</groupId>
-                <artifactId>htmlunit-websocket-client</artifactId>
-                <version>${htmlunit.version}</version>
-            </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -303,25 +260,6 @@
 
         <!-- Test dependencies which can be used in sub-modules -->
         <dependency>
-            <groupId>javax.annotation</groupId>
-            <artifactId>javax.annotation-api</artifactId>
-            <version>1.3.2</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>jakarta.xml.bind</groupId>
-            <artifactId>jakarta.xml.bind-api</artifactId>
-            <version>2.3.2</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.glassfish.jaxb</groupId>
-            <artifactId>jaxb-runtime</artifactId>
-            <version>2.3.2</version>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
             <version>${junit.version}</version>
@@ -348,35 +286,6 @@
             <groupId>org.jboss.shrinkwrap.resolver</groupId>
             <artifactId>shrinkwrap-resolver-impl-maven-archive</artifactId>
             <version>${shrinkwrap-resolver.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>xmlunit</groupId>
-            <artifactId>xmlunit</artifactId>
-            <version>1.6</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.skyscreamer</groupId>
-            <artifactId>jsonassert</artifactId>
-            <version>1.5.1</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.htmlunit</groupId>
-            <artifactId>htmlunit</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>rhino</groupId>
-            <artifactId>js</artifactId>
-            <version>1.7R2</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.json</groupId>
-            <artifactId>json</artifactId>
-            <version>20250517</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -438,7 +347,6 @@
         <plugins>
             <plugin>
                 <artifactId>maven-enforcer-plugin</artifactId>
-                <version>3.5.0</version>
                 <configuration>
                     <rules>
                         <requireMavenVersion>

--- a/tck/util/pom.xml
+++ b/tck/util/pom.xml
@@ -36,7 +36,7 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
-            <version>5.11.4</version>
+            <version>${junit.version}</version>
         </dependency>
         <dependency>
             <groupId>org.junit.platform</groupId>
@@ -81,12 +81,6 @@
             <groupId>org.eu.ingwar.tools</groupId>
             <artifactId>arquillian-suite-extension</artifactId>
             <version>${arquillian-suite-extension.version}</version>
-        </dependency>
-
-        <dependency>
-            <groupId>org.htmlunit</groupId>
-            <artifactId>htmlunit</artifactId>
-			<scope>compile</scope>
         </dependency>
     </dependencies>
 </project>

--- a/tck/util/src/main/java/ee/jakarta/tck/faces/util/selenium/ChromeDevtoolsDriver.java
+++ b/tck/util/src/main/java/ee/jakarta/tck/faces/util/selenium/ChromeDevtoolsDriver.java
@@ -391,9 +391,9 @@ public class ChromeDevtoolsDriver extends RemoteWebDriver implements ExtendedWeb
         lastGet = questionMark > 0 ? url.substring(0, questionMark) : url;
         if (firstRequest) {
             firstRequest = false;
-            getAndWaitForWindowAndFaces(url, Duration.ofSeconds(60));
+            getAndWaitForWindowAndFaces(url);
         } else {
-            getAndWaitForFaces(url, Duration.ofSeconds(10));
+            getAndWaitForFaces(url);
         }
     }
 
@@ -405,9 +405,9 @@ public class ChromeDevtoolsDriver extends RemoteWebDriver implements ExtendedWeb
      * @param url target link
      * @param timeout time to wait.
      */
-    protected void getAndWaitForWindowAndFaces(String url, Duration timeout) {
-        WebDriverWait waitForWindow = new WebDriverWait(delegate, timeout, Duration.ofSeconds(5));
-        WebDriverWait waitForJs = new WebDriverWait(delegate, Duration.ofSeconds(10L), Duration.ofMillis(10));
+    private void getAndWaitForWindowAndFaces(String url) {
+        WebDriverWait waitForWindow = new WebDriverWait(delegate, STD_TIMEOUT, Duration.ofSeconds(5));
+        WebDriverWait waitForJs = new WebDriverWait(delegate, STD_TIMEOUT, Duration.ofMillis(10));
         waitForWindow.until(d -> {
             try {
                 d.get(url);
@@ -426,7 +426,7 @@ public class ChromeDevtoolsDriver extends RemoteWebDriver implements ExtendedWeb
 
         LOG.log(FINEST, "Communication with Faces started!");
 
-        waitForFaces(timeout);
+        waitForFaces(STD_TIMEOUT);
     }
 
     /**
@@ -436,9 +436,9 @@ public class ChromeDevtoolsDriver extends RemoteWebDriver implements ExtendedWeb
      * @param url target link
      * @param timeout time to wait.
      */
-    protected void getAndWaitForFaces(String url, Duration timeout) {
+    private void getAndWaitForFaces(String url) {
         delegate.get(url);
-        waitForFaces(timeout);
+        waitForFaces(STD_TIMEOUT);
     }
 
     @Override


### PR DESCRIPTION
Removed unused test deps from tck/pom.xml — htmlunit (replaced by Selenium long ago), junit 4, xmlunit, jsonassert, rhino, org.json, javax.annotation-api, jakarta.xml.bind-api, jaxb-runtime — and the htmlunit dep from tck/util. Aligned tck/util junit-jupiter version with the parent (${junit.version}).

ChromeDevtoolsDriver: replaced hardcoded 10s/60s waits in the get() path with STD_TIMEOUT; tightened method visibility to private (neither was overridden or called externally) and dropped the now-redundant timeout parameter.

Spec1396IT: WS wait helpers now use page.waitForCondition instead of a hand-rolled WebDriverWait; the "Selenium can't wait until WS is opened" comments were stale HtmlUnit framing — the real reason is that WebDriver has no first-class WebSocket event API, so we poll a DOM flag set by the page's JS.

Issue2166IT: tightened to assert Init runs exactly once on initial GET.
Spec1556IT: dropped stale HtmlUnit-specific note.