### PR TITLE
Add IT covering search expression resolution across unrendered subtrees

### DIFF
--- a/tck/faces23/search-expression/src/main/java/ee/jakarta/tck/faces/faces23/search_expression/Issue5809.java
+++ b/tck/faces23/search-expression/src/main/java/ee/jakarta/tck/faces/faces23/search_expression/Issue5809.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.faces.faces23.search_expression;
+
+import java.util.List;
+
+import jakarta.enterprise.inject.Model;
+
+@Model
+public class Issue5809 {
+
+    private boolean listTouched;
+
+    /**
+     * Backs the value of an {@code h:dataTable}. Reading it forces row iteration,
+     * which happens whenever a tree visit descends into the table - including the
+     * search expression resolution visit, which by design does not skip unrendered
+     * subtrees.
+     */
+    public List<String> getList() {
+        listTouched = true;
+        return List.of("one", "two", "three");
+    }
+
+    public boolean isListTouched() {
+        return listTouched;
+    }
+}

--- a/tck/faces23/search-expression/src/main/webapp/issue5809uc1.xhtml
+++ b/tck/faces23/search-expression/src/main/webapp/issue5809uc1.xhtml
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<!--
+
+    Copyright (c) 2026 Contributors to the Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<html lang="en"
+    xmlns:f="jakarta.faces.core"
+    xmlns:h="jakarta.faces.html">
+    <h:head>
+        <title>Issue5809IT - UC1: unrendered target stays resolvable</title>
+    </h:head>
+    <h:body>
+        <h:form id="form">
+
+            <!-- The target is currently rendered="false" but exists in the tree. Its
+                 client id must still be resolved into the button's ajax request, so
+                 that toggling its visibility later does not require re-rendering the
+                 button (the "failsafe" coupling search expressions deliberately keep). -->
+            <h:commandButton id="button" value="Action">
+                <f:ajax render="@root:@id(target)" />
+            </h:commandButton>
+
+            <h:panelGroup id="target" layout="block" rendered="false">target</h:panelGroup>
+
+        </h:form>
+    </h:body>
+</html>

--- a/tck/faces23/search-expression/src/main/webapp/issue5809uc2.xhtml
+++ b/tck/faces23/search-expression/src/main/webapp/issue5809uc2.xhtml
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<!--
+
+    Copyright (c) 2026 Contributors to the Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<html lang="en"
+    xmlns:f="jakarta.faces.core"
+    xmlns:h="jakarta.faces.html">
+    <h:head>
+        <title>Issue5809IT - UC2: mixed rendered and unrendered targets</title>
+    </h:head>
+    <h:body>
+        <h:form id="form">
+
+            <!-- One rendered, one unrendered target in a single render list. Both must
+                 resolve; an unrendered target must not abort resolution of the rest. -->
+            <h:commandButton id="button" value="Action">
+                <f:ajax render="@root:@id(shown) @root:@id(hidden)" />
+            </h:commandButton>
+
+            <h:panelGroup id="shown" layout="block">shown</h:panelGroup>
+            <h:panelGroup id="hidden" layout="block" rendered="false">hidden</h:panelGroup>
+
+        </h:form>
+    </h:body>
+</html>

