### PR TITLE
Add TCK coverage for c:forEach postback re-render

### DIFF
--- a/tck/faces22/iteration/src/main/java/ee/jakarta/tck/faces/faces22/iteration/ForEachContentIdBean.java
+++ b/tck/faces22/iteration/src/main/java/ee/jakarta/tck/faces/faces22/iteration/ForEachContentIdBean.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2026 Contributors to Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.faces.faces22.iteration;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+
+import jakarta.faces.view.ViewScoped;
+import jakarta.inject.Named;
+
+/**
+ * Backs a page whose c:forEach derives each component's id from the item value. Replacing the list with a same-size
+ * list of different values must regenerate the ids, so it exercises the case where the iteration count is unchanged
+ * but the per-element build-time attributes are not.
+ */
+@Named
+@ViewScoped
+public class ForEachContentIdBean implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private List<String> items = new ArrayList<>(List.of("a", "b", "c"));
+
+    public List<String> getItems() {
+        return items;
+    }
+
+    /**
+     * Replaces the list with three different values - same count, different content.
+     */
+    public String replace() {
+        items = new ArrayList<>(List.of("x", "y", "z"));
+        return null;
+    }
+}

--- a/tck/faces22/iteration/src/main/java/ee/jakarta/tck/faces/faces22/iteration/ForEachUnchangedPostbackBean.java
+++ b/tck/faces22/iteration/src/main/java/ee/jakarta/tck/faces/faces22/iteration/ForEachUnchangedPostbackBean.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2026 Contributors to Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.faces.faces22.iteration;
+
+import java.io.Serializable;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import jakarta.faces.view.ViewScoped;
+import jakarta.inject.Named;
+
+/**
+ * Backs a page that iterates the same three logical rows through a c:forEach over each supported source kind - a List,
+ * an array, a begin/end integer range and a Map - so a no-op postback can assert every kind re-renders unchanged.
+ */
+@Named
+@ViewScoped
+public class ForEachUnchangedPostbackBean implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private final List<String> list = List.of("list-A", "list-B", "list-C");
+    private final String[] array = { "array-A", "array-B", "array-C" };
+    private final Map<String, String> map = new LinkedHashMap<>();
+    private int postbacks;
+
+    public ForEachUnchangedPostbackBean() {
+        map.put("k0", "map-A");
+        map.put("k1", "map-B");
+        map.put("k2", "map-C");
+    }
+
+    public List<String> getList() {
+        return list;
+    }
+
+    public String[] getArray() {
+        return array;
+    }
+
+    public Map<String, String> getMap() {
+        return map;
+    }
+
+    public int getPostbacks() {
+        return postbacks;
+    }
+
+    /**
+     * Records the postback but deliberately leaves every iterated source untouched.
+     */
+    public String submit() {
+        postbacks++;
+        return null;
+    }
+}

--- a/tck/faces22/iteration/src/main/webapp/foreach-content-id.xhtml
+++ b/tck/faces22/iteration/src/main/webapp/foreach-content-id.xhtml
@@ -1,0 +1,32 @@
+<!--
+
+    Copyright (c) 2026 Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+<!DOCTYPE html>
+<html xmlns:h="jakarta.faces.html"
+      xmlns:c="jakarta.tags.core">
+    <h:head></h:head>
+    <h:body>
+        <h:form id="form">
+            <c:forEach items="#{forEachContentIdBean.items}" var="item">
+                <h:panelGroup id="item_#{item}" layout="block">
+                    <h:outputText value="#{item}"/>
+                </h:panelGroup>
+            </c:forEach>
+            <h:commandButton id="replace" value="Replace" action="#{forEachContentIdBean.replace}"/>
+        </h:form>
+    </h:body>
+</html>

--- a/tck/faces22/iteration/src/main/webapp/foreach-unchanged-postback.xhtml
+++ b/tck/faces22/iteration/src/main/webapp/foreach-unchanged-postback.xhtml
@@ -1,0 +1,48 @@
+<!--
+
+    Copyright (c) 2026 Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+<!DOCTYPE html>
+<html xmlns:h="jakarta.faces.html"
+      xmlns:c="jakarta.tags.core">
+    <h:head></h:head>
+    <h:body>
+        <h:form id="form">
+            <c:forEach items="#{forEachUnchangedPostbackBean.list}" var="row" varStatus="loop">
+                <h:panelGroup id="list_#{loop.index}" layout="block">
+                    <h:outputText value="#{row}"/>
+                </h:panelGroup>
+            </c:forEach>
+            <c:forEach items="#{forEachUnchangedPostbackBean.array}" var="row" varStatus="loop">
+                <h:panelGroup id="array_#{loop.index}" layout="block">
+                    <h:outputText value="#{row}"/>
+                </h:panelGroup>
+            </c:forEach>
+            <c:forEach begin="0" end="2" var="i">
+                <h:panelGroup id="range_#{i}" layout="block">
+                    <h:outputText value="range-#{i}"/>
+                </h:panelGroup>
+            </c:forEach>
+            <c:forEach items="#{forEachUnchangedPostbackBean.map}" var="entry" varStatus="loop">
+                <h:panelGroup id="map_#{loop.index}" layout="block">
+                    <h:outputText value="#{entry.value}"/>
+                </h:panelGroup>
+            </c:forEach>
+            <h:outputText id="count" value="postbacks=#{forEachUnchangedPostbackBean.postbacks}"/>
+            <h:commandButton id="submit" value="Submit" action="#{forEachUnchangedPostbackBean.submit}"/>
+        </h:form>
+    </h:body>
+</html>

