### PR TITLE
Add TCK IT for f:loadBundle re-resolution across postbacks

### DIFF
--- a/tck/faces23/misc-additive-config/src/main/java/ee/jakarta/tck/faces/faces23/misc_additive_config/LoadBundleBean.java
+++ b/tck/faces23/misc-additive-config/src/main/java/ee/jakarta/tck/faces/faces23/misc_additive_config/LoadBundleBean.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2026 Contributors to Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.faces.faces23.misc_additive_config;
+
+import jakarta.enterprise.context.RequestScoped;
+import jakarta.inject.Named;
+
+@Named
+@RequestScoped
+public class LoadBundleBean {
+
+    private static final String BUNDLE_PREFIX = "ee.jakarta.tck.faces.faces23.misc_additive_config.";
+
+    private String mylocale = "en";
+
+    private String basename = BUNDLE_PREFIX + "GreetingA";
+
+    public String getMylocale() {
+        return mylocale;
+    }
+
+    public void changeMyLocale(String mylocale) {
+        this.mylocale = mylocale;
+    }
+
+    public String getBasename() {
+        return basename;
+    }
+
+    public void useA() {
+        basename = BUNDLE_PREFIX + "GreetingA";
+    }
+
+    public void useB() {
+        basename = BUNDLE_PREFIX + "GreetingB";
+    }
+}

--- a/tck/faces23/misc-additive-config/src/main/resources/ee/jakarta/tck/faces/faces23/misc_additive_config/GreetingA.properties
+++ b/tck/faces23/misc-additive-config/src/main/resources/ee/jakarta/tck/faces/faces23/misc_additive_config/GreetingA.properties
@@ -1,0 +1,6 @@
+# Copyright (c) 2026 Contributors to Eclipse Foundation.
+# SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+#
+# One of two bundles selected by a non-literal f:loadBundle basename, to verify the bundle
+# is re-resolved on a postback that switches the basename.
+greeting=Alpha

--- a/tck/faces23/misc-additive-config/src/main/resources/ee/jakarta/tck/faces/faces23/misc_additive_config/GreetingB.properties
+++ b/tck/faces23/misc-additive-config/src/main/resources/ee/jakarta/tck/faces/faces23/misc_additive_config/GreetingB.properties
@@ -1,0 +1,6 @@
+# Copyright (c) 2026 Contributors to Eclipse Foundation.
+# SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+#
+# One of two bundles selected by a non-literal f:loadBundle basename, to verify the bundle
+# is re-resolved on a postback that switches the basename.
+greeting=Bravo

--- a/tck/faces23/misc-additive-config/src/main/resources/ee/jakarta/tck/faces/faces23/misc_additive_config/Messages.properties
+++ b/tck/faces23/misc-additive-config/src/main/resources/ee/jakarta/tck/faces/faces23/misc_additive_config/Messages.properties
@@ -4,3 +4,4 @@
 # Maps the active view locale to its resource locale-prefix so the ResourceHandler
 # resolves h:outputScript/h:outputStylesheet to the matching resources/<locale>/ path.
 jakarta.faces.resource.localePrefix=en
+greeting=Hello

--- a/tck/faces23/misc-additive-config/src/main/resources/ee/jakarta/tck/faces/faces23/misc_additive_config/Messages_au.properties
+++ b/tck/faces23/misc-additive-config/src/main/resources/ee/jakarta/tck/faces/faces23/misc_additive_config/Messages_au.properties
@@ -4,3 +4,4 @@
 # Maps the active view locale to its resource locale-prefix so the ResourceHandler
 # resolves h:outputScript/h:outputStylesheet to the matching resources/<locale>/ path.
 jakarta.faces.resource.localePrefix=au
+greeting=Gday

--- a/tck/faces23/misc-additive-config/src/main/resources/ee/jakarta/tck/faces/faces23/misc_additive_config/Messages_en.properties
+++ b/tck/faces23/misc-additive-config/src/main/resources/ee/jakarta/tck/faces/faces23/misc_additive_config/Messages_en.properties
@@ -4,3 +4,4 @@
 # Maps the active view locale to its resource locale-prefix so the ResourceHandler
 # resolves h:outputScript/h:outputStylesheet to the matching resources/<locale>/ path.
 jakarta.faces.resource.localePrefix=en
+greeting=Hello

--- a/tck/faces23/misc-additive-config/src/main/resources/ee/jakarta/tck/faces/faces23/misc_additive_config/Messages_fr.properties
+++ b/tck/faces23/misc-additive-config/src/main/resources/ee/jakarta/tck/faces/faces23/misc_additive_config/Messages_fr.properties
@@ -4,3 +4,4 @@
 # Maps the active view locale to its resource locale-prefix so the ResourceHandler
 # resolves h:outputScript/h:outputStylesheet to the matching resources/<locale>/ path.
 jakarta.faces.resource.localePrefix=fr
+greeting=Bonjour

--- a/tck/faces23/misc-additive-config/src/main/resources/ee/jakarta/tck/faces/faces23/misc_additive_config/Messages_us.properties
+++ b/tck/faces23/misc-additive-config/src/main/resources/ee/jakarta/tck/faces/faces23/misc_additive_config/Messages_us.properties
@@ -4,3 +4,4 @@
 # Maps the active view locale to its resource locale-prefix so the ResourceHandler
 # resolves h:outputScript/h:outputStylesheet to the matching resources/<locale>/ path.
 jakarta.faces.resource.localePrefix=us
+greeting=Howdy

