### PR TITLE
Cache the parse formatter in DateTimeConverter.getAsObject

### DIFF
--- a/api/src/main/java/jakarta/faces/convert/DateTimeConverter.java
+++ b/api/src/main/java/jakarta/faces/convert/DateTimeConverter.java
@@ -393,14 +393,11 @@ public class DateTimeConverter implements Converter<Object>, PartialStateHolder 
                 return null;
             }
 
-            // Identify the Locale to use for parsing
-            Locale locale = getLocale(context);
-
-            // Create and configure the parser to be used
-            parser = getDateFormat(locale, true);
-            if (timeZone != null) {
-                parser.setTimeZone(timeZone);
-            }
+            // Create and configure the parser to be used, reused per FacesContext across equal configurations (see
+            // getCachedFormatter). Unlike the formatter it is built with forParsing=true, so it is cached under a
+            // distinct key: for the java.time local/offset/zoned types the parser normalizes fixed-width whitespace,
+            // which the formatter must not.
+            parser = getCachedFormatter(context, true);
 
             // Perform the requested parsing
             returnValue = parser.parse(value);
@@ -508,7 +505,7 @@ public class DateTimeConverter implements Converter<Object>, PartialStateHolder 
             // Create and configure the formatter to be used, reused per FacesContext across equal configurations (see
             // getCachedFormatter): it is a function of this converter's configuration only, and rebuilding it per value
             // dominated allocation on conversion-heavy views (e.g. a per-row f:convertDateTime unrolled by c:forEach).
-            FormatWrapper formatter = getCachedFormatter(context);
+            FormatWrapper formatter = getCachedFormatter(context, false);
 
             // Perform the requested formatting
             return formatter.format(value);
@@ -559,12 +556,15 @@ public class DateTimeConverter implements Converter<Object>, PartialStateHolder 
     }
 
     /**
-     * Return the fully configured formatter for {@link #getAsString}, cached in the FacesContext attributes keyed by
-     * this converter's format-determining configuration. The formatter is a function of that configuration only, so two
-     * converters with equal configuration share one instance within a FacesContext - single-threaded, so sequential
-     * {@code format} calls are safe - turning a per-value format rebuild into a single build per configuration.
+     * Return the fully configured formatter for {@link #getAsString} ({@code forParsing == false}) or {@link #getAsObject}
+     * ({@code forParsing == true}), cached in the FacesContext attributes keyed by this converter's format-determining
+     * configuration plus {@code forParsing}. The formatter is a function of those inputs only, so two converters with equal
+     * configuration share one instance within a FacesContext - single-threaded, so sequential {@code format}/{@code parse}
+     * calls are safe - turning a per-value formatter rebuild into a single build per configuration. Parser and formatter
+     * are cached separately because they diverge for the java.time local/offset/zoned types (the parser normalizes
+     * fixed-width whitespace).
      */
-    private FormatWrapper getCachedFormatter(FacesContext context) {
+    private FormatWrapper getCachedFormatter(FacesContext context, boolean forParsing) {
         Locale locale = getLocale(context);
         Map<Object, Object> attributes = context.getAttributes();
         @SuppressWarnings("unchecked")
@@ -573,10 +573,10 @@ public class DateTimeConverter implements Converter<Object>, PartialStateHolder 
             cache = new FormatterCache();
             attributes.put(FORMATTER_CACHE_KEY, cache);
         }
-        String key = formatterKey(locale);
+        String key = formatterKey(locale, forParsing);
         FormatWrapper formatter = cache.get(key);
         if (formatter == null) {
-            formatter = getDateFormat(locale, false);
+            formatter = getDateFormat(locale, forParsing);
             if (timeZone != null) {
                 formatter.setTimeZone(timeZone);
             }
@@ -586,10 +586,10 @@ public class DateTimeConverter implements Converter<Object>, PartialStateHolder 
     }
 
     /** Key over every property {@link #getCachedFormatter} reads to build the formatter. */
-    private String formatterKey(Locale locale) {
+    private String formatterKey(Locale locale, boolean forParsing) {
         return new StringBuilder(48).append(pattern).append('|').append(type).append('|').append(dateStyle).append('|')
                 .append(timeStyle).append('|').append(locale).append('|')
-                .append(timeZone == null ? null : timeZone.getID()).toString();
+                .append(timeZone == null ? null : timeZone.getID()).append('|').append(forParsing).toString();
     }
 
     private FormatWrapper getDateFormat(Locale locale, boolean forParsing) {


### PR DESCRIPTION
## What

`DateTimeConverter.getAsString` already reuses a per-`FacesContext` `FormatWrapper` via `getCachedFormatter`, but `getAsObject` still built a fresh formatter on every parse. This routes the parse path through the same cache.

The parser and formatter are cached under separate keys via a new `forParsing` component in the cache key, because they genuinely diverge for the `java.time` `local*`/`offset*`/`zoned*` types: the parser normalizes fixed-width whitespace (NNBSP/NBSP → regular space, per #5399) while the formatter must not.

## Why

The parse formatter is a pure function of the converter's configuration plus `forParsing` — no component-type or per-call mutation — so it is safe to reuse within a single-threaded `FacesContext`, exactly like the format side. This eliminates the per-value parser rebuild on conversion-heavy postbacks: an invalid-form re-render, or a per-row `f:convertDateTime` unrolled by `c:forEach`.

`NumberConverter`'s parse path is deliberately left as-is: its parser is not a pure function of config (it depends on the target component's expected type for `setParseBigDecimal`, and mutates/restores `DecimalFormatSymbols` in place), so the same caching does not apply there.

## Verification

- Behavior unchanged; API builds clean (release 17).
- `DateTimeConverterTest` green on JDK 21 (4/4, 0 skipped), including the format→parse roundtrip on one converter within one `FacesContext` — which stays correct only because the two formatters are keyed separately on `forParsing`.
- Full TCK green.

Refs eclipse-ee4j/mojarra#5753

🤖 Generated with Claude Opus 4.8
