### PR TITLE
Add foreach input-binding iteration test

### DIFF
--- a/tck/faces22/iteration/src/main/java/ee/jakarta/tck/faces/faces22/iteration/ForEachInputBindingBean.java
+++ b/tck/faces22/iteration/src/main/java/ee/jakarta/tck/faces/faces22/iteration/ForEachInputBindingBean.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2026 Contributors to Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.faces.faces22.iteration;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import jakarta.faces.view.ViewScoped;
+import jakarta.inject.Named;
+
+/**
+ * Backs a page that binds an h:inputText to a per-item property inside a c:forEach, for each source kind whose loop var
+ * addresses a mutable element: a List and an insertion-ordered Set of mutable rows, and a Map. Submitting a distinct
+ * value into every input must update the matching model element, which requires resolving the loop var during Update
+ * Model Values (not just on render) - exercising IndexedValueExpression (List), IteratedValueExpression (Set) and
+ * MappedValueExpression (Map). The summaries read the model back so a test can assert each value reached its element.
+ */
+@Named
+@ViewScoped
+public class ForEachInputBindingBean implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    /** A mutable element; identity-based (no equals/hashCode) so mutating {@code value} is safe while held in a Set. */
+    public static class Row implements Serializable {
+
+        private static final long serialVersionUID = 1L;
+
+        private String value;
+
+        public Row(String value) {
+            this.value = value;
+        }
+
+        public String getValue() {
+            return value;
+        }
+
+        public void setValue(String value) {
+            this.value = value;
+        }
+    }
+
+    private final List<Row> list = new ArrayList<>(List.of(new Row("L0"), new Row("L1"), new Row("L2")));
+    private final Set<Row> set = new LinkedHashSet<>(List.of(new Row("S0"), new Row("S1"), new Row("S2")));
+    private final Map<String, Row> map = new LinkedHashMap<>();
+
+    public ForEachInputBindingBean() {
+        map.put("k0", new Row("M0"));
+        map.put("k1", new Row("M1"));
+        map.put("k2", new Row("M2"));
+    }
+
+    public List<Row> getList() {
+        return list;
+    }
+
+    public Set<Row> getSet() {
+        return set;
+    }
+
+    public Map<String, Row> getMap() {
+        return map;
+    }
+
+    public String getListSummary() {
+        return "L:" + list.stream().map(Row::getValue).collect(Collectors.joining(","));
+    }
+
+    public String getSetSummary() {
+        return "S:" + set.stream().map(Row::getValue).collect(Collectors.joining(","));
+    }
+
+    public String getMapSummary() {
+        return "M:" + map.values().stream().map(Row::getValue).collect(Collectors.joining(","));
+    }
+
+    public String submit() {
+        return null;
+    }
+}

--- a/tck/faces22/iteration/src/main/webapp/foreach-input-binding.xhtml
+++ b/tck/faces22/iteration/src/main/webapp/foreach-input-binding.xhtml
@@ -1,0 +1,39 @@
+<!--
+
+    Copyright (c) 2026 Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+<!DOCTYPE html>
+<html xmlns:h="jakarta.faces.html"
+      xmlns:c="jakarta.tags.core">
+    <h:head></h:head>
+    <h:body>
+        <h:form id="form">
+            <c:forEach items="#{forEachInputBindingBean.list}" var="row" varStatus="loop">
+                <h:inputText id="list_#{loop.index}" value="#{row.value}"/>
+            </c:forEach>
+            <c:forEach items="#{forEachInputBindingBean.set}" var="row" varStatus="loop">
+                <h:inputText id="set_#{loop.index}" value="#{row.value}"/>
+            </c:forEach>
+            <c:forEach items="#{forEachInputBindingBean.map}" var="entry" varStatus="loop">
+                <h:inputText id="map_#{loop.index}" value="#{entry.value.value}"/>
+            </c:forEach>
+            <h:outputText id="listSummary" value="#{forEachInputBindingBean.listSummary}"/>
+            <h:outputText id="setSummary" value="#{forEachInputBindingBean.setSummary}"/>
+            <h:outputText id="mapSummary" value="#{forEachInputBindingBean.mapSummary}"/>
+            <h:commandButton id="submit" value="Submit" action="#{forEachInputBindingBean.submit}"/>
+        </h:form>
+    </h:body>
+</html>

