### PR TITLE
Implement UIViewRoot.restoreViewScopeState() properly

### DIFF
--- a/api/src/main/java/jakarta/faces/component/UIViewRoot.java
+++ b/api/src/main/java/jakarta/faces/component/UIViewRoot.java
@@ -237,9 +237,6 @@ public class UIViewRoot extends UIComponentBase implements UniqueIdVendor {
     private static final String VIEW_MAP_ID_KEY = "org.glassfish.mojarra.application.view.viewMapId";
     private static final String ACTIVE_VIEW_MAPS_KEY = "org.glassfish.mojarra.application.view.activeViewMaps";
 
-    // TODO: can be dropped after https://github.com/eclipse-ee4j/mojarra/issues/5787 
-    private static final String RESTORE_VIEW_SCOPE_ONLY_KEY = "org.glassfish.mojarra.application.view.restoreViewScopeOnly";
-
     enum PropertyKeys {
         /**
          * <p>
@@ -1791,15 +1788,14 @@ public class UIViewRoot extends UIComponentBase implements UniqueIdVendor {
             return;
         }
 
-        values = (Object[]) state;
-        super.restoreState(context, values[0]);
+        restoreViewMap(context, (Object[]) state);
+        viewScopeStateRestored = true;
     }
-
-    // END TENATIVE <== ???
 
     // ----------------------------------------------------- StateHolder Methods
 
     private Object[] values;
+    private boolean viewScopeStateRestored;
 
     @Override
     public Object saveState(FacesContext context) {
@@ -1818,7 +1814,6 @@ public class UIViewRoot extends UIComponentBase implements UniqueIdVendor {
     }
 
     @Override
-    @SuppressWarnings("unchecked") // the opaque state Object and session-stored view maps are cast back to their saved types.
     public void restoreState(FacesContext context, Object state) {
         if (context == null) {
             throw new NullPointerException();
@@ -1829,11 +1824,25 @@ public class UIViewRoot extends UIComponentBase implements UniqueIdVendor {
 
         values = (Object[]) state;
 
-        if (!context.getAttributes().containsKey(RESTORE_VIEW_SCOPE_ONLY_KEY)) {
-            super.restoreState(context, values[0]);
-        }
+        super.restoreState(context, values[0]);
 
-        String viewMapId = (String) values[1];
+        if (!viewScopeStateRestored) {
+            restoreViewMap(context, values);
+        }
+    }
+
+    // --------------------------------------------------------- Private Methods
+
+    /**
+     * Restores the view map associated with the view map id in the saved state. {@link #restoreViewScopeState} invokes
+     * this up front so that view scoped beans are resolvable in EL while the view is being built; {@link #restoreState}
+     * invokes it only when that did not already happen. Rewiring it a second time would be destructive: when the saved
+     * view map is no longer among the active view maps, building the view mints a replacement whose id is held in the
+     * transient state, and restoring the saved id over it would orphan that replacement.
+     */
+    @SuppressWarnings("unchecked") // the session-stored view maps are cast back to their saved types.
+    private void restoreViewMap(FacesContext context, Object[] state) {
+        String viewMapId = (String) state[1];
 
         getTransientStateHelper().putTransient(VIEW_MAP_ID_KEY, viewMapId);
 
@@ -1843,8 +1852,6 @@ public class UIViewRoot extends UIComponentBase implements UniqueIdVendor {
             viewMap = (Map<String, Object>) viewMaps.get(viewMapId);
         }
     }
-
-    // --------------------------------------------------------- Private Methods
 
     private static String getIdentifier(String target) {
         // check map


### PR DESCRIPTION
Implements `UIViewRoot.restoreViewScopeState(FacesContext, Object)`, a stub since Faces 2.2 (https://github.com/jakartaee/faces/issues/787). Full rationale in eclipse-ee4j/mojarra#5787; the Mojarra side follows in a separate PR.

The method restored the component tree rather than the view scope and had no callers in Mojarra, so the real behaviour was driven out-of-band through a `RESTORE_VIEW_SCOPE_ONLY` context attribute. This extracts the view map wiring into a private `restoreViewMap()`, invokes it from `restoreViewScopeState()` as `StateManagementStrategy.restoreView()`'s javadoc prescribes, and drops the attribute branching. The saved state shape is unchanged.

A `viewScopeStateRestored` flag stops `restoreState()` from rewiring the view map a second time. That was destructive when the saved view map is no longer among the active view maps (LRU-evicted, or gone with an expired session): building the view mints a replacement, and the second run restored the stale id over it, orphaning it.

**Cleaner API/impl split.** `UIViewRoot` is the only class in this repo carrying `org.glassfish.mojarra.*` string contracts, and it had three. This drops the only one that steered behaviour — `restoreState()` branched on impl runtime state via a key duplicated as two independent literals with no import between them. The remaining `VIEW_MAP_ID_KEY` and `ACTIVE_VIEW_MAPS_KEY` merely name where the view scope data lives; both are tracked by #2185, now the last item for this class.

**Compatibility.** Public since 2.2 but unused in Mojarra. This makes it load-bearing and corrects its semantics, so any external caller relying on the current behaviour sees a change. The signature is unchanged.

**Testing.** Full Faces TCK green. Unit tests are added on the Mojarra side, as this repo has no `UIViewRoot` test; both were verified to fail without this change, and removing only the guard fails only the guard test. Note the TCK pins just the signature — javadoc assertion `JSF:JAVADOC:3009` describes this behaviour, is marked `testable="true"`, and has no test.

🤖 Generated with Claude Opus 4.8
