### PR TITLE
Add CSP-disabled command component TCK tests (faces50/csp-disabled)

### DIFF
--- a/tck/faces50/csp-disabled/pom.xml
+++ b/tck/faces50/csp-disabled/pom.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.eclipse.ee4j.tck.faces.faces50</groupId>
+        <artifactId>pom</artifactId>
+        <version>5.0.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>csp-disabled</artifactId>
+    <packaging>war</packaging>
+
+    <name>Jakarta Faces TCK ${project.version} - ${test.moduleName} - ${project.artifactId}</name>
+
+    <build>
+        <finalName>test-${test.moduleName}-${project.artifactId}</finalName>
+    </build>
+</project>

--- a/tck/faces50/csp-disabled/src/main/webapp/WEB-INF/faces-config.xml
+++ b/tck/faces50/csp-disabled/src/main/webapp/WEB-INF/faces-config.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+<faces-config
+    xmlns="https://jakarta.ee/xml/ns/jakartaee"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-facesconfig_4_1.xsd"
+    version="4.1">
+</faces-config>

--- a/tck/faces50/csp-disabled/src/main/webapp/WEB-INF/web.xml
+++ b/tck/faces50/csp-disabled/src/main/webapp/WEB-INF/web.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+<web-app
+    xmlns="https://jakarta.ee/xml/ns/jakartaee"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-app_6_1.xsd"
+    version="6.1">
+    <context-param>
+        <param-name>jakarta.faces.PROJECT_STAGE</param-name>
+        <param-value>${webapp.projectStage}</param-value>
+    </context-param>
+    <context-param>
+        <param-name>jakarta.faces.PARTIAL_STATE_SAVING</param-name>
+        <param-value>${webapp.partialStateSaving}</param-value>
+    </context-param>
+    <context-param>
+        <param-name>jakarta.faces.STATE_SAVING_METHOD</param-name>
+        <param-value>${webapp.stateSavingMethod}</param-value>
+    </context-param>
+    <context-param>
+        <param-name>jakarta.faces.SERIALIZE_SERVER_STATE</param-name>
+        <param-value>${webapp.serializeServerState}</param-value>
+    </context-param>
+
+    <!--
+        jakarta.faces.ENABLE_CSP_NONCE is deliberately NOT set here: CSP nonce injection is
+        disabled by default, and these tests verify the default (CSP-disabled) rendering path
+        of command components under both standard and exact servlet mappings.
+    -->
+
+    <servlet>
+        <servlet-name>Faces Servlet</servlet-name>
+        <servlet-class>jakarta.faces.webapp.FacesServlet</servlet-class>
+        <load-on-startup>1</load-on-startup>
+    </servlet>
+    <servlet-mapping>
+        <servlet-name>Faces Servlet</servlet-name>
+        <url-pattern>*.xhtml</url-pattern>
+        <!-- Exact mapping (Faces 2.3+), the specific regression surface of mojarra issue 5741. -->
+        <url-pattern>/issue5741</url-pattern>
+    </servlet-mapping>
+</web-app>

--- a/tck/faces50/csp-disabled/src/main/webapp/issue5606.xhtml
+++ b/tck/faces50/csp-disabled/src/main/webapp/issue5606.xhtml
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<!--
+
+    Copyright (c) Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+<html lang="en"
+    xmlns:f="jakarta.faces.core"
+    xmlns:h="jakarta.faces.html"
+>
+    <h:head>
+        <title>issue5606</title>
+    </h:head>
+    <h:body>
+        <h:form id="form">
+            <h:commandLink id="commandLink" value="commandLink" />
+            <h:outputText id="commandLinkExecuted" value="#{not empty param['form:commandLink']}" />
+
+            <h:commandButton id="ajaxButton" value="ajaxButton">
+                <f:ajax execute="@this" render="ajaxExecuted" />
+            </h:commandButton>
+            <h:panelGroup id="ajaxExecuted">
+                <h:outputText value="#{facesContext.partialViewContext.ajaxRequest}" />
+            </h:panelGroup>
+        </h:form>
+    </h:body>
+</html>