--- a/tck/faces22/iteration/src/test/java/ee/jakarta/tck/faces/faces22/iteration/ForEachContentIdIT.java
+++ b/tck/faces22/iteration/src/test/java/ee/jakarta/tck/faces/faces22/iteration/ForEachContentIdIT.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2026 Contributors to Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.faces.faces22.iteration;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.By;
+
+import ee.jakarta.tck.faces.util.selenium.BaseITNG;
+import ee.jakarta.tck.faces.util.selenium.WebPage;
+
+/**
+ * When a c:forEach list is replaced on postback with a same-size list of different values, the per-element build-time
+ * attributes must be regenerated. Here each row's component id is derived from the item value, so an unchanged count
+ * must not be mistaken for an unchanged iteration: the old content-derived ids must be gone and the new ones present.
+ * This complements Issue2631 (which asserts changed <em>values</em>) by asserting changed <em>generated ids</em>.
+ */
+class ForEachContentIdIT extends BaseITNG {
+
+    /**
+     * @see jakarta.faces.component.UIComponent#getClientId()
+     */
+    @Test
+    void sameCountContentChangeRegeneratesIds() {
+        WebPage page = getPage("foreach-content-id.xhtml");
+
+        // Initial GET: ids derived from a, b, c.
+        assertEquals("a", page.findElement(By.id("form:item_a")).getText(), "item_a on initial render");
+        assertEquals("b", page.findElement(By.id("form:item_b")).getText(), "item_b on initial render");
+        assertEquals("c", page.findElement(By.id("form:item_c")).getText(), "item_c on initial render");
+
+        // Replace with x, y, z - same count, different content.
+        page.guardHttp(() -> page.findElement(By.id("form:replace")).click());
+
+        // The new content-derived ids are present ...
+        assertEquals("x", page.findElement(By.id("form:item_x")).getText(), "item_x after replace");
+        assertEquals("y", page.findElement(By.id("form:item_y")).getText(), "item_y after replace");
+        assertEquals("z", page.findElement(By.id("form:item_z")).getText(), "item_z after replace");
+
+        // ... and the stale ones are gone (a same-count change must still be treated as a change).
+        assertFalse(page.containsSource("form:item_a"), "stale id item_a gone after replace");
+        assertFalse(page.containsSource("form:item_b"), "stale id item_b gone after replace");
+        assertFalse(page.containsSource("form:item_c"), "stale id item_c gone after replace");
+    }
+}

--- a/tck/faces22/iteration/src/test/java/ee/jakarta/tck/faces/faces22/iteration/ForEachUnchangedPostbackIT.java
+++ b/tck/faces22/iteration/src/test/java/ee/jakarta/tck/faces/faces22/iteration/ForEachUnchangedPostbackIT.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2026 Contributors to Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.faces.faces22.iteration;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.By;
+
+import ee.jakarta.tck.faces.util.selenium.BaseITNG;
+import ee.jakarta.tck.faces.util.selenium.WebPage;
+
+/**
+ * A c:forEach whose backing source is <em>not</em> mutated on postback must re-render every row unchanged, for each
+ * source kind - List, array, begin/end integer range and Map. This complements Issue2631 (collection swapped on
+ * postback) and Issue2896 (item added on postback), which both mutate; here the no-op postback must preserve each
+ * iteration's generated id and value.
+ */
+class ForEachUnchangedPostbackIT extends BaseITNG {
+
+    /**
+     * After a postback that only bumps a counter and leaves every source untouched, each iteration of every source kind
+     * must still be present with its original generated id and value.
+     *
+     * @see jakarta.faces.component.UIComponent#getClientId()
+     */
+    @Test
+    void unchangedForEachRetainsRowsOnPostback() {
+        WebPage page = getPage("foreach-unchanged-postback.xhtml");
+
+        // Initial GET: every source rendered its three rows.
+        assertRows(page);
+        assertTrue(page.findElement(By.id("form:count")).getText().contains("postbacks=0"), "no postback yet");
+
+        // Postback that does not touch any source.
+        page.guardHttp(() -> page.findElement(By.id("form:submit")).click());
+
+        // The postback executed and every row survived unchanged.
+        assertTrue(page.findElement(By.id("form:count")).getText().contains("postbacks=1"), "postback executed");
+        assertRows(page);
+    }
+
+    private void assertRows(WebPage page) {
+        for (int i = 0; i < 3; i++) {
+            assertEquals("list-" + (char) ('A' + i), page.findElement(By.id("form:list_" + i)).getText(), "list row " + i);
+            assertEquals("array-" + (char) ('A' + i), page.findElement(By.id("form:array_" + i)).getText(), "array row " + i);
+            assertEquals("range-" + i, page.findElement(By.id("form:range_" + i)).getText(), "range row " + i);
+            assertEquals("map-" + (char) ('A' + i), page.findElement(By.id("form:map_" + i)).getText(), "map row " + i);
+        }
+    }
+}


### PR DESCRIPTION
Adds TCK coverage for `c:forEach` postback re-rendering, complementing the existing `faces22/iteration` tests (Issue2631 swaps a same-size set on postback, Issue2896 adds a nested item — both mutate).

- **ForEachUnchangedPostbackIT** — a no-op postback must re-render every row unchanged, across each source kind: `List`, array, `begin`/`end` range and `Map`. Guards against a `c:forEach` render optimization dropping rows when nothing changed.
- **ForEachContentIdIT** — replacing a list with a same-size list of different values must regenerate content-derived component ids (`id="item_#{item}"`), so an unchanged count is not mistaken for an unchanged iteration. Complements Issue2631, which asserts changed values rather than changed generated ids.

The tests are implementation-agnostic — both Mojarra and MyFaces pass them. They cover the `c:forEach` render re-apply optimization in eclipse-ee4j/mojarra#5824 (part of the perf-benchmark work in eclipse-ee4j/mojarra#5753).

🤖 Generated with Claude Opus 4.8
