### PR TITLE
Generalize Render Response resource push to allow modern mechanisms (HTTP 103 Early Hints)

### DIFF
--- a/spec/src/main/asciidoc/ChangeLog.adoc
+++ b/spec/src/main/asciidoc/ChangeLog.adoc
@@ -12,6 +12,9 @@ pre-Jakarta Faces specification under the JCP.
 
 This release contains the following backwards compatible changes:
 
+* Issue ID {issue_tracker_url}2173[2173] +
+Change: generalize Render Response resource push to allow modern mechanisms such as HTTP 103 Early Hints
+
 * Issue ID {issue_tracker_url}2137[2137] +
 Spec: clarify Jakarta Faces objects valid for _@Inject_ injection
 

--- a/spec/src/main/asciidoc/RequestProcessingLifecycle.adoc
+++ b/spec/src/main/asciidoc/RequestProcessingLifecycle.adoc
@@ -632,13 +632,16 @@ that are unique within the scope of the closest parent _NamingContainer_
 component. The value of the _rendersChildren_ property is handled as
 expected, and may be either _true_ or __false__.
 
-* If running on a container that supports
-Jakarta Servlet 4.0 or later, after any dynamic component manipulations have
+* After any dynamic component manipulations have
 been completed, any resources that have been added to the UIViewRoot,
-such as scripts, images, or stylesheets, and any inline images, must be
-pushed to the client using the Jakarta Servlet Server Push API. All of the
-pushes must be started before any of the HTML of the response is
-rendered to the client.
+such as scripts, images, or stylesheets, and any inline images, should be
+proactively communicated to the client using a server-push or resource-hint
+mechanism provided by the container, such as HTTP 103 Early Hints (RFC 8297).
+Any such hints or pushes must be issued before any of the HTML of the
+response is rendered to the client. The choice of mechanism,
+and whether to perform this optimization at all, is left to the
+implementation and the capabilities of the underlying container and
+connection.
 
 * For partial requests, where partial view
 rendering is required, there must be no content written outside of the


### PR DESCRIPTION
### What

Rewords the Render Response requirement in §2.2.6 (`RequestProcessingLifecycle.adoc`) so it no longer mandates the deprecated Jakarta Servlet Server Push API.

- `must` → `should`
- Drop the reference to the deprecated "Jakarta Servlet Server Push API" (`PushBuilder` / `newPushBuilder()`) and the "Jakarta Servlet 4.0 or later" version gate
- Name **HTTP 103 Early Hints (RFC 8297)** as the example mechanism; the wording stays mechanism-neutral and leaves the choice (and whether to apply the optimization at all) to the implementation and container/connection capabilities
- Keep the ordering constraint: hints/pushes must be issued before any of the HTML is rendered

Also adds a ChangeLog entry under the 5.0 backwards-compatible changes.

### Why

The previous text mandated pushing resources via the Jakarta Servlet Server Push API, which is now deprecated, and HTTP/2 Server Push is no longer honored by browsers (removed from Chrome 106, Oct 2022; never shipped by others) — so the `must` mandated a no-op against a deprecated API.

HTTP/2 Server Push is intentionally **not** named as an example, to avoid enshrining a defunct technology in a forward-looking spec (see issue discussion). It remains permitted via the non-exhaustive "such as" wording.

Closes #2173
