### PR TITLE
Persist system-event listeners in the partial-state delta only when changed

### DIFF
--- a/api/src/main/java/jakarta/faces/component/UIComponent.java
+++ b/api/src/main/java/jakarta/faces/component/UIComponent.java
@@ -2446,4 +2446,12 @@ public abstract class UIComponent implements PartialStateHolder, TransientStateH
      * rides in the partial-state delta. Transient: re-derived per request as {@code buildView} rebuilds the tree.
      */
     transient boolean valueExpressionsModified;
+
+    /**
+     * {@code true} once a system-event listener is subscribed or unsubscribed after {@code markInitialState}, so the
+     * change rides in the partial-state delta. Listeners established during the view build ({@code @ListenerFor},
+     * {@code f:event}) are re-established by {@code buildView} on restore, so they stay out of the delta. Transient:
+     * re-derived per request as {@code buildView} rebuilds the tree.
+     */
+    transient boolean systemEventListenersModified;
 }

--- a/api/src/main/java/jakarta/faces/component/UIComponentBase.java
+++ b/api/src/main/java/jakarta/faces/component/UIComponentBase.java
@@ -927,8 +927,14 @@ public abstract class UIComponentBase extends UIComponent {
         }
 
         if (!listenersForEventClass.contains(facesLifecycleListener)) {
-            clearInitialState();
             listenersForEventClass.add(facesLifecycleListener);
+            // A listener subscribed while the view's initial state is being built (@ListenerFor on a component or
+            // renderer, an f:event handler) is part of the initial-state baseline and buildView re-establishes it on
+            // restore, so only a subscription made after markInitialState needs to ride along in the delta (mirrors
+            // valueExpressionsModified / rendererTypeSet).
+            if (initialStateMarked()) {
+                systemEventListenersModified = true;
+            }
         }
     }
 
@@ -966,6 +972,9 @@ public abstract class UIComponentBase extends UIComponent {
 
                 if (existingListener.equals(componentListener)) {
                     i.remove();
+                    if (initialStateMarked()) {
+                        systemEventListenersModified = true;
+                    }
                     break;
                 }
             }
@@ -1324,7 +1333,9 @@ public abstract class UIComponentBase extends UIComponent {
 
         if (initialStateMarked()) {
             Object savedFacesListeners = listeners != null ? listeners.saveState(context) : null;
-            Object savedSysEventListeners = saveSystemEventListeners(context);
+            // buildView re-subscribes @ListenerFor / f:event listeners on restore, so only a subscription made after
+            // markInitialState needs to ride along in the delta (mirrors valueExpressionsModified / rendererTypeSet).
+            Object savedSysEventListeners = systemEventListenersModified ? saveSystemEventListeners(context) : null;
             Object savedBehaviors = saveBehaviorsState(context);
             // buildView re-applies facelet value expressions on restore, so only a change made after
             // markInitialState needs to ride along in the delta (mirrors rendererType/rendererTypeSet).
@@ -1412,6 +1423,11 @@ public abstract class UIComponentBase extends UIComponent {
                 listenersByEventClass.putAll(restoredListeners);
             } else {
                 listenersByEventClass = restoredListeners;
+            }
+            if (values.length != 7) {
+                // Partial-state delta: a listener changed after markInitialState; keep it dirty so the change stays
+                // in the delta across subsequent postbacks (mirrors valueExpressionsModified / rendererTypeSet).
+                systemEventListenersModified = true;
             }
         }
 


### PR DESCRIPTION
## Problem

Under partial state saving, `UIComponentBase.saveState` persisted the system-event listener map (`listenersByEventClass`) **unconditionally** — unlike value expressions (gated on `valueExpressionsModified`) and `rendererType` (gated on `rendererTypeSet`).

But `@ListenerFor` listeners — on a component **or** on a renderer — and `f:event` handlers are re-subscribed by `buildView` on every restore. So persisting them is redundant: it re-adds a listener the tree rebuild already established.

Worse, it emits a per-component **delta for otherwise-static components**. Every `h:selectOneRadio` / `f:importConstants` / `f:websocket` / `h:outputScript` / `h:outputStylesheet` gets a listener in state because its renderer is `@ListenerFor(PostAddToViewEvent)`. One such component in a form is enough to push the saved state past the "view-root-only" threshold, so the state manager runs the full O(n) restore traversal (building every component's client id) instead of the fast path.

## Fix

Make system-event listeners delta-aware, mirroring the existing `valueExpressionsModified` / `rendererTypeSet` pattern:

- add `transient boolean systemEventListenersModified`;
- `subscribeToEvent` / `unsubscribeFromEvent` set it **only when the change happens after `markInitialState`** (a genuine runtime change);
- `saveState` saves the listener map only when the flag is set;
- `restoreState` re-arms the flag when a listener delta was restored, so it persists across postbacks.

Build-time listeners (`@ListenerFor`, `f:event`) stay in the initial-state baseline and are rebuilt by `buildView`; genuine runtime subscriptions still ride the delta. **Full state saving is unaffected** (it saves the full listener map regardless).

This matches how MyFaces already treats these listeners (its per-event-class list is a `PartialStateHolder` `_DeltaList` that only emits post-mark additions).

## Measurement

Isolated `form-inputs` (a form whose only per-component deltas were two `selectOneRadio` listeners), Tomcat, warmup 200, 20k runs, before/after A/B:

- component state entries: **3 → 1** → the view-root-only restore fast path now applies
- **`RESTORE_VIEW` −9.1%** (453 → 412 µs); other phases flat

Any view using `@ListenerFor` components/renderers or `f:event` now saves smaller state and is likelier to hit the fast path.

## Testing

Full TCK green.

Found while profiling the Mojarra perf scenarios (eclipse-ee4j/mojarra#5753).

🤖 Generated with Claude Opus 4.8