--- a/tck/faces50/csp-disabled/src/main/webapp/issue5741.xhtml
+++ b/tck/faces50/csp-disabled/src/main/webapp/issue5741.xhtml
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<!--
+
+    Copyright (c) Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+<html lang="en"
+    xmlns:f="jakarta.faces.core"
+    xmlns:h="jakarta.faces.html"
+>
+    <h:head>
+        <title>issue5741</title>
+    </h:head>
+    <h:body>
+        <h:form id="form">
+            <h:commandLink id="commandLink" value="commandLink" />
+            <h:outputText id="commandLinkExecuted" value="#{not empty param['form:commandLink']}" />
+
+            <h:commandButton id="commandButton" value="commandButton" />
+            <h:outputText id="commandButtonExecuted" value="#{not empty param['form:commandButton']}" />
+
+            <h:commandButton id="ajaxButton" value="ajaxButton">
+                <f:ajax execute="@this" render="ajaxButtonExecuted" />
+            </h:commandButton>
+            <h:panelGroup id="ajaxButtonExecuted">
+                <h:outputText value="#{facesContext.partialViewContext.ajaxRequest}" />
+            </h:panelGroup>
+
+            <h:commandLink id="ajaxLink" value="ajaxLink">
+                <f:ajax execute="@this" render="ajaxLinkExecuted" />
+            </h:commandLink>
+            <h:panelGroup id="ajaxLinkExecuted">
+                <h:outputText value="#{facesContext.partialViewContext.ajaxRequest}" />
+            </h:panelGroup>
+
+            <h:button id="outcomeButton" value="outcomeButton" outcome="issue5741" />
+        </h:form>
+    </h:body>
+</html>

--- a/tck/faces50/csp-disabled/src/test/java/ee/jakarta/tck/faces/faces50/csp_disabled/Issue5606IT.java
+++ b/tck/faces50/csp-disabled/src/test/java/ee/jakarta/tck/faces/faces50/csp_disabled/Issue5606IT.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GPL-2.0 with Classpath-exception-2.0 which
+ * is available at https://openjdk.java.net/legal/gplv2+ce.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 or Apache-2.0
+ */
+package ee.jakarta.tck.faces.faces50.csp_disabled;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import jakarta.faces.application.ResourceHandler;
+
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.FindBy;
+
+import ee.jakarta.tck.faces.util.selenium.BaseITNG;
+import ee.jakarta.tck.faces.util.selenium.WebPage;
+
+/**
+ * With CSP nonce injection disabled (the default, i.e. {@link ResourceHandler#ENABLE_CSP_NONCE} not set),
+ * command components must render their {@code onclick} handler and keep working, and no CSP nonce may be
+ * emitted onto the {@code faces.js} script element. Whether the handler is rendered as an inline
+ * {@code onclick} attribute or wired via a {@code <script>} block is implementation-specific per
+ * jakartaee/faces#2167, so this asserts the observable contract (handler present, click still works,
+ * no nonce) rather than the rendering strategy.
+ *
+ * @see ResourceHandler#ENABLE_CSP_NONCE
+ * @see https://github.com/eclipse-ee4j/mojarra/issues/5606
+ */
+class Issue5606IT extends BaseITNG {
+
+    @FindBy(id = "form:commandLink")
+    private WebElement commandLink;
+
+    @FindBy(id = "form:commandLinkExecuted")
+    private WebElement commandLinkExecuted;
+
+    @FindBy(id = "form:ajaxButton")
+    private WebElement ajaxButton;
+
+    @FindBy(id = "form:ajaxExecuted")
+    private WebElement ajaxExecuted;
+
+    @Test
+    public void testCommandLinkWithoutCsp() {
+        var page = getPage("issue5606.xhtml");
+        assertNull(getNonce(page), "No CSP nonce must be emitted when CSP is disabled (the default)");
+        assertTrue(page.isAttributeWired(commandLink, "onclick"), "commandLink must have its onclick handler rendered");
+        assertEquals("false", commandLinkExecuted.getText());
+        page.guardHttp(commandLink::click);
+        assertEquals("true", commandLinkExecuted.getText());
+    }
+
+    @Test
+    public void testCommandButtonAjaxWithoutCsp() {
+        var page = getPage("issue5606.xhtml");
+        assertNull(getNonce(page), "No CSP nonce must be emitted when CSP is disabled (the default)");
+        assertTrue(page.isAttributeWired(ajaxButton, "onclick"), "ajaxButton must have its onclick handler rendered");
+        assertEquals("false", ajaxExecuted.getText());
+        page.guardAjax(ajaxButton::click);
+        assertEquals("true", ajaxExecuted.getText());
+    }
+
+    private String getNonce(WebPage page) {
+        var scripts = page.findElements(By.cssSelector("script[src*='jakarta.faces.resource/faces.js']"));
+        return scripts.isEmpty() ? null : scripts.get(0).getDomAttribute("nonce");
+    }
+}

