### PR TITLE
Align h:panelGroup rendering docs with actual wrapper behavior

### DIFF
--- a/api/src/main/java/jakarta/faces/component/html/HtmlPanelGroup.java
+++ b/api/src/main/java/jakarta/faces/component/html/HtmlPanelGroup.java
@@ -78,8 +78,11 @@ public class HtmlPanelGroup extends UIPanel implements ClientBehaviorHolder {
      *
      * @return the property value
      * <p>
-     * Contents: The type of layout markup to use when rendering this group. If the value is "block" the renderer must
-     * produce an HTML "div" element. Otherwise HTML "span" element must be produced.
+     * Contents: The type of layout markup to use when rendering this group. <span class="changed_modified_5_0">When a
+     * wrapper element is rendered, a value of "block" produces an HTML "div" element and any other value produces an
+     * HTML "span" element. A wrapper element is only rendered when the component has a renderable client id or any
+     * renderable attribute ("style", "styleClass", any passthrough attribute, or an attached client behavior); when
+     * there is nothing renderable to carry, no wrapper element is rendered.</span>
      */
     public java.lang.String getLayout() {
         return (java.lang.String) getStateHelper().eval(PropertyKeys.layout);

--- a/api/src/main/renderkitdoc/standard-html-renderkit.xml
+++ b/api/src/main/renderkitdoc/standard-html-renderkit.xml
@@ -8412,18 +8412,17 @@ this application, and passing the result through the
             </renderer-extension>
         </renderer>
         <renderer>
-            <description>Intended for use in situations when only one
+            <description><![CDATA[Intended for use in situations when only one
       UIComponent child can be nested, such as in the case of facets.
-      If the "style" or "styleClass" attributes are present, and the "layout"
-      attribute is present with a value of "block", render a "div" element,
-      outputting the value of the "style" attribute as the value of the 
-      "style" attribute and the value of the "styleClass" attribute as the
-      value of the "class" attribute.  Otherwise, if the "layout" attribute
-      is not present, or the "layout" attribute contains a value other than
-      "block", render a "span" element, outputting the value of the 
-      "style" attribute as the value of the "style" attribute, and the value 
-      of the "styleClass" attribute as the value of the "class"
-      attribute. </description>
+      <span class="changed_modified_5_0">A wrapper element is rendered only when the component has a renderable
+      client id, or when any renderable attribute is present ("style",
+      "styleClass", any passthrough attribute, or an attached client behavior);
+      otherwise no wrapper element is rendered and only the children are
+      rendered.  When a wrapper element is rendered, a "layout" value of "block"
+      produces a "div" element and any other value (or an absent "layout")
+      produces a "span" element, outputting the value of the "style" attribute
+      as the value of the "style" attribute and the value of the "styleClass"
+      attribute as the value of the "class" attribute.</span>]]></description>
             <component-family>jakarta.faces.Panel</component-family>
             <renderer-type>jakarta.faces.Group</renderer-type>
             <renderer-class />
@@ -8455,12 +8454,13 @@ this application, and passing the result through the
                 </attribute-extension>
             </attribute>
             <attribute>
-                <description>
-          The type of layout markup to use when rendering this group.
-          If the value is "block" the renderer must produce an HTML
-          "div" element.  Otherwise HTML "span" element must
-          be produced.
-                </description>
+                <description><![CDATA[The type of layout markup to use when rendering this group.
+          <span class="changed_modified_5_0">When a wrapper element is rendered, a value of "block" produces an HTML
+          "div" element and any other value produces an HTML "span" element.  A
+          wrapper element is only rendered when the component has a renderable
+          client id or any renderable attribute ("style", "styleClass", any
+          passthrough attribute, or an attached client behavior); when there is
+          nothing renderable to carry, no wrapper element is rendered.</span>]]></description>
                 <display-name>Layout</display-name>
                 <icon />
                 <attribute-name>layout</attribute-name>

--- a/api/src/main/vdldoc/faces.html.taglib.xml
+++ b/api/src/main/vdldoc/faces.html.taglib.xml
@@ -7863,22 +7863,18 @@
     </tag>
     <tag>
         <description>
-            Intended for use in situations when only one
+            <![CDATA[Intended for use in situations when only one
             UIComponent child can be nested, such as in the case of facets.
-            If the "style" or "styleClass" attributes are present, and the
-            "layout"
-            attribute is present with a value of "block", render a "div"
-            element,
-            outputting the value of the "style" attribute as the value of the
-            "style" attribute and the value of the "styleClass" attribute as the
-            value of the "class" attribute. Otherwise, if the "layout" attribute
-            is not present, or the "layout" attribute contains a value other
-            than
-            "block", render a "span" element, outputting the value of the
-            "style" attribute as the value of the "style" attribute, and the
-            value
-            of the "styleClass" attribute as the value of the "class"
-            attribute.
+            <span class="changed_modified_5_0">A wrapper element is rendered only when the component has a renderable
+            client id, or when any renderable attribute is present ("style",
+            "styleClass", any passthrough attribute, or an attached client
+            behavior); otherwise no wrapper element is rendered and only the
+            children are rendered. When a wrapper element is rendered, a "layout"
+            value of "block" produces a "div" element and any other value (or an
+            absent "layout") produces a "span" element, outputting the value of
+            the "style" attribute as the value of the "style" attribute and the
+            value of the "styleClass" attribute as the value of the "class"
+            attribute.</span>]]>
         </description>
         <tag-name>panelGroup</tag-name>
         <component>
@@ -7907,10 +7903,14 @@
         </attribute>
         <attribute>
             <description>
-                The type of layout markup to use when rendering this group.
-                If the value is "block" the renderer must produce an HTML
-                "div" element. Otherwise HTML "span" element must
-                be produced.
+                <![CDATA[The type of layout markup to use when rendering this group.
+                <span class="changed_modified_5_0">When a wrapper element is rendered, a value of "block" produces
+                an HTML "div" element and any other value produces an HTML "span"
+                element. A wrapper element is only rendered when the component has
+                a renderable client id or any renderable attribute ("style",
+                "styleClass", any passthrough attribute, or an attached client
+                behavior); when there is nothing renderable to carry, no wrapper
+                element is rendered.</span>]]>
             </description>
             <name>layout</name>
             <required>false</required>


### PR DESCRIPTION
Doc-only resolution of the conflicting `h:panelGroup` / `jakarta.faces.Group` rendering docs (option **b** from #2182). No behavior change — the wrapper-omission/`layout`-as-trigger impl work stays on its own ticket.

## Problem

The four normative sources contradicted each other and reality:

- **layout property/attribute text** (javadoc, vdldoc, renderkitdoc) claimed `layout="block"` *unconditionally* produces a `div`.
- **renderer/tag descriptions** (vdldoc, renderkitdoc) gated the wrapper on `style`/`styleClass` only.

Neither matches the implementations, which render a wrapper element only when there is something renderable to carry it (client id, `style`, `styleClass`, any passthrough attribute, or an attached client behavior), and only *then* select `div` vs `span` by `layout`.

## Change

Documented the existing behavior across all five doc locations, standardized on the broader MyFaces "any renderable attribute" gate as the specified minimum:

- `HtmlPanelGroup.getLayout()` javadoc
- `faces.html.taglib.xml` — `panelGroup` tag description + `layout` attribute description
- `standard-html-renderkit.xml` — `jakarta.faces.Group` renderer description + `layout` attribute description

Reworded portions are marked `changed_modified_5_0`; the unchanged lead sentence stays outside the change span.

Refs #2182

🤖 Generated with Claude Opus 4.8