--- a/tck/faces22/iteration/src/test/java/ee/jakarta/tck/faces/faces22/iteration/ForEachInputBindingIT.java
+++ b/tck/faces22/iteration/src/test/java/ee/jakarta/tck/faces/faces22/iteration/ForEachInputBindingIT.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2026 Contributors to Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.faces.faces22.iteration;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+
+import ee.jakarta.tck.faces.util.selenium.BaseITNG;
+import ee.jakarta.tck.faces.util.selenium.WebPage;
+
+/**
+ * An h:inputText bound to a per-item property inside a c:forEach must, on postback, push each submitted value to the
+ * matching model element - so the loop var has to resolve to the correct element during Update Model Values, not only on
+ * render. Covers every source kind whose var addresses a mutable element: a List (IndexedValueExpression), an
+ * insertion-ordered Set of mutable rows (IteratedValueExpression) and a Map (MappedValueExpression). Complements
+ * ForEachUnchangedPostbackIT, which only reads the var while rendering.
+ */
+class ForEachInputBindingIT extends BaseITNG {
+
+    private static final String[] IDS = { "form:list_0", "form:list_1", "form:list_2", "form:set_0", "form:set_1",
+            "form:set_2", "form:map_0", "form:map_1", "form:map_2" };
+
+    /**
+     * Type a distinct value into every per-item input and submit; each value must land on the matching model element for
+     * every source kind, and each input must redisplay its element's updated value.
+     */
+    @Test
+    void perItemInputUpdatesMatchingModelElementOnPostback() {
+        WebPage page = getPage("foreach-input-binding.xhtml");
+
+        // Initial GET: each input shows its element's initial value.
+        assertInputs(page, "L0", "L1", "L2", "S0", "S1", "S2", "M0", "M1", "M2");
+
+        // Give every input a distinct new value.
+        for (String id : IDS) {
+            type(page, id, page.findElement(By.id(id)).getAttribute("value") + "x");
+        }
+
+        page.guardHttp(() -> page.findElement(By.id("form:submit")).click());
+
+        // Each submitted value reached the matching model element, in order, for every source kind.
+        assertEquals("L:L0x,L1x,L2x", page.findElement(By.id("form:listSummary")).getText(), "list model");
+        assertEquals("S:S0x,S1x,S2x", page.findElement(By.id("form:setSummary")).getText(), "set model");
+        assertEquals("M:M0x,M1x,M2x", page.findElement(By.id("form:mapSummary")).getText(), "map model");
+
+        // And each input redisplays its element's updated value.
+        assertInputs(page, "L0x", "L1x", "L2x", "S0x", "S1x", "S2x", "M0x", "M1x", "M2x");
+    }
+
+    private void assertInputs(WebPage page, String... expected) {
+        for (int i = 0; i < IDS.length; i++) {
+            assertEquals(expected[i], page.findElement(By.id(IDS[i])).getAttribute("value"), IDS[i]);
+        }
+    }
+
+    private void type(WebPage page, String id, String value) {
+        WebElement input = page.findElement(By.id(id));
+        input.clear();
+        input.sendKeys(value);
+    }
+}


### PR DESCRIPTION
Covers a per-item h:inputText bound inside a c:forEach and submitted, for each var-expression kind: a List (IndexedValueExpression), an insertion-ordered Set of mutable rows (IteratedValueExpression) and a Map (MappedValueExpression). Asserts each submitted value reaches the matching model element, which exercises resolving the loop var during Update Model Values - the existing iteration tests read the var only on render.

Part of eclipse-ee4j/mojarra#5753