--- a/tck/faces50/csp-disabled/src/test/java/ee/jakarta/tck/faces/faces50/csp_disabled/Issue5741IT.java
+++ b/tck/faces50/csp-disabled/src/test/java/ee/jakarta/tck/faces/faces50/csp_disabled/Issue5741IT.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GPL-2.0 with Classpath-exception-2.0 which
+ * is available at https://openjdk.java.net/legal/gplv2+ce.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 or Apache-2.0
+ */
+package ee.jakarta.tck.faces.faces50.csp_disabled;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import jakarta.faces.application.ResourceHandler;
+
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.FindBy;
+
+import ee.jakarta.tck.faces.util.selenium.BaseITNG;
+import ee.jakarta.tck.faces.util.selenium.WebPage;
+
+/**
+ * Same CSP-disabled contract as {@link Issue5606IT}, but exercised through an exact servlet mapping
+ * (the extensionless {@code /issue5741} url-pattern) rather than the standard {@code *.xhtml} suffix
+ * mapping. Under exact mapping the wrong event handler used to be rendered for command components,
+ * breaking the click; this verifies that with CSP disabled (the default) each command component keeps
+ * its {@code onclick} handler wired and functioning and no CSP nonce is emitted.
+ *
+ * @see ResourceHandler#ENABLE_CSP_NONCE
+ * @see https://github.com/eclipse-ee4j/mojarra/issues/5741
+ */
+class Issue5741IT extends BaseITNG {
+
+    private static final String PAGE = "issue5741"; // Exact-mapped, hence extensionless.
+
+    @FindBy(id = "form:commandLink")
+    private WebElement commandLink;
+
+    @FindBy(id = "form:commandLinkExecuted")
+    private WebElement commandLinkExecuted;
+
+    @FindBy(id = "form:commandButton")
+    private WebElement commandButton;
+
+    @FindBy(id = "form:commandButtonExecuted")
+    private WebElement commandButtonExecuted;
+
+    @FindBy(id = "form:ajaxButton")
+    private WebElement ajaxButton;
+
+    @FindBy(id = "form:ajaxButtonExecuted")
+    private WebElement ajaxButtonExecuted;
+
+    @FindBy(id = "form:ajaxLink")
+    private WebElement ajaxLink;
+
+    @FindBy(id = "form:ajaxLinkExecuted")
+    private WebElement ajaxLinkExecuted;
+
+    @FindBy(id = "form:outcomeButton")
+    private WebElement outcomeButton;
+
+    @Test
+    public void testCommandLink() {
+        var page = getPage(PAGE);
+        assertNull(getNonce(page), "No CSP nonce must be emitted when CSP is disabled (the default)");
+        assertTrue(page.isAttributeWired(commandLink, "onclick"), "commandLink must have its onclick handler rendered");
+        assertEquals("false", commandLinkExecuted.getText());
+        page.guardHttp(commandLink::click);
+        assertEquals("true", commandLinkExecuted.getText());
+    }
+
+    // A plain h:commandButton renders a native submit input without an onclick handler, so unlike the
+    // link and ajax variants there is nothing to assert on the handler; the full postback must just work.
+    @Test
+    public void testCommandButton() {
+        var page = getPage(PAGE);
+        assertNull(getNonce(page), "No CSP nonce must be emitted when CSP is disabled (the default)");
+        assertEquals("false", commandButtonExecuted.getText());
+        page.guardHttp(commandButton::click);
+        assertEquals("true", commandButtonExecuted.getText());
+    }
+
+    @Test
+    public void testCommandButtonAjax() {
+        var page = getPage(PAGE);
+        assertNull(getNonce(page), "No CSP nonce must be emitted when CSP is disabled (the default)");
+        assertTrue(page.isAttributeWired(ajaxButton, "onclick"), "ajaxButton must have its onclick handler rendered");
+        assertEquals("false", ajaxButtonExecuted.getText());
+        page.guardAjax(ajaxButton::click);
+        assertEquals("true", ajaxButtonExecuted.getText());
+    }
+
+    @Test
+    public void testCommandLinkAjax() {
+        var page = getPage(PAGE);
+        assertNull(getNonce(page), "No CSP nonce must be emitted when CSP is disabled (the default)");
+        assertTrue(page.isAttributeWired(ajaxLink, "onclick"), "ajaxLink must have its onclick handler rendered");
+        assertEquals("false", ajaxLinkExecuted.getText());
+        page.guardAjax(ajaxLink::click);
+        assertEquals("true", ajaxLinkExecuted.getText());
+    }
+
+    @Test
+    public void testOutcomeButton() {
+        var page = getPage(PAGE);
+        assertNull(getNonce(page), "No CSP nonce must be emitted when CSP is disabled (the default)");
+        assertTrue(page.isAttributeWired(outcomeButton, "onclick"), "outcomeButton must have its onclick handler rendered");
+    }
+
+    private String getNonce(WebPage page) {
+        var scripts = page.findElements(By.cssSelector("script[src*='jakarta.faces.resource/faces.js']"));
+        return scripts.isEmpty() ? null : scripts.get(0).getDomAttribute("nonce");
+    }
+}

