### PR TITLE
Reduce allocation and state writes on the component-id paths

### DIFF
--- a/api/src/main/java/jakarta/faces/component/UIComponentBase.java
+++ b/api/src/main/java/jakarta/faces/component/UIComponentBase.java
@@ -3815,28 +3815,45 @@ public abstract class UIComponentBase extends UIComponent {
             return base;
         }
 
-        // Search through our facets and children
-        UIComponent component = null;
-        for (Iterator<UIComponent> i = base.getFacetsAndChildren(); i.hasNext();) {
-            UIComponent kid = i.next();
-            if (!(kid instanceof NamingContainer)) {
-                if (checkId && id.equals(kid.getId())) {
-                    component = kid;
-                    break;
-                }
-
-                component = findComponent(kid, id, true);
-
+        // Search through our facets and children, in the order getFacetsAndChildren() defines (facets first),
+        // but without that method's per-node wrapper collection and iterator: this walk recurses over the whole
+        // subtree, so allocating two objects per node visited dominates the cost of resolving a single id.
+        if (base.getFacetCount() != 0) {
+            for (UIComponent facet : base.getFacets().values()) {
+                UIComponent component = findComponentInKid(facet, id);
                 if (component != null) {
-                    break;
+                    return component;
                 }
-            } else if (id.equals(kid.getId())) {
-                component = kid;
-                break;
             }
         }
 
-        return component;
+        if (base.getChildCount() != 0) {
+            List<UIComponent> children = base.getChildren();
+            for (int i = 0, size = children.size(); i < size; i++) {
+                UIComponent component = findComponentInKid(children.get(i), id);
+                if (component != null) {
+                    return component;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * <p>
+     * Match <code>id</code> against a single facet or child of the component being searched: a
+     * {@link NamingContainer} matches only on its own id and is never descended into, any other kid is matched
+     * by a recursive scan which checks its own id first.
+     * </p>
+     */
+    private static UIComponent findComponentInKid(UIComponent kid, String id) {
+
+        if (kid instanceof NamingContainer) {
+            return id.equals(kid.getId()) ? kid : null;
+        }
+
+        return findComponent(kid, id, true);
     }
 
     private List<Object> collectChildState(FacesContext context, List<Object> stateList) {

--- a/api/src/main/java/jakarta/faces/component/UIData.java
+++ b/api/src/main/java/jakarta/faces/component/UIData.java
@@ -1240,10 +1240,16 @@ public class UIData extends UIComponentBase implements NamingContainer, UniqueId
 
     @Override
     public String createUniqueId(FacesContext context, String seed) {
+        // A seed is already unique within the view, so the counter -- and the state write backing it -- is only
+        // needed to generate an id when no seed is given.
+        if (seed != null) {
+            return UIViewRoot.UNIQUE_ID_PREFIX + seed;
+        }
+
         Integer i = (Integer) getStateHelper().get(PropertyKeys.lastId);
         int lastId = i != null ? i : 0;
         getStateHelper().put(PropertyKeys.lastId, ++lastId);
-        return UIViewRoot.UNIQUE_ID_PREFIX + (seed == null ? lastId : seed);
+        return UIViewRoot.UNIQUE_ID_PREFIX + lastId;
     }
 
     /**

--- a/api/src/main/java/jakarta/faces/component/UIForm.java
+++ b/api/src/main/java/jakarta/faces/component/UIForm.java
@@ -16,7 +16,6 @@
 
 package jakarta.faces.component;
 
-import static jakarta.faces.component.PackageUtils.coalesce;
 import static jakarta.faces.component.UIViewRoot.UNIQUE_ID_PREFIX;
 import static jakarta.faces.component.visit.VisitResult.COMPLETE;
 
@@ -281,11 +280,18 @@ public class UIForm extends UIComponentBase implements NamingContainer, UniqueId
     @Override
     public String createUniqueId(FacesContext context, String seed) {
         if (isPrependId()) {
-            int lastId = coalesce(getLastId(), 0);
+            // A seed is already unique within the view, so the counter -- and the state write backing it -- is only
+            // needed to generate an id when no seed is given.
+            if (seed != null) {
+                return UNIQUE_ID_PREFIX + seed;
+            }
+
+            Integer i = getLastId();
+            int lastId = i != null ? i : 0;
 
             setLastId(++lastId);
 
-            return UNIQUE_ID_PREFIX + coalesce(seed, lastId);
+            return UNIQUE_ID_PREFIX + lastId;
         }
 
         UIComponent ancestorNamingContainer = getParent() == null ? null : getParent().getNamingContainer();

--- a/api/src/main/java/jakarta/faces/component/UINamingContainer.java
+++ b/api/src/main/java/jakarta/faces/component/UINamingContainer.java
@@ -16,7 +16,6 @@
 
 package jakarta.faces.component;
 
-import static jakarta.faces.component.PackageUtils.coalesce;
 import static jakarta.faces.component.UIViewRoot.UNIQUE_ID_PREFIX;
 import static jakarta.faces.component.visit.VisitResult.COMPLETE;
 import static java.util.logging.Level.SEVERE;
@@ -167,10 +166,17 @@ public class UINamingContainer extends UIComponentBase implements NamingContaine
 
     @Override
     public String createUniqueId(FacesContext context, String seed) {
-        int lastId = coalesce(getLastId(), 0);
+        // A seed is already unique within the view, so the counter -- and the state write backing it -- is only
+        // needed to generate an id when no seed is given.
+        if (seed != null) {
+            return UNIQUE_ID_PREFIX + seed;
+        }
+
+        Integer i = getLastId();
+        int lastId = i != null ? i : 0;
         setLastId(++lastId);
 
-        return UNIQUE_ID_PREFIX + coalesce(seed, lastId);
+        return UNIQUE_ID_PREFIX + lastId;
     }
 
     // ----------------------------------------------------- Private Methods


### PR DESCRIPTION
Two allocation/state reductions on the component-id paths, found while profiling `test/perf` for eclipse-ee4j/mojarra#5753.

### `UIComponentBase.findComponent`

The recursive walk called `getFacetsAndChildren()` at **every node**, and that method wraps the children in `Collections.unmodifiableList` and allocates an iterator over it. An `h:message` or `h:outputLabel` with a `for` attribute resolves its target through `findComponent` on every render, so a form with ~80 of them walks the subtree ~80 times.

Those wrappers accounted for **563 MB of the 1.87 GB** allocated during `RENDER_RESPONSE` of the `form-inputs` perf scenario. Iterating the facets and then the children directly, in the order `getFacetsAndChildren()` defines, removes them.

Measured on `test/perf` (Tomcat, 8000 runs, interleaved A/B):

| scenario | before | after | Δ |
|---|--:|--:|--:|
| form-inputs RENDER_RESPONSE | 1413 µs | ~1240 µs | -12% |
| form-invalid RENDER_RESPONSE | 1198 µs | ~1030 µs | -14% |
| form-inputs-ajax RENDER_RESPONSE | 1397 µs | ~1210 µs | -14% |

Behaviour is unchanged: a `NamingContainer` child still matches only on its own id and is never descended into, and the base id is still examined only when `checkId` is set. Verified with 12 assertions run against both the old and the new implementation, which agree on every case (facets-before-children ordering, duplicate ids across a facet and a child, `NamingContainer` subtrees, empty components, missing ids).

### `createUniqueId`

`UIViewRoot.createUniqueId` already returns `UNIQUE_ID_PREFIX + seed` before reading `lastId`. `UIForm`, `UINamingContainer` and `UIData` instead did a `StateHelper` get **and** put to advance `lastId`, then discarded the value whenever a seed was supplied — which Facelets always does. This gives them the same fast path.

It drops a state read-modify-write per component built inside a form, a naming container or a `UIData`, and keeps `lastId` out of the saved delta state of views whose ids all come from Facelets. It also flattens `PackageUtils.coalesce` out of the remaining seedless path: it is a `@SafeVarargs T...` method, so each call allocated an array.

**Behaviour note:** a seeded call no longer consumes a counter value, so a seedless call that follows one now yields the next unused number. This matches `UIViewRoot`, which has always behaved this way.

**Wall time is unchanged** for this second commit — it is made for the smaller saved state and for consistency with `UIViewRoot`, not for speed. Verified with 24 assertions across all four `UniqueIdVendor` implementations.

### Testing

Full Faces TCK green. Mojarra-side companion PR (impl changes) follows separately; it will bump the `faces` submodule pin once this merges.

🤖 Generated with Claude Opus 4.8
