### PR TITLE
Re-apply CDI injection to full-state-restored Faces artifacts

### DIFF
--- a/api/src/main/java/jakarta/faces/component/PackageUtils.java
+++ b/api/src/main/java/jakarta/faces/component/PackageUtils.java
@@ -27,12 +27,19 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.WeakHashMap;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
+import jakarta.enterprise.context.spi.CreationalContext;
+import jakarta.enterprise.inject.spi.AnnotatedType;
+import jakarta.enterprise.inject.spi.BeanManager;
+import jakarta.enterprise.inject.spi.CDI;
+import jakarta.enterprise.inject.spi.InjectionTarget;
 import jakarta.faces.context.FacesContext;
 import jakarta.faces.event.PhaseId;
 import jakarta.faces.model.SelectItem;
@@ -52,6 +59,10 @@ class PackageUtils {
     static final String REMOVED_CHILDREN = "facelets.REMOVED_CHILDREN";
     static final String DYNAMIC_COMPONENT = "facelets.DYNAMIC_COMPONENT";
     static final String FACET_NAME = "facelets.FACET_NAME";
+
+    // Per-class InjectionTarget cache, keyed weakly by BeanManager so a redeployed application's targets are
+    // released together with its (now unreferenced) bean manager. Can be removed once the deprecated FSS support is removed.
+    private static final Map<BeanManager, Map<Class<?>, InjectionTarget<?>>> INJECTION_TARGETS = Collections.synchronizedMap(new WeakHashMap<>());
 
     private PackageUtils() {
     }
@@ -304,6 +315,48 @@ class PackageUtils {
      */
     public static <T> Iterator<T> unmodifiableIterator(Iterator<T> iterator) {
         return new UnmodifiableIterator<>(iterator);
+    }
+
+    /**
+     * Perform CDI resource injection ({@code @Inject}) and invoke {@code @PostConstruct} on a Faces artifact that was
+     * instantiated reflectively rather than obtained from CDI -- notably a {@code @FacesValidator}/{@code @FacesConverter}/
+     * {@code @FacesBehavior} recreated from full state saving, which is otherwise restored with its {@code @Inject} fields
+     * left null. No-op when the class declares no injection points (so a plain artifact's {@code @PostConstruct} is not
+     * fired) or when CDI is unavailable.
+     */
+    static void injectAndPostConstruct(Object instance) {
+        if (instance == null) {
+            return;
+        }
+
+        BeanManager beanManager;
+        try {
+            beanManager = CDI.current().getBeanManager();
+        } catch (IllegalStateException e) {
+            return; // No CDI available in this environment.
+        }
+
+        InjectionTarget<Object> injectionTarget = getInjectionTarget(beanManager, instance.getClass());
+        if (injectionTarget == null || injectionTarget.getInjectionPoints().isEmpty()) {
+            return; // Nothing to inject; leave a plain artifact untouched (including its @PostConstruct).
+        }
+
+        CreationalContext<Object> creationalContext = beanManager.createCreationalContext(null);
+        injectionTarget.inject(instance, creationalContext);
+        injectionTarget.postConstruct(instance);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static InjectionTarget<Object> getInjectionTarget(BeanManager beanManager, Class<?> clazz) {
+        Map<Class<?>, InjectionTarget<?>> cache = INJECTION_TARGETS.computeIfAbsent(beanManager, k -> new ConcurrentHashMap<>());
+        return (InjectionTarget<Object>) cache.computeIfAbsent(clazz, c -> {
+            try {
+                AnnotatedType<?> annotatedType = beanManager.createAnnotatedType(c);
+                return beanManager.getInjectionTargetFactory(annotatedType).createInjectionTarget(null);
+            } catch (RuntimeException e) {
+                return null; // Not a CDI-injectable type; skip injection for it.
+            }
+        });
     }
 
     public static class UnmodifiableIterator<T> implements Iterator<T> {

--- a/api/src/main/java/jakarta/faces/component/StateHolderSaver.java
+++ b/api/src/main/java/jakarta/faces/component/StateHolderSaver.java
@@ -126,6 +126,11 @@ class StateHolderSaver implements Serializable {
             throw new IllegalStateException(e);
         }
 
+        // Full state saving recreates the artifact reflectively, bypassing the CDI-managed creation path that the
+        // tag-driven partial-state rebuild uses (e.g. Application.createValidator). Re-apply CDI injection so a restored
+        // @FacesValidator/@FacesConverter/@FacesBehavior keeps its @Inject fields (no-op when there is nothing to inject).
+        PackageUtils.injectAndPostConstruct(result);
+
         if (null != savedState && result instanceof StateHolder) {
             // don't need to check transient, since that was done on
             // the saving side.


### PR DESCRIPTION
Restores CDI injection into `@FacesValidator`/`@FacesConverter`/`@FacesBehavior` under **full state saving** (`partialStateSaving=false`), which regressed with #1584.

## Problem

Under full state saving an artifact that is not itself a `StateHolder` (e.g. a plain `@FacesValidator` with an `@Inject` field) is saved by `jakarta.faces.component.StateHolderSaver` as just its class name, and on restore is recreated through a bare reflective `newInstance()`. That bypasses the CDI-managed creation path, so its `@Inject` fields are left `null` — an injected validator observes `inject=false` after a postback.

Before #1584 the `CdiValidator`/`CdiConverter`/`CdiBehavior` wrappers saved only the id and re-resolved the CDI-injected delegate on restore, so injection survived full state saving. Removing them in favour of relying on CDI only dropped that guarantee.

Under partial state saving the tag-driven `buildView` recreates the artifact through `Application.createValidator` (CDI-injected) on every postback and this reflective restore path is never taken, so injection was preserved there — which is why the regression only surfaces under full state saving.

## Fix

Re-apply CDI injection right after the reflective `newInstance()` in `StateHolderSaver.restore()` — the single chokepoint reached by every attached-object full-state restore — via a new `PackageUtils.injectAndPostConstruct` helper. It:

- is a no-op when the class declares no injection points (a plain, non-CDI artifact keeps its `@PostConstruct` unfired);
- is a no-op when CDI is unavailable;
- caches the per-class `InjectionTarget` per `BeanManager` (weakly keyed, released with the bean manager on redeploy).

One chokepoint covers validators, converters and behaviors.

## Verification

Full Jakarta Faces TCK green under both default (partial) and `-Dwebapp.partialStateSaving=false` (full) state saving. `Issue4551IT.twoAnnotatedJSFValidatorsInvoked`, which failed only under full state saving, now passes.

🤖 Generated with Claude Opus 4.8
