### PR TITLE
Document AI-assisted contribution policy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,6 +37,26 @@ Contributor Agreement (ECA) on file.
 For more information, please see the Eclipse Committer Handbook:
 https://eclipse.org/projects/handbook/#resources-commit
 
+## AI-assisted contributions
+
+Use of AI coding assistants is welcome. If an AI tool materially contributed to a change, it is appreciated (but not required) to credit it in the commit message with a `Co-authored-by` trailer. Always include the model name and version so the attribution stays meaningful over time (model versions differ in behaviour). Here are some examples:
+
+- `Co-authored-by: Claude Opus 4.8 <noreply@anthropic.com>`
+- `Co-authored-by: GitHub Copilot (GPT-5) <copilot@github.com>`
+- `Co-authored-by: Cursor (Claude Sonnet 4.5) <cursoragent@cursor.com>`
+- `Co-authored-by: Devin AI 2.0 <158243242+devin-ai-integration[bot]@users.noreply.github.com>`
+- `Co-authored-by: OpenAI Codex (GPT-5-Codex) <codex@openai.com>`
+- `Co-authored-by: Gemini 2.5 Pro <gemini@google.com>`
+- `Co-authored-by: Grok 4 <grok@x.ai>`
+
+Use whatever model and version your tool actually reports.
+
+Why we ask for this:
+
+- **Traceability** — makes it clear which parts of the history were AI-assisted, which helps when auditing a regression or a licensing question later.
+- **Accountability** — ties the change to the tool and model that produced it, not just a vague "AI" label; model versions differ in behaviour and matter.
+- **Responsibility** — the human contributor remains the author of record. The `Signed-off-by` and ECA requirements above apply unchanged, and you are expected to review, understand, and stand behind any AI-generated code you submit.
+
 ## Eclipse Development Process
 
 This Eclipse Foundation open project is governed by the Eclipse Foundation

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ Refer to the `README.md` of the subprojects.
 ## Making Changes
 
 To make changes, fork this repository, make your changes, and submit a pull request.
+Before submitting, please review [CONTRIBUTING.md](CONTRIBUTING.md) for the Eclipse Contributor
+Agreement (ECA), the sign-off requirement, and the AI-assisted contribution policy.
 
 ## Plans for Faces.next
 


### PR DESCRIPTION
Adds an **AI-assisted contributions** section to `CONTRIBUTING.md`, mirroring [mojarra#5852](https://github.com/eclipse-ee4j/mojarra/pull/5852): AI coding assistants are welcome, and materially-contributing tools should be credited with a model-versioned `Co-authored-by` trailer. The human contributor remains the author of record; ECA and `Signed-off-by` requirements are unchanged.

Also references `CONTRIBUTING.md` from the README's "Making Changes" section — it was previously linked nowhere.

Documentation only, no code changes.

🤖 Generated with Claude Opus 4.8