### PR TITLE
Avoid two redundant EL resolver walks per input during validation

### DIFF
--- a/api/src/main/java/jakarta/faces/component/UIComponentBase.java
+++ b/api/src/main/java/jakarta/faces/component/UIComponentBase.java
@@ -787,6 +787,28 @@ public abstract class UIComponentBase extends UIComponent {
     }
 
     /**
+     * Whether at least one listener of the given type would receive an event broadcast by this component. Reads the
+     * same list {@link #broadcast} does, without building the arrays {@link #getFacesListeners} has to allocate.
+     *
+     * @param clazz the listener type to look for
+     * @return true if such a listener is attached
+     */
+    boolean hasFacesListener(Class<? extends FacesListener> clazz) {
+
+        if (listeners == null) {
+            return false;
+        }
+
+        for (Iterator<FacesListener> i = listeners.iterator(); i.hasNext();) {
+            if (clazz.isAssignableFrom(i.next().getClass())) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
      * @throws IllegalArgumentException {@inheritDoc}
      * @throws NullPointerException {@inheritDoc}
      */

--- a/api/src/main/java/jakarta/faces/component/UIInput.java
+++ b/api/src/main/java/jakarta/faces/component/UIInput.java
@@ -880,10 +880,16 @@ public class UIInput extends UIOutput implements EditableValueHolder {
         // If our value is valid, store the new value, erase the
         // "submitted" value, and emit a ValueChangeEvent if appropriate
         if (isValid()) {
-            Object previous = getValue();
+            // Reading the previous value evaluates the value expression, which walks the whole ELResolver chain and,
+            // with CDI in that chain, resolves the bean afresh. It only feeds the ValueChangeEvent, and a queued event
+            // is discarded at broadcast when nothing is listening for it, so skip the read in that case.
+            boolean valueChangeObserved = hasFacesListener(ValueChangeListener.class);
+            Object previous = valueChangeObserved ? getValue() : null;
+
             setValue(newValue);
             setSubmittedValue(null);
-            if (compareValues(previous, newValue)) {
+
+            if (valueChangeObserved && compareValues(previous, newValue)) {
                 queueEvent(new ValueChangeEvent(context, this, previous, newValue));
             }
         }

--- a/api/src/main/java/jakarta/faces/validator/BeanValidator.java
+++ b/api/src/main/java/jakarta/faces/validator/BeanValidator.java
@@ -35,6 +35,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.regex.Pattern;
 
+import jakarta.el.ELContext;
 import jakarta.el.PropertyNotFoundException;
 import jakarta.el.ValueExpression;
 import jakarta.el.ValueReference;
@@ -318,7 +319,8 @@ public class BeanValidator implements Validator<Object>, PartialStateHolder {
             return;
         }
 
-        ValueReference valueReference = getValueReference(context, component, valueExpression);
+        ResolvedValueReference resolvedValueReference = resolveValueReference(context, component, valueExpression);
+        ValueReference valueReference = resolvedValueReference.getReference();
 
         if (valueReference == null || valueReference.getBase() == null) {
             return;
@@ -328,7 +330,8 @@ public class BeanValidator implements Validator<Object>, PartialStateHolder {
 
         if (isResolvable(valueReference, valueExpression)) {
             jakarta.validation.Validator beanValidator = getBeanValidator(context);
-            Object coercedValue = value == null ? null : context.getApplication().getExpressionFactory().coerceToType(value, valueExpression.getType(context.getELContext()));
+            Object coercedValue = value == null ? null
+                    : context.getApplication().getExpressionFactory().coerceToType(value, getPropertyType(context, valueExpression, resolvedValueReference));
 
             Set<? extends ConstraintViolation<?>> violations = null;
 
@@ -369,7 +372,32 @@ public class BeanValidator implements Validator<Object>, PartialStateHolder {
         }
     }
 
-    private static ValueReference getValueReference(FacesContext context, UIComponent component, ValueExpression valueExpression) {
+    /**
+     * A {@link ValueReference}, plus whether it had to be unwrapped out of a composite component's
+     * <code>#{cc.attrs.x}</code> indirection. Once unwrapped it points at the backing bean property rather than at
+     * what the original expression's own {@link ValueExpression#getType} would report, which
+     * {@link #getPropertyType} has to account for.
+     */
+    private static final class ResolvedValueReference {
+
+        private final ValueReference reference;
+        private final boolean unwrappedFromCompositeComponent;
+
+        ResolvedValueReference(ValueReference reference, boolean unwrappedFromCompositeComponent) {
+            this.reference = reference;
+            this.unwrappedFromCompositeComponent = unwrappedFromCompositeComponent;
+        }
+
+        ValueReference getReference() {
+            return reference;
+        }
+
+        boolean isUnwrappedFromCompositeComponent() {
+            return unwrappedFromCompositeComponent;
+        }
+    }
+
+    private static ResolvedValueReference resolveValueReference(FacesContext context, UIComponent component, ValueExpression valueExpression) {
         try {
             ValueReference reference = valueExpression.getValueReference(context.getELContext());
             if (reference != null) {
@@ -377,11 +405,11 @@ public class BeanValidator implements Validator<Object>, PartialStateHolder {
                 if (base instanceof CompositeComponentExpressionHolder) {
                     ValueExpression ve = ((CompositeComponentExpressionHolder) base).getExpression(String.valueOf(reference.getProperty()));
                     if (ve != null) {
-                        reference = getValueReference(context, component, ve);
+                        return new ResolvedValueReference(resolveValueReference(context, component, ve).getReference(), true);
                     }
                 }
             }
-            return reference;
+            return new ResolvedValueReference(reference, false);
         }
         catch (PropertyNotFoundException e) {
             if (component instanceof UIInput && ((UIInput) component).getSubmittedValue() == null) {
@@ -392,11 +420,40 @@ public class BeanValidator implements Validator<Object>, PartialStateHolder {
                                        valueExpression.getExpressionString(),
                                        component.getId() });
                 }
-                return null;
+                return new ResolvedValueReference(null, false);
             } else {
                 throw e;
             }
         }
+    }
+
+    /**
+     * The type of the property the value expression points at.
+     * <p>
+     * {@link ValueExpression#getType} re-resolves the expression from its root and then asks the resolver about the
+     * base and property it arrives at. That base and property are exactly what the {@link ValueReference} already
+     * holds, so the resolver can be asked directly and the walk skipped -- which matters because with CDI in the
+     * resolver chain the root resolution is a bean lookup, once per input per request.
+     * <p>
+     * A reference unwrapped out of a composite component no longer describes the original expression's own target, so
+     * that case keeps the full walk.
+     */
+    private static Class<?> getPropertyType(FacesContext context, ValueExpression valueExpression, ResolvedValueReference resolvedValueReference) {
+        ELContext elContext = context.getELContext();
+
+        if (resolvedValueReference.isUnwrappedFromCompositeComponent()) {
+            return valueExpression.getType(elContext);
+        }
+
+        ValueReference valueReference = resolvedValueReference.getReference();
+        elContext.setPropertyResolved(false);
+        Class<?> type = elContext.getELResolver().getType(elContext, valueReference.getBase(), valueReference.getProperty());
+
+        if (!elContext.isPropertyResolved()) {
+            throw new PropertyNotFoundException(valueExpression.getExpressionString());
+        }
+
+        return type;
     }
 
     private boolean isResolvable(jakarta.el.ValueReference valueReference, ValueExpression valueExpression) {


### PR DESCRIPTION
## Avoid two redundant EL resolver walks per input during validation

During PROCESS_VALIDATIONS, each input resolved its value expression from the root more times than it needed to. Every root-identifier resolution walks the full `ELResolver` chain, and when a CDI `ELResolver` is in that chain each walk is a bean lookup (a fresh `CreationalContext` per call). This removes two of those walks per input per request.

### `UIInput.validate`

It read the previous value with `getValue()` only to feed a `ValueChangeEvent`. A queued event is discarded at broadcast when no `ValueChangeListener` is registered, so with no listener the read, the `compareValues()` and the event are all dead work. The read is now guarded by a new package-private `UIComponentBase.hasFacesListener()`, which scans the same list `broadcast()` iterates without allocating the arrays `getFacesListeners()` builds.

### `BeanValidator.validate`

It called `ValueExpression.getType()` to coerce the submitted value immediately after `getValueReference()` had already resolved the expression's base and property. `getType()` re-resolves the expression from its root. It now asks the resolver for the type of the base and property the `ValueReference` already holds. A reference unwrapped out of a composite component's `#{cc.attrs.x}` indirection no longer describes the original expression's own type, so that case keeps the full walk.

### Compliance

Both changes are observationally identical: with no listener the event could not have been delivered, and the property type is looked up on the same base and property either way. Full Faces TCK is green.

### Measured

Tomcat, order-balanced interleaved A/B, warm single-thread bench, four validation-heavy scenarios. (Measured on the 4.1 baseline; ported unchanged.)

| scenario | PROCESS_VALIDATIONS | scenario total |
|---|--:|--:|
| composite-inputs | −39.8% | −13.0% |
| form-inputs | −31.1% | −2.7% |
| table-inputs | −42.9% | −14.6% |
| repeat-inputs | −34.5% | −9.8% |

−9.9% across those four scenarios. Both changes mirror what Apache MyFaces already does. One local trade: composite-inputs UPDATE_MODEL_VALUES moves +11.8% (the same `cc.attrs` EL walk, JIT-warmed less now that PV no longer exercises it first); the composite total is still −13%.

Part of eclipse-ee4j/mojarra#5753.

🤖 Generated with Claude Opus 4.8
