### PR TITLE
Fix intermittent Spec1423IT timeout on stylesheet assertion

### DIFF
--- a/tck/faces23/ajax/src/main/webapp/resources/spec1423/addedProgrammatically.js
+++ b/tck/faces23/ajax/src/main/webapp/resources/spec1423/addedProgrammatically.js
@@ -15,8 +15,3 @@
  */
 
 document.getElementById("scriptResult").innerHTML = "addedProgrammatically";
-// Defer the computed-style read to the next layout pass — when this script is appended via a partial
-// response, the matching stylesheet may still be loading, so reading synchronously can miss its rules.
-requestAnimationFrame(() => {
-    document.getElementById("stylesheetResult").innerHTML = window.getComputedStyle(document.body).getPropertyValue("background-color");
-});

--- a/tck/faces23/ajax/src/main/webapp/resources/spec1423/addedViaInclude.js
+++ b/tck/faces23/ajax/src/main/webapp/resources/spec1423/addedViaInclude.js
@@ -15,8 +15,3 @@
  */
 
 document.getElementById("scriptResult").innerHTML = "addedViaInclude";
-// Defer the computed-style read to the next layout pass — when this script is appended via a partial
-// response, the matching stylesheet may still be loading, so reading synchronously can miss its rules.
-requestAnimationFrame(() => {
-    document.getElementById("stylesheetResult").innerHTML = window.getComputedStyle(document.body).getPropertyValue("background-color");
-});

--- a/tck/faces23/ajax/src/main/webapp/spec1423.xhtml
+++ b/tck/faces23/ajax/src/main/webapp/spec1423.xhtml
@@ -44,6 +44,5 @@
         </h:form>
 
         <div id="scriptResult" />
-        <div id="stylesheetResult" />
     </h:body>
 </html>