--- a/tck/faces23/search-expression/src/main/webapp/issue5809uc3.xhtml
+++ b/tck/faces23/search-expression/src/main/webapp/issue5809uc3.xhtml
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<!--
+
+    Copyright (c) 2026 Contributors to the Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<html lang="en"
+    xmlns:f="jakarta.faces.core"
+    xmlns:h="jakarta.faces.html">
+    <h:head>
+        <title>Issue5809IT - UC3: @root:@id resolves past an unrendered subtree</title>
+    </h:head>
+    <h:body>
+        <h:form id="form">
+
+            <!-- Shape of the reported reproducer. @root:@id(pnlShown1) is resolved with
+                 RESOLVE_SINGLE_COMPONENT, so the visit stops at the first match. The
+                 unrendered subtree is placed BEFORE the target on purpose: the visit
+                 traverses it before reaching pnlShown1, which is exactly the behavior
+                 #5809 is about. By design the visit does not skip unrendered subtrees,
+                 so the table's model getter runs during resolution (asserted below via
+                 listTouched). This is intended; do not "fix" it by passing
+                 SKIP_UNRENDERED - see https://github.com/eclipse-ee4j/mojarra/issues/5809 -->
+            <h:commandButton id="button" value="Action">
+                <f:ajax render="@root:@id(pnlShown1)" />
+            </h:commandButton>
+
+            <h:panelGroup id="pnlHidden" rendered="false">
+                <h:dataTable id="tblHidden" value="#{issue5809.list}" var="item">
+                    <h:column><h:outputText value="#{item}" /></h:column>
+                </h:dataTable>
+            </h:panelGroup>
+
+            <h:panelGroup id="pnlShown1" layout="block">shown1</h:panelGroup>
+            <h:panelGroup id="pnlShown2" layout="block">shown2</h:panelGroup>
+
+            <!-- Rendered after the button, so it reflects whether the resolution visit
+                 (run during the button's encode) descended into the unrendered table. -->
+            <h:outputText id="listTouched" value="#{issue5809.listTouched}" />
+
+        </h:form>
+    </h:body>
+</html>

--- a/tck/faces23/search-expression/src/main/webapp/issue5809uc4.xhtml
+++ b/tck/faces23/search-expression/src/main/webapp/issue5809uc4.xhtml
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<!--
+
+    Copyright (c) 2026 Contributors to the Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<html lang="en"
+    xmlns:f="jakarta.faces.core"
+    xmlns:h="jakarta.faces.html">
+    <h:head>
+        <title>Issue5809IT - UC4: resolution traverses a rendered dataTable</title>
+    </h:head>
+    <h:body>
+        <h:form id="form">
+
+            <!-- The target sits after a rendered, row-stamped h:dataTable. Resolving
+                 @root:@id(after) must visit through the table's rows and still reach
+                 the later sibling. Guards the indexed-traversal path. -->
+            <h:commandButton id="button" value="Action">
+                <f:ajax render="@root:@id(after)" />
+            </h:commandButton>
+
+            <h:dataTable id="table" value="#{issue5809.list}" var="item">
+                <h:column><h:outputText id="cell" value="#{item}" /></h:column>
+            </h:dataTable>
+
+            <h:panelGroup id="after" layout="block">after</h:panelGroup>
+
+        </h:form>
+    </h:body>
+</html>

--- a/tck/faces23/search-expression/src/main/webapp/issue5809uc5.xhtml
+++ b/tck/faces23/search-expression/src/main/webapp/issue5809uc5.xhtml
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<!--
+
+    Copyright (c) 2026 Contributors to the Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<html lang="en"
+    xmlns:f="jakarta.faces.core"
+    xmlns:h="jakarta.faces.html">
+    <h:head>
+        <title>Issue5809IT - UC5: f:ajax inside an iterating component</title>
+    </h:head>
+    <h:body>
+        <h:form id="form">
+
+            <!-- Resolved before the table so RESOLVE_SINGLE_COMPONENT finds it quickly. -->
+            <h:panelGroup id="status" layout="block">status</h:panelGroup>
+
+            <!-- Each row's f:ajax source is row-stamped (form:table:N:in). Resolving
+                 @root:@id(status) from within the iteration must still work per row. -->
+            <h:dataTable id="table" value="#{issue5809.list}" var="item">
+                <h:column>
+                    <h:inputText id="in">
+                        <f:ajax render="@root:@id(status)" />
+                    </h:inputText>
+                </h:column>
+            </h:dataTable>
+
+        </h:form>
+    </h:body>
+</html>

--- a/tck/faces23/search-expression/src/main/webapp/issue5809uc6.xhtml
+++ b/tck/faces23/search-expression/src/main/webapp/issue5809uc6.xhtml
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<!--
+
+    Copyright (c) 2026 Contributors to the Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<html lang="en"
+    xmlns:f="jakarta.faces.core"
+    xmlns:h="jakarta.faces.html">
+    <h:head>
+        <title>Issue5809IT - UC6: relative keywords resolve</title>
+    </h:head>
+    <h:body>
+        <h:form id="form">
+
+            <!-- @form is a passthrough keyword: emitted as-is, resolved client-side. -->
+            <h:inputText id="inForm">
+                <f:ajax render="@form" />
+            </h:inputText>
+
+            <!-- @parent resolves server-side to the enclosing panelGroup (form:wrap). -->
+            <h:panelGroup id="wrap" layout="block">
+                <h:inputText id="inParent">
+                    <f:ajax render="@parent" />
+                </h:inputText>
+            </h:panelGroup>
+
+            <!-- @previous resolves server-side to the preceding sibling (form:inPrevA). -->
+            <h:inputText id="inPrevA" />
+            <h:inputText id="inPrevB">
+                <f:ajax render="@previous" />
+            </h:inputText>
+
+        </h:form>
+    </h:body>
+</html>

--- a/tck/faces23/search-expression/src/test/java/ee/jakarta/tck/faces/faces23/search_expression/Issue5809IT.java
+++ b/tck/faces23/search-expression/src/test/java/ee/jakarta/tck/faces/faces23/search_expression/Issue5809IT.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.faces.faces23.search_expression;
+
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+
+import ee.jakarta.tck.faces.util.selenium.BaseITNG;
+import ee.jakarta.tck.faces.util.selenium.WebPage;
+
+/**
+ * Characterization tests for the agreed, by-design behavior of search expressions
+ * used as f:ajax render targets. They lock in the conclusion of
+ * <a href="https://github.com/eclipse-ee4j/mojarra/issues/5809">mojarra #5809</a>:
+ * resolution scans the whole tree and deliberately does not skip unrendered
+ * subtrees, so currently-unrendered targets stay resolvable and the coupling
+ * between an ajax source and its targets is not tied to their render state.
+ * These guard against traversal/perf refactors silently changing it.
+ */
+public class Issue5809IT extends BaseITNG {
+
+    /**
+     * UC1: a target that is currently {@code rendered="false"} must still be
+     * resolved into the source's ajax request, so toggling its visibility later
+     * does not require re-rendering the source.
+     */
+    @Test
+    void testUnrenderedTargetStaysResolvable() throws Exception {
+        WebPage page = getPage("issue5809uc1.xhtml");
+
+        WebElement button = page.findElement(By.id("form:button"));
+        assertTrue(page.getBehaviorScript(button).contains("form:target"),
+                "unrendered target must still resolve");
+    }
+
+    /**
+     * UC2: in a render list mixing a rendered and an unrendered target, both must
+     * resolve - the unrendered one must not abort resolution of the rest.
+     */
+    @Test
+    void testMixedRenderedAndUnrenderedTargets() throws Exception {
+        WebPage page = getPage("issue5809uc2.xhtml");
+
+        WebElement button = page.findElement(By.id("form:button"));
+        String script = page.getBehaviorScript(button);
+        assertTrue(script.contains("form:shown"), "rendered target must resolve");
+        assertTrue(script.contains("form:hidden"), "unrendered target must resolve");
+    }
+
+    /**
+     * UC3: {@code @root:@id(...)} resolving a target located past an unrendered
+     * subtree must traverse that subtree (by design, no SKIP_UNRENDERED), reaching
+     * the model getter of the unrendered table along the way. Pins the exact #5809
+     * behavior so it cannot be silently reverted.
+     */
+    @Test
+    void testResolutionTraversesUnrenderedSubtree() throws Exception {
+        WebPage page = getPage("issue5809uc3.xhtml");
+
+        WebElement button = page.findElement(By.id("form:button"));
+        assertTrue(page.getBehaviorScript(button).contains("form:pnlShown1"),
+                "target past the unrendered subtree must resolve");
+
+        String listTouched = page.findElement(By.id("form:listTouched")).getText();
+        assertEquals("true", listTouched, "unrendered subtree must be traversed during resolution");
+    }
+
+    /**
+     * UC4: a target after a rendered, row-stamped {@code h:dataTable} must resolve,
+     * i.e. resolution visits through the table's rows and continues to the later
+     * sibling. Guards the indexed-traversal path.
+     */
+    @Test
+    void testResolutionTraversesRenderedDataTable() throws Exception {
+        WebPage page = getPage("issue5809uc4.xhtml");
+
+        WebElement button = page.findElement(By.id("form:button"));
+        assertTrue(page.getBehaviorScript(button).contains("form:after"),
+                "target after the table must resolve");
+
+        String firstCell = page.findElement(By.id("form:table:0:cell")).getText();
+        assertEquals("one", firstCell, "table rows must have rendered");
+    }
+
+    /**
+     * UC5: an f:ajax whose source is inside an iterating component must resolve per
+     * row - the row-stamped source must not break resolving the shared target.
+     */
+    @Test
+    void testResolutionFromInsideIteratingComponent() throws Exception {
+        WebPage page = getPage("issue5809uc5.xhtml");
+
+        WebElement row0 = page.findElement(By.id("form:table:0:in"));
+        WebElement row1 = page.findElement(By.id("form:table:1:in"));
+        assertTrue(page.getBehaviorScript(row0).contains("form:status"),
+                "row 0 must resolve the shared target");
+        assertTrue(page.getBehaviorScript(row1).contains("form:status"),
+                "row 1 must resolve the shared target");
+    }
+
+    /**
+     * UC6: the common relative keywords resolve. {@code @form} is passthrough
+     * (emitted as-is); {@code @parent} and {@code @previous} resolve server-side to
+     * concrete client ids. Complements Spec1238IT, which covers {@code @this @next}.
+     */
+    @Test
+    void testRelativeKeywords() throws Exception {
+        WebPage page = getPage("issue5809uc6.xhtml");
+
+        WebElement inForm = page.findElement(By.id("form:inForm"));
+        assertTrue(page.getBehaviorScript(inForm).contains("@form"),
+                "@form must stay passthrough");
+
+        WebElement inParent = page.findElement(By.id("form:inParent"));
+        assertTrue(page.getBehaviorScript(inParent).contains("form:wrap"),
+                "@parent must resolve to the enclosing panelGroup");
+
+        WebElement inPrevB = page.findElement(By.id("form:inPrevB"));
+        assertTrue(page.getBehaviorScript(inPrevB).contains("form:inPrevA"),
+                "@previous must resolve to the preceding sibling");
+    }
+}


### PR DESCRIPTION
Characterization tests for the agreed by-design behavior of eclipse-ee4j/mojarra#5809: search expression resolution scans the whole tree and deliberately does not skip unrendered subtrees, so currently-unrendered `f:ajax` render targets stay resolvable and the source/target coupling is independent of render state.

Six use cases under `faces23/search-expression`, guarding against traversal or perf refactors silently changing it:

- **UC1**: an unrendered target still resolves into the source's ajax request
- **UC2**: a mixed rendered/unrendered render list resolves both
- **UC3**: `@root:@id(...)` traverses an unrendered subtree, touching its model getter
- **UC4**: a target after a rendered, row-stamped `h:dataTable` resolves
- **UC5**: an `f:ajax` source inside an iterating component resolves per row
- **UC6**: `@form` stays passthrough, `@parent`/`@previous` resolve server-side

Full TCK is green.

🤖 Generated with Claude Opus 4.8