### PR TITLE
Add IT for mojarra#5865: dynamic add inside a UIData row

### DIFF
--- a/tck/faces23/dynamic-components/src/main/java/ee/jakarta/tck/faces/faces23/dynamic_components/Issue5865Bean.java
+++ b/tck/faces23/dynamic-components/src/main/java/ee/jakarta/tck/faces/faces23/dynamic_components/Issue5865Bean.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2026 Contributors to Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.faces.faces23.dynamic_components;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+
+import jakarta.enterprise.context.SessionScoped;
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.component.html.HtmlOutputText;
+import jakarta.faces.context.FacesContext;
+import jakarta.inject.Named;
+
+/**
+ * Adds a child to a panel group which sits inside a data table row.
+ *
+ * <p>
+ * The command button invoking this also sits inside a row, so the row index is set by the time the action runs.
+ * The panel group is a single component instance reused for every row, so the added child belongs to all of them.
+ * </p>
+ */
+@Named
+@SessionScoped
+public class Issue5865Bean implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    public static final String ADDED = "ADDED-INSIDE-ROW";
+
+    private final List<String> rows = new ArrayList<>(List.of("row0", "row1", "row2"));
+
+    public List<String> getRows() {
+        return rows;
+    }
+
+    public void addInsideRow() {
+        FacesContext context = FacesContext.getCurrentInstance();
+        UIComponent group = context.getViewRoot().findComponent("form:table:group");
+
+        HtmlOutputText output = new HtmlOutputText();
+        output.setId("added" + group.getChildCount());
+        output.setValue(ADDED);
+        group.getChildren().add(output);
+    }
+
+    public void postback() {
+        // Just a way to post back.
+    }
+}

--- a/tck/faces23/dynamic-components/src/main/webapp/issue5865.xhtml
+++ b/tck/faces23/dynamic-components/src/main/webapp/issue5865.xhtml
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<!--
+
+    Copyright (c) 2026 Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+<html
+      xmlns:f="jakarta.faces.core"
+      xmlns:h="jakarta.faces.html">
+    <f:view>
+        <h:head>
+            <title>Issue5865</title>
+        </h:head>
+        <h:body>
+            <h:messages />
+            <h:form id="form">
+                <h:dataTable id="table" value="#{issue5865Bean.rows}" var="row">
+                    <h:column>
+                        <h:outputText value="#{row}" />
+                        <h:panelGroup id="group" layout="block" />
+                        <h:commandButton id="add" value="AddInsideRow"
+                                         action="#{issue5865Bean.addInsideRow}" />
+                    </h:column>
+                </h:dataTable>
+                <h:commandButton id="postback" value="Postback"
+                                 action="#{issue5865Bean.postback}" />
+            </h:form>
+        </h:body>
+    </f:view>
+</html>

--- a/tck/faces23/dynamic-components/src/test/java/ee/jakarta/tck/faces/faces23/dynamic_components/Issue5865IT.java
+++ b/tck/faces23/dynamic-components/src/test/java/ee/jakarta/tck/faces/faces23/dynamic_components/Issue5865IT.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2026 Contributors to Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.faces.faces23.dynamic_components;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+
+import ee.jakarta.tck.faces.util.selenium.BaseITNG;
+import ee.jakarta.tck.faces.util.selenium.WebPage;
+
+/**
+ * A component added programmatically to a container inside a data table row must render in the proper place, and
+ * must stay there across postbacks.
+ */
+public class Issue5865IT extends BaseITNG {
+
+    private static final int ROWS = 3;
+
+    private static int addedCount(WebPage page) {
+        String source = page.getSource();
+        int count = 0;
+        for (int i = source.indexOf(Issue5865Bean.ADDED); i >= 0;
+                i = source.indexOf(Issue5865Bean.ADDED, i + Issue5865Bean.ADDED.length())) {
+            count++;
+        }
+        return count;
+    }
+
+    /**
+     * The add is performed by a command button inside a row, so the row index is set while it runs. The panel group
+     * it targets is a single component instance reused for every row, so one add renders once per row.
+     *
+     * @see jakarta.faces.component.UIComponent#getChildren()
+     * @see https://github.com/eclipse-ee4j/mojarra/issues/5865
+     */
+    @Test
+    void testAddInsideDataTableRow() throws Exception {
+        WebPage page = getPage("issue5865.xhtml");
+        assertEquals(0, addedCount(page), "nothing added yet");
+
+        WebElement add = page.findElement(By.id("form:table:1:add"));
+        page.guardHttp(add::click);
+        assertEquals(ROWS, addedCount(page), "the added child must render, in every row of the shared group");
+
+        WebElement postback = page.findElement(By.id("form:postback"));
+        page.guardHttp(postback::click);
+        assertEquals(ROWS, addedCount(page), "the added child must survive a postback");
+    }
+}


### PR DESCRIPTION
IT for eclipse-ee4j/mojarra#5865, fixed by eclipse-ee4j/mojarra#5867.

A component added programmatically to a container inside a data table row must render in the proper place, and must stay there across postbacks:

> "It must be possible to programmatically add components to the tree and have them render in the proper place in the hierarchy."
> — RequestProcessingLifecycle.adoc, dynamic component manipulation

Nothing there exempts a subtree inside a `UIData`, and the same clause contemplates adds within one: "these manipulations do require that any components added to the tree have ids that are unique within the scope of the closest parent `NamingContainer`" — a `UIData` is a `NamingContainer`. That dynamic adds persist across postbacks is already asserted by `Issue2125IT`, for a non-row-scoped add.

The add is performed by a command button inside a row, so the row index is set while the action runs. The panel group it targets is a single component instance reused for every row, so one add renders once per row — hence the assertion of three, not one.

Red on Mojarra before eclipse-ee4j/mojarra#5867, green after: the add rendered in the request which created it, then vanished on the next postback.

🤖 Generated with Claude Opus 4.8