--- a/tck/faces23/ajax/src/test/java/ee/jakarta/tck/faces/faces23/ajax/Spec1423IT.java
+++ b/tck/faces23/ajax/src/test/java/ee/jakarta/tck/faces/faces23/ajax/Spec1423IT.java
@@ -42,12 +42,12 @@ class Spec1423IT extends BaseITNG {
 		WebElement button;
 
 		assertTrue(page.findElement(By.id("scriptResult")).getText().isEmpty());
-		assertTrue(page.findElement(By.id("stylesheetResult")).getText().isEmpty());
+		assertEquals(NO_BACKGROUND_COLOR, backgroundColor(page));
 
 		button = page.findElement(By.id("form1:addViaHead"));
 		page.guardAjax(button::click);
 		assertEquals("addedViaHead", page.findElement(By.id("scriptResult")).getText().trim());
-		assertTrue(page.findElement(By.id("stylesheetResult")).getText().isEmpty());
+		assertEquals(NO_BACKGROUND_COLOR, backgroundColor(page));
 	}
 
 	/**
@@ -61,14 +61,14 @@ class Spec1423IT extends BaseITNG {
 		WebElement button;
 
 		assertTrue(page.findElement(By.id("scriptResult")).getText().isEmpty());
-		assertTrue(page.findElement(By.id("stylesheetResult")).getText().isEmpty());
+		assertEquals(NO_BACKGROUND_COLOR, backgroundColor(page));
 
 		button = page.findElement(By.id("form1:addViaHead"));
 		page.guardAjax(button::click);
 
-		waitForScriptAndStylesheetResult(page, "addedViaHead", "");
+		waitForScriptAndStylesheetResult(page, "addedViaHead", NO_BACKGROUND_COLOR);
 		assertEquals("addedViaHead", page.findElement(By.id("scriptResult")).getText().trim());
-		assertTrue(page.findElement(By.id("stylesheetResult")).getText().isEmpty());
+		assertEquals(NO_BACKGROUND_COLOR, backgroundColor(page));
 
 		button = page.findElement(By.id("form2:addViaInclude"));
 		page.guardAjax(button::click);
@@ -84,7 +84,7 @@ class Spec1423IT extends BaseITNG {
 		page.guardAjax(button::click);
 
 		assertEquals("addedViaBody", page.findElement(By.id("scriptResult")).getText().trim());
-		assertEquals("rgb(255, 0, 0)", page.findElement(By.id("stylesheetResult")).getText().trim());
+		assertEquals("rgb(255, 0, 0)", backgroundColor(page));
 
 		button = page.findElement(By.id("form1:addProgrammatically"));
 		page.guardAjax(button::click);
@@ -94,28 +94,35 @@ class Spec1423IT extends BaseITNG {
 		button = page.findElement(By.id("form1:addViaHead"));
 		page.guardAjax(button::click);
 
-		assertEquals("rgb(0, 255, 0)", page.findElement(By.id("stylesheetResult")).getText().trim());
+		assertEquals("rgb(0, 255, 0)", backgroundColor(page));
 		assertEquals("addedProgrammatically", page.findElement(By.id("scriptResult")).getText().trim());
 
 		button = page.findElement(By.id("form1:addViaBody"));
 		page.guardAjax(button::click);
 		assertEquals("addedProgrammatically", page.findElement(By.id("scriptResult")).getText().trim());
-		assertEquals("rgb(0, 255, 0)", page.findElement(By.id("stylesheetResult")).getText().trim());
+		assertEquals("rgb(0, 255, 0)", backgroundColor(page));
 
 		button = page.findElement(By.id("form2:addViaInclude"));
 		page.guardAjax(button::click);
 		assertEquals("addedProgrammatically", page.findElement(By.id("scriptResult")).getText().trim());
-		assertEquals("rgb(0, 255, 0)", page.findElement(By.id("stylesheetResult")).getText().trim());
+		assertEquals("rgb(0, 255, 0)", backgroundColor(page));
 	}
 	
+	// Computed background-color of an unstyled body in Chrome (i.e. no stylesheet resource applied yet).
+	private static final String NO_BACKGROUND_COLOR = "rgba(0, 0, 0, 0)";
+
 	// guardAjax returns once the partial response has been processed and the new <script>/<link>
 	// resource tags have been inserted into the DOM, but the browser still has to fetch, parse and
-	// execute them asynchronously before scriptResult/stylesheetResult reflect the new values.
-	// The stylesheetResult update is additionally deferred to the next animation frame so the
-	// computed style is read after the matching stylesheet has applied. Poll until both settle.
-	private void waitForScriptAndStylesheetResult(WebPage page, String expectedScriptResult, String expectedStylesheetResult) {
+	// apply them asynchronously before the script result and the matching stylesheet take effect.
+	// The injected <link> loads over the network, so its rules only enter the CSSOM some frames later;
+	// read the live computed style on every poll until both the script and the stylesheet have settled.
+	private void waitForScriptAndStylesheetResult(WebPage page, String expectedScriptResult, String expectedBackgroundColor) {
 		page.waitForCondition(wd -> page.findElement(By.id("scriptResult")).getText().trim().equals(expectedScriptResult)
-				&& page.findElement(By.id("stylesheetResult")).getText().trim().equals(expectedStylesheetResult));
+				&& backgroundColor(page).equals(expectedBackgroundColor));
+	}
+
+	private static String backgroundColor(WebPage page) {
+		return String.valueOf(page.executeScript("return window.getComputedStyle(document.body).getPropertyValue('background-color')"));
 	}
 
 }


### PR DESCRIPTION
## Problem

`Spec1423IT` failed intermittently with a Selenium `TimeoutException` on the script+stylesheet assertion.

The stylesheet assertions read a `#stylesheetResult` div that the injected resource script (`addedViaInclude.js` / `addedProgrammatically.js`) latched **exactly once** inside a single `requestAnimationFrame`. A dynamically inserted `<link rel="stylesheet">` loads asynchronously, so when that one frame fired before the stylesheet entered the CSSOM, a stale `background-color` was latched into the div and never corrected. The poll then exhausted its 10 s timeout — or a later non-waiting `assertEquals` read the stale div and failed. On warm/cached runs the load won the race, hence the flakiness.

## Fix

Assert the stylesheet via the **live computed `background-color`** of the body, read via `executeScript` on every poll iteration, so the wait absorbs however long the async CSS load takes regardless of frame timing. This applies to both the wait helper and the four non-waiting `assertEquals` (otherwise a stale latch would just turn a timeout into a value mismatch at the next div read).

Removed the now-unused `#stylesheetResult` div and the dead `requestAnimationFrame` blocks from the two resource scripts.

`#scriptResult` is unchanged — it is set synchronously and was never part of the race.

## Verification

20 consecutive runs of `Spec1423IT` (both `spec1423Basic` and `spec1423`), each a fresh GlassFish deploy: 20/20 green.

🤖 Generated with Claude Opus 4.8