--- a/tck/faces50/pom.xml
+++ b/tck/faces50/pom.xml
@@ -46,6 +46,7 @@
         <module>facelets</module>
         <module>ajax</module>
         <module>csp</module>
+        <module>csp-disabled</module>
         <module>misc</module>
         <module>view-protection</module>
         <module>extensionless-mapping</module>


### PR DESCRIPTION
Ports two mojarra ITs that had no TCK equivalent — `issue5606` and `issue5741` — into a new `faces50/csp-disabled` module.

Both cover the default **CSP-disabled** rendering path of command components: the `onclick` handler must be rendered and the click must keep working, and no CSP nonce may be emitted. `issue5741` additionally exercises this under an **exact servlet mapping** (extensionless url-pattern), which was the specific regression surface.

## Why a new module

CSP nonce injection is application-wide via `jakarta.faces.ENABLE_CSP_NONCE`, so these tests cannot share the CSP-*enabled* `faces50/csp` war. The new module leaves the context-param unset (the default) so it renders the CSP-disabled path.

## Implementation-agnostic

The original mojarra tests assert on Mojarra-internal JS symbols (`mojarra.cljs`/`ab`/`ael`), which aren't portable. Rewritten to assert the spec-observable contract only:

- **no CSP nonce** on the `faces.js` script (ties to `ResourceHandler.ENABLE_CSP_NONCE` default);
- **handler wired** via the existing `WebPage.isAttributeWired` helper (per jakartaee/faces#2167 — inline `on*` or scripted, both accepted);
- **click still works** — full postback and ajax round-trips fire the action (this is what actually catches the regression).

A plain non-ajax `h:commandButton` renders a native submit input with no `onclick`, so only its functional postback is asserted.

## Tests

- `Issue5606IT` (2): commandLink + ajax commandButton, standard mapping
- `Issue5741IT` (5): commandLink, commandButton, ajax button, ajax link, `h:button`, all under exact mapping

7/7 green on GlassFish.

🤖 Generated with Claude Opus 4.8