--- a/tck/faces23/misc-additive-config/src/main/webapp/LoadBundleBasename.xhtml
+++ b/tck/faces23/misc-additive-config/src/main/webapp/LoadBundleBasename.xhtml
@@ -1,0 +1,34 @@
+<!--
+
+    Copyright (c) 2026 Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+<!DOCTYPE html>
+<html
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core">
+
+    <h:head>
+        <title>LoadBundleBasename</title>
+    </h:head>
+    <h:body>
+        <f:loadBundle basename="#{loadBundleBean.basename}" var="msg"/>
+        <h:outputText id="greeting" value="#{msg.greeting}"/>
+        <h:form id="form">
+            <h:commandButton id="a" value="A" action="#{loadBundleBean.useA}"/>
+            <h:commandButton id="b" value="B" action="#{loadBundleBean.useB}"/>
+        </h:form>
+    </h:body>
+</html>

--- a/tck/faces23/misc-additive-config/src/main/webapp/LoadBundleLocale.xhtml
+++ b/tck/faces23/misc-additive-config/src/main/webapp/LoadBundleLocale.xhtml
@@ -1,0 +1,37 @@
+<!--
+
+    Copyright (c) 2026 Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+<!DOCTYPE html>
+<html
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core">
+
+    <h:head>
+        <title>LoadBundleLocale</title>
+    </h:head>
+    <h:body>
+        <f:view locale="#{loadBundleBean.mylocale}">
+            <f:loadBundle basename="ee.jakarta.tck.faces.faces23.misc_additive_config.Messages" var="msg"/>
+            <h:outputText id="greeting" value="#{msg.greeting}"/>
+            <h:form id="form">
+                <h:commandButton id="en" value="en" action="#{loadBundleBean.changeMyLocale('en')}"/>
+                <h:commandButton id="fr" value="fr" action="#{loadBundleBean.changeMyLocale('fr')}"/>
+                <h:commandButton id="au" value="au" action="#{loadBundleBean.changeMyLocale('au')}"/>
+            </h:form>
+        </f:view>
+    </h:body>
+</html>

--- a/tck/faces23/misc-additive-config/src/test/java/ee/jakarta/tck/faces/faces23/misc_additive_config/LoadBundleIT.java
+++ b/tck/faces23/misc-additive-config/src/test/java/ee/jakarta/tck/faces/faces23/misc_additive_config/LoadBundleIT.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2026 Contributors to Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.faces.faces23.misc_additive_config;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.By;
+
+import ee.jakarta.tck.faces.util.selenium.BaseITNG;
+import ee.jakarta.tck.faces.util.selenium.WebPage;
+
+/**
+ * An f:loadBundle whose result depends on per-request state must be re-resolved on a postback that changes
+ * that state, even when the view structure is otherwise static. This exercises both the view-locale and the
+ * basename inputs of f:loadBundle across a full postback.
+ *
+ * @see jakarta.faces.view.facelets.FaceletContext
+ */
+class LoadBundleIT extends BaseITNG {
+
+    /**
+     * The bundle is loaded under the active view locale; switching f:view locale via a postback must re-resolve
+     * it to the new locale's variant.
+     */
+    @Test
+    void testLocaleSwitchReResolvesBundle() {
+        WebPage page = getPage("LoadBundleLocale.xhtml");
+        assertEquals("Hello", greeting(page), "default locale en resolves greeting to Messages_en");
+
+        page.guardHttp(page.findElement(By.id("form:fr"))::click);
+        assertEquals("Bonjour", greeting(page), "locale fr resolves greeting to Messages_fr");
+
+        page.guardHttp(page.findElement(By.id("form:au"))::click);
+        assertEquals("Gday", greeting(page), "locale au resolves greeting to Messages_au");
+
+        page.guardHttp(page.findElement(By.id("form:en"))::click);
+        assertEquals("Hello", greeting(page), "locale en resolves greeting to Messages_en after postback");
+    }
+
+    /**
+     * Switching a non-literal f:loadBundle basename via a postback must re-resolve it to the new bundle.
+     */
+    @Test
+    void testBasenameSwitchReResolvesBundle() {
+        WebPage page = getPage("LoadBundleBasename.xhtml");
+        assertEquals("Alpha", greeting(page), "default basename GreetingA");
+
+        page.guardHttp(page.findElement(By.id("form:b"))::click);
+        assertEquals("Bravo", greeting(page), "basename GreetingB after postback");
+
+        page.guardHttp(page.findElement(By.id("form:a"))::click);
+        assertEquals("Alpha", greeting(page), "basename GreetingA after postback");
+    }
+
+    private static String greeting(WebPage page) {
+        return page.findElement(By.id("greeting")).getText();
+    }
+}


### PR DESCRIPTION
Adds `LoadBundleIT` to `tck/faces23/misc-additive-config`, asserting that `f:loadBundle` re-resolves its bundle across a postback when an input it depends on changes:

- **testLocaleSwitchReResolvesBundle** — a page with `<f:view locale="#{bean.mylocale}">` and `<f:loadBundle basename="…Messages" var="msg">` displays `#{msg.greeting}`; switching the locale via a postback must re-resolve the bundle to the new locale's variant (`Hello` → `Bonjour` → `Gday` → `Hello`).
- **testBasenameSwitchReResolvesBundle** — a page with `<f:loadBundle basename="#{bean.basename}" var="msg">` toggles a non-literal basename between two bundles via a postback; the displayed `#{msg.greeting}` must follow (`Alpha` ⇄ `Bravo`).

Adds a `greeting` key to the existing `Messages_*` bundles and two basename-distinct bundles (`GreetingA`/`GreetingB`).

Both behaviors are spec-expected re-resolution on postback. They also guard against an implementation skipping the render-time facelet re-apply for static views (e.g. Mojarra's `refreshTransientBuildOnPSS`), which must still re-apply views whose `f:view`/`f:loadBundle` inputs vary per request.

🤖 Generated with Claude Opus 4.8
