### PR TITLE
Permit on* attribute rendering as DOM event listeners for CSP compatibility

### DIFF
--- a/api/src/main/renderkitdoc/standard-html-renderkit.xml
+++ b/api/src/main/renderkitdoc/standard-html-renderkit.xml
@@ -201,7 +201,15 @@
        with the same name as a <em>renderer specific attribute</em>, the
        <em>pass through attribute</em> takes precedence.  <em>Pass
        through attributes</em> are rendered as if they were passed to
-       <code>ResponseWriter.writeURIAttribute()</code>.</p>
+       <code>ResponseWriter.writeURIAttribute()</code>.
+       <span class="changed_modified_5_0">As an exception, when the attribute
+       name starts with 'on' and the substring after 'on' names a DOM event,
+       the implementation MAY instead arrange for the attribute's script
+       value to be invoked on that DOM event at runtime, provided the
+       observable behavior &mdash; including any chaining required by
+       <a href="#general_behavior_encoding">&sect;general_behavior_encoding</a>
+       and short-circuit-on-<code>false</code> semantics &mdash; is
+       preserved.</span></p>
 
 
      </ul>
@@ -216,7 +224,15 @@
          and the attribute name starts with 'on'
          and the substring after 'on' is contained in <code>ClientBehaviorHolder#getEventNames()</code>
          and it is not available as a <em>renderer specific attribute</em>,
-         then it must be rendered the same way as a <em>pass through attribute</em>.
+         then the implementation must ensure that the attribute's script value
+         is invoked on the corresponding DOM event, chained with any client
+         behavior scripts and renderer-specific scripts per the order defined
+         in <a href="#general_behavior_encoding">&sect;general_behavior_encoding</a>.
+         The implementation MAY satisfy this requirement either by rendering
+         the attribute the same way as a <em>pass through attribute</em>, or
+         by attaching the script as a DOM event listener at runtime, provided
+         the chaining order and short-circuit-on-<code>false</code> contract
+         are preserved.
        </p>
      </ul>
      </div>

--- a/spec/src/main/asciidoc/ChangeLog.adoc
+++ b/spec/src/main/asciidoc/ChangeLog.adoc
@@ -105,7 +105,8 @@ Spec: clarify _request_, _session_, and _application_ EL resolution
 
 * Issue ID {issue_tracker_url}1507[1507] +
 New: automatically pass through all HTML on-event attributes via HtmlEvents +
-New: ADDITIONAL_HTML_EVENT_NAMES context parameter
+New: ADDITIONAL_HTML_EVENT_NAMES context parameter +
+Spec: permit on-event attributes to be rendered as DOM event listeners for CSP compatibility
 
 * Issue ID {issue_tracker_url}1501[1501] +
 New: CDI @Observes support for system events


### PR DESCRIPTION
Relaxes two paragraphs in standard-html-renderkit.xml that previously mandated inline-attribute output:

- Behavior Event Attributes (5.0): no longer requires "rendered the same way as a pass through attribute"; instead requires the observable behavior (script invoked on DOM event, chained per §general_behavior_encoding, short-circuit on false).
- Rendering Pass Through Attributes (2.2): adds a carve-out for on* attribute names so implementations MAY arrange runtime event-listener attachment as an equivalent rendering.

Both relaxations are permissive (MAY), so existing impls that emit on* inline remain conformant. Extends the existing #1507 changelog entry.

Closes #2167