### PR TITLE
Add IT for Mojarra #5809: search expression must skip unrendered

### DIFF
--- a/tck/faces23/search-expression/src/main/java/ee/jakarta/tck/faces/faces23/search_expression/Issue5809.java
+++ b/tck/faces23/search-expression/src/main/java/ee/jakarta/tck/faces/faces23/search_expression/Issue5809.java
@@ -26,6 +26,8 @@ import jakarta.inject.Named;
 public class Issue5809 {
 
     private boolean listTouched;
+    private boolean revealed;
+    private String message = "";
 
     /**
      * Backs the value of an unrendered {@code h:dataTable}. Reading it forces row
@@ -39,5 +41,22 @@ public class Issue5809 {
 
     public boolean isListTouched() {
         return listTouched;
+    }
+
+    /**
+     * Reveals a component that is unrendered in the initial request but rendered after
+     * the ajax call, and updates the always-rendered target's message.
+     */
+    public void action() {
+        revealed = true;
+        message = "updated";
+    }
+
+    public boolean isRevealed() {
+        return revealed;
+    }
+
+    public String getMessage() {
+        return message;
     }
 }

--- a/tck/faces23/search-expression/src/main/java/ee/jakarta/tck/faces/faces23/search_expression/Issue5809.java
+++ b/tck/faces23/search-expression/src/main/java/ee/jakarta/tck/faces/faces23/search_expression/Issue5809.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.faces.faces23.search_expression;
+
+import java.util.List;
+
+import jakarta.enterprise.context.RequestScoped;
+import jakarta.inject.Named;
+
+@Named
+@RequestScoped
+public class Issue5809 {
+
+    private boolean listTouched;
+
+    /**
+     * Backs the value of an unrendered {@code h:dataTable}. Reading it forces row
+     * iteration, which only happens when a tree visit descends into the unrendered
+     * subtree - i.e. when the search expression resolution failed to skip it.
+     */
+    public List<String> getList() {
+        listTouched = true;
+        return List.of("item");
+    }
+
+    public boolean isListTouched() {
+        return listTouched;
+    }
+}

--- a/tck/faces23/search-expression/src/main/webapp/issue5809.xhtml
+++ b/tck/faces23/search-expression/src/main/webapp/issue5809.xhtml
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<!--
+
+    Copyright (c) 2026 Contributors to the Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<html lang="en"
+    xmlns:f="jakarta.faces.core"
+    xmlns:h="jakarta.faces.html">
+    <h:head>
+        <title>Issue5809IT - search expression must not traverse unrendered components</title>
+    </h:head>
+    <h:body>
+        <h:form id="form">
+
+            <!-- Unrendered subtree placed before the resolved target so that
+                 RESOLVE_SINGLE_COMPONENT does not stop the visit before reaching it. -->
+            <h:dataTable id="hidden" rendered="false" value="#{issue5809.list}" var="item">
+                <h:column>#{item}</h:column>
+            </h:dataTable>
+
+            <h:panelGroup id="target" layout="block">target</h:panelGroup>
+
+            <h:commandButton id="button" value="Action">
+                <f:ajax render="@root:@id(target)" />
+            </h:commandButton>
+
+            <h:outputText id="listTouched" value="#{issue5809.listTouched}" />
+
+        </h:form>
+    </h:body>
+</html>

--- a/tck/faces23/search-expression/src/main/webapp/issue5809conditional.xhtml
+++ b/tck/faces23/search-expression/src/main/webapp/issue5809conditional.xhtml
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<!--
+
+    Copyright (c) 2026 Contributors to the Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<html lang="en"
+    xmlns:f="jakarta.faces.core"
+    xmlns:h="jakarta.faces.html">
+    <h:head>
+        <title>Issue5809IT - render-after-ajax must not traverse an unrendered subtree</title>
+    </h:head>
+    <h:body>
+        <h:form id="form">
+
+            <!-- Unrendered subtree placed BEFORE the resolved target, so resolving
+                 @id(wrapper) must traverse past it. Without SKIP_UNRENDERED the visit
+                 iterates this table's rows and invokes its model getter (recorded via
+                 listTouched); with the fix the table is skipped. -->
+            <h:dataTable id="hidden" rendered="false" value="#{issue5809.list}" var="item">
+                <h:column>#{item}</h:column>
+            </h:dataTable>
+
+            <!-- Always-rendered wrapper whose content becomes visible only after the
+                 ajax action. The wrapper provides the client-side markup the partial
+                 response replaces, which is what makes "render after ajax" work. -->
+            <h:panelGroup id="wrapper" layout="block">
+                <h:outputText id="revealed" value="#{issue5809.message}" rendered="#{issue5809.revealed}" />
+            </h:panelGroup>
+
+            <h:commandButton id="button" value="Action" action="#{issue5809.action}">
+                <f:ajax render="@root:@id(wrapper)" />
+            </h:commandButton>
+
+            <h:outputText id="listTouched" value="#{issue5809.listTouched}" />
+
+        </h:form>
+    </h:body>
+</html>

--- a/tck/faces23/search-expression/src/test/java/ee/jakarta/tck/faces/faces23/search_expression/Issue5809IT.java
+++ b/tck/faces23/search-expression/src/test/java/ee/jakarta/tck/faces/faces23/search_expression/Issue5809IT.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.faces.faces23.search_expression;
+
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+
+import ee.jakarta.tck.faces.util.selenium.BaseITNG;
+import ee.jakarta.tck.faces.util.selenium.WebPage;
+
+public class Issue5809IT extends BaseITNG {
+
+    /**
+     * Resolving an f:ajax render expression such as {@code @root:@id(...)} must not
+     * traverse unrendered components. An unrendered subtree has no client-side
+     * markup and can never be a useful ajax target, so the resolution visit must
+     * skip it - mirroring the partial render visit, which already does so.
+     *
+     * @see https://github.com/eclipse-ee4j/mojarra/issues/5809
+     */
+    @Test
+    void test() throws Exception {
+        WebPage page = getPage("issue5809.xhtml");
+
+        // The rendered target must still resolve to its client id.
+        WebElement button = page.findElement(By.id("form:button"));
+        assertTrue(page.getBehaviorScript(button).contains("form:target"));
+
+        // The unrendered h:dataTable must not have been traversed, so its model
+        // getter must not have been invoked during the render expression resolution.
+        WebElement listTouched = page.findElement(By.id("form:listTouched"));
+        assertEquals("false", listTouched.getText());
+    }
+}

--- a/tck/faces23/search-expression/src/test/java/ee/jakarta/tck/faces/faces23/search_expression/Issue5809IT.java
+++ b/tck/faces23/search-expression/src/test/java/ee/jakarta/tck/faces/faces23/search_expression/Issue5809IT.java
@@ -18,6 +18,7 @@ package ee.jakarta.tck.faces.faces23.search_expression;
 
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
@@ -49,5 +50,38 @@ public class Issue5809IT extends BaseITNG {
         // getter must not have been invoked during the render expression resolution.
         WebElement listTouched = page.findElement(By.id("form:listTouched"));
         assertEquals("false", listTouched.getText());
+    }
+
+    /**
+     * Resolving a render target located past an unrendered subtree must skip that
+     * subtree, and doing so must not break revealing a component only after the ajax
+     * call - the "render after ajax" case raised against this change.
+     * <p>
+     * The component that becomes visible after the action is wrapped in an
+     * always-rendered {@code wrapper}: that wrapper supplies the client-side markup
+     * the partial response replaces, which is what makes render-after-ajax work at
+     * all (a partial update for an id with no element throws client-side). The
+     * wrapper is rendered, so {@code SKIP_UNRENDERED} never skips it; the unrendered
+     * table that precedes it is skipped rather than row-iterated.
+     *
+     * @see https://github.com/eclipse-ee4j/mojarra/issues/5809
+     */
+    @Test
+    void testRenderAfterAjaxDoesNotTraverseUnrenderedSubtree() throws Exception {
+        WebPage page = getPage("issue5809conditional.xhtml");
+
+        // Resolving @id(wrapper) must skip the unrendered table that precedes it
+        // instead of iterating its rows and invoking the model getter.
+        WebElement button = page.findElement(By.id("form:button"));
+        assertTrue(page.getBehaviorScript(button).contains("form:wrapper"));
+        assertEquals("false", page.findElement(By.id("form:listTouched")).getText());
+
+        // The revealed content is not rendered yet.
+        assertFalse(page.containsText("updated"));
+
+        // After the ajax call the component that becomes rendered shows up through its
+        // wrapper - skipping the unrendered subtree does not break render-after-ajax.
+        page.guardAjax(() -> page.findElement(By.id("form:button")).click());
+        assertTrue(page.containsText("updated"));
     }
 }


### PR DESCRIPTION
## Summary

Adds an integration test asserting that resolving an `f:ajax` render
expression such as `@root:@id(target)` does **not** traverse unrendered
components.

An unrendered subtree has no client-side markup and can never be a
useful ajax target, so the resolution visit must skip it — mirroring the
partial render visit, which already passes `SKIP_UNRENDERED`.

## How it works (standard components only)

- An unrendered `h:dataTable` is placed **before** the resolved target so
  that `RESOLVE_SINGLE_COMPONENT` does not stop the visit before reaching
  it.
- The table's model getter (`#{issue5809.list}`) flips a request-scoped
  flag. Reading it forces row iteration, which only happens when a tree
  visit descends into the unrendered subtree.
- The flag is rendered into the page; the test asserts it stayed `false`,
  and that the rendered target still resolved into the ajax behavior
  script.

Red against an unfixed build, green once the render expression
resolution skips unrendered.

Covers eclipse-ee4j/mojarra#5809.
