### PR TITLE
Make faces.d.ts a global ambient declaration

### DIFF
--- a/api/src/main/resources/META-INF/resources/jakarta.faces/faces.d.ts
+++ b/api/src/main/resources/META-INF/resources/jakarta.faces/faces.d.ts
@@ -20,7 +20,7 @@
  * @namespace
  * @since 2.0
  */
-export declare namespace faces {
+declare namespace faces {
 
     /**
      * <p class="changed_added_5_0">Project stage values, mirroring


### PR DESCRIPTION
Follow-up to #2155 (re #1598), addressing feedback from @werpu in https://github.com/jakartaee/faces/pull/2155#issuecomment-4589998995.

`faces.d.ts` opened with `export declare namespace faces`. That top-level `export` makes the file a **module**: per the TypeScript rule, any `.d.ts` with a top-level `import`/`export` is a module whose declarations are only visible after an explicit `import`. But `faces.js` ships as a classic global script (`<script src=".../faces.js">`) and the `faces` object is window-scoped, so it's used as a bare global with no import. Modeling it as a module forces a bogus `import { faces }` that corresponds to no real runtime import.

Dropping the top-level `export` (→ `declare namespace faces`) makes the file a **global ambient declaration**, so `faces` is ambiently available — matching how the script actually behaves and aligning with the MyFaces and Tobago typings.

The inner `export` keywords are untouched; those are namespace-member exports, required to expose `faces.ajax`, `faces.getViewState`, etc. So this is a single-keyword change.

See the TypeScript handbook on global declaration files: https://www.typescriptlang.org/docs/handbook/declaration-files/templates/global-d-ts.html

🤖 Generated with Claude Opus 4.8