### PR TITLE
Add Issue4128IT: component binding must not duplicate its action listener

### DIFF
--- a/tck/faces23/facelets/src/main/java/ee/jakarta/tck/faces/faces23/facelets/Issue4128Bean.java
+++ b/tck/faces23/facelets/src/main/java/ee/jakarta/tck/faces/faces23/facelets/Issue4128Bean.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) Contributors to Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.faces.faces23.facelets;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+
+import jakarta.faces.component.html.HtmlDataTable;
+import jakarta.faces.view.ViewScoped;
+import jakarta.inject.Named;
+
+@Named
+@ViewScoped
+public class Issue4128Bean implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    // The table is bound to this property: the component instance is reused across postbacks, and the
+    // Facelets refresh must locate-and-reuse it (not recreate its subtree) -- the condition the test exercises.
+    private HtmlDataTable dataTable;
+
+    private List<String> rows = new ArrayList<>(List.of("row"));
+
+    // Counts action-listener invocations: the regression recreated the bound button and fired this twice per click.
+    private int actionCount;
+
+    public void addRow() {
+        actionCount++;
+        rows.add("row" + actionCount);
+        dataTable.setRows(dataTable.getRows() + 1);
+    }
+
+    public HtmlDataTable getDataTable() {
+        return dataTable;
+    }
+
+    public void setDataTable(HtmlDataTable dataTable) {
+        this.dataTable = dataTable;
+    }
+
+    public List<String> getRows() {
+        return rows;
+    }
+
+    public int getActionCount() {
+        return actionCount;
+    }
+}

--- a/tck/faces23/facelets/src/main/webapp/issue4128.xhtml
+++ b/tck/faces23/facelets/src/main/webapp/issue4128.xhtml
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<!--
+
+    Copyright (c) Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+<html xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core">
+    <h:head>
+        <title>Issue4128IT</title>
+    </h:head>
+    <h:body>
+        <h:form id="form">
+            <h:dataTable id="table" binding="#{issue4128Bean.dataTable}" value="#{issue4128Bean.rows}" var="row">
+                <h:column>
+                    <f:facet name="header">
+                        <h:commandButton id="add" value="Add row" actionListener="#{issue4128Bean.addRow()}" />
+                    </f:facet>
+                    <h:outputText value="#{row}" />
+                </h:column>
+            </h:dataTable>
+            <h:outputText id="count" value="#{issue4128Bean.actionCount}" />
+        </h:form>
+    </h:body>
+</html>

--- a/tck/faces23/facelets/src/test/java/ee/jakarta/tck/faces/faces23/facelets/Issue4128IT.java
+++ b/tck/faces23/facelets/src/test/java/ee/jakarta/tck/faces/faces23/facelets/Issue4128IT.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) Contributors to Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.faces.faces23.facelets;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import jakarta.faces.component.html.HtmlDataTable;
+
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.By;
+
+import ee.jakarta.tck.faces.util.selenium.BaseITNG;
+import ee.jakarta.tck.faces.util.selenium.WebPage;
+
+class Issue4128IT extends BaseITNG {
+
+    /**
+     * A command button bound into a dataTable via component binding must have its action invoked
+     * exactly once per click. A Facelets-refresh regression recreated the bound subtree during the
+     * postback build instead of reusing it, registering the action listener twice so it fired twice
+     * per click. Each click must advance the counter by exactly one.
+     *
+     * @see HtmlDataTable
+     * @see https://github.com/eclipse-ee4j/mojarra/issues/4128
+     */
+    @Test
+    void boundDataTableActionFiresOncePerClick() {
+        WebPage page = getPage("issue4128.xhtml");
+        assertEquals("0", page.findElement(By.id("form:count")).getText());
+
+        page.guardHttp(page.findElement(By.id("form:table:add"))::click);
+        assertEquals("1", page.findElement(By.id("form:count")).getText());
+
+        page.guardHttp(page.findElement(By.id("form:table:add"))::click);
+        assertEquals("2", page.findElement(By.id("form:count")).getText());
+
+        page.guardHttp(page.findElement(By.id("form:table:add"))::click);
+        assertEquals("3", page.findElement(By.id("form:count")).getText());
+    }
+}


### PR DESCRIPTION
Discovered while analyzing poor RESTORE_VIEW performance for Mojarra https://github.com/eclipse-ee4j/mojarra/issues/5753. Part of current (inefficient) RESTORE_VIEW impl in Mojarra was caused by fix for https://github.com/eclipse-ee4j/mojarra/issues/4128 and then https://github.com/eclipse-ee4j/mojarra/issues/4811 attempted to fix it but in hindsight the 4811 fix is unnecessary when the fix for 4128 is rearchitected because MyFaces has none of the approach done in 4811.

---

A UICommand bound into a dataTable via the binding attribute must invoke its action exactly once per click. When the bound component lives in a longer-than-request scope (the spec-discouraged but legal binding-on-@ViewScoped pattern), the Facelets refresh must reuse the existing component during the postback build rather than recreate its subtree -- recreating it registers the action listener twice, so it fires twice per click. See eclipse-ee4j/mojarra#4128.

The original regression test lived under mojarra's test/javaee6web and was dropped in the 3.0->4.0 migration via https://github.com/eclipse-ee4j/mojarra/commit/ed55113a3; this ports it (DuplicateController + issue4124.xhtml + Issue4124IT) to a modern CDI / Jakarta-namespace / Selenium IT under faces23/facelets, where the module already pins PARTIAL_STATE_SAVING=true (the bug is PSS-specific).

This IT ensures that any performance optimizations to RESTORE_VIEW won't regress this corner case issue. This IT confirmed failed when 4128 is reverted on a local build.