### PR TITLE
Expose faces.d.ts as a UMD declaration (global + module)

### DIFF
--- a/api/src/main/resources/META-INF/resources/jakarta.faces/faces.d.ts
+++ b/api/src/main/resources/META-INF/resources/jakarta.faces/faces.d.ts
@@ -915,3 +915,6 @@ declare namespace faces {
         export function chain(source: HTMLElement | string, event?: Event | null, ...scripts: string[]): boolean;
     }
 }
+
+export = faces;
+export as namespace faces;


### PR DESCRIPTION
Follow-up to #2176 (re #1598), addressing @werpu's feedback in https://github.com/jakartaee/faces/pull/2155#issuecomment-4589998995.

#2176 made `faces.d.ts` a pure **global** ambient declaration (`declare namespace faces`) so a classic `<script src=".../faces.js">` consumer can use the window-scoped `faces` without an import. Good for consumers — but a global declaration is a **non-module**, and a non-module can't be imported as a type. The Mojarra implementation type-checks `faces.js` against this file via `import ... from ".../faces"`, which then fails with `TS2306: File is not a module`, severing the impl↔spec conformance check.

This adds two lines to make it a **UMD** declaration:

```ts
export = faces;
export as namespace faces;
```

So it is now **both**:
- **global** — `<script>` consumers still use `faces.ajax.request(...)` with no import (verified: a non-module consumer compiles clean);
- **module** — an implementation can `import` it to structurally type-check itself against the spec, and **fails to compile when it drifts** (verified: changing a spec signature breaks the Mojarra rollup build with `TS2322`).

Paired with eclipse-ee4j/mojarra#5758, which bumps the submodule here and switches its spec-type import to the `export = faces` default import. Mojarra's full TS build + 393 jest tests pass against this change.

🤖 Generated with Claude Opus 4.8