### PR TITLE
Add TCK coverage for spec 2182 h:panelGroup wrapper gate

### DIFF
--- a/tck/faces50/misc/src/main/webapp/spec2182.xhtml
+++ b/tck/faces50/misc/src/main/webapp/spec2182.xhtml
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<!--
+
+    Copyright (c) Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+<html
+    xmlns:f="jakarta.faces.core"
+    xmlns:h="jakarta.faces.html"
+>
+    <h:head>
+        <title>spec 2182</title>
+    </h:head>
+    <h:body>
+        <div id="c1"><h:panelGroup><i id="bare">x</i></h:panelGroup></div>
+        <div id="c2"><h:panelGroup><f:passThroughAttribute name="data-test" value="pta"/><i id="pta">x</i></h:panelGroup></div>
+        <div id="c3"><h:panelGroup styleClass="scmark"><i id="sc">x</i></h:panelGroup></div>
+        <div id="c4"><h:panelGroup layout="block" styleClass="dbmark"><i id="db">x</i></h:panelGroup></div>
+        <div id="c5"><h:panelGroup><f:ajax event="click"/><i id="ajax">x</i></h:panelGroup></div>
+        <div id="c6"><h:panelGroup layout="block"><i id="lb">x</i></h:panelGroup></div>
+    </h:body>
+</html>

--- a/tck/faces50/misc/src/test/java/ee/jakarta/tck/faces/faces50/misc/Spec2182IT.java
+++ b/tck/faces50/misc/src/test/java/ee/jakarta/tck/faces/faces50/misc/Spec2182IT.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GPL-2.0 with Classpath-exception-2.0 which
+ * is available at https://openjdk.java.net/legal/gplv2+ce.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 or Apache-2.0
+ */
+package ee.jakarta.tck.faces.faces50.misc;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+import ee.jakarta.tck.faces.util.selenium.BaseITNG;
+
+/**
+ * A {@code h:panelGroup} renders a wrapper element when it carries a renderable id, {@code style}, {@code styleClass},
+ * any pass-through attribute, or an attached client behavior; {@code layout="block"} makes that wrapper a {@code div}
+ * rather than a {@code span}, but does not by itself force a wrapper.
+ *
+ * @see https://github.com/jakartaee/faces/issues/2182
+ */
+class Spec2182IT extends BaseITNG {
+
+    @Test
+    void testWrapperGate() {
+        String body = getResponseBody("spec2182.xhtml");
+        assertAll(
+            () -> assertTrue(body.contains("<div id=\"c1\"><i id=\"bare\">"), () -> "a bare panelGroup emits no wrapper, but got:\n" + body),
+            () -> assertTrue(body.contains("<span data-test=\"pta\"><i id=\"pta\">"), () -> "a pass-through attribute forces a span wrapper carrying that attribute, but got:\n" + body),
+            () -> assertTrue(body.contains("<span class=\"scmark\"><i id=\"sc\">"), () -> "styleClass forces a span wrapper, but got:\n" + body),
+            () -> assertTrue(body.contains("<div class=\"dbmark\"><i id=\"db\">"), () -> "layout=block makes the wrapper a div, but got:\n" + body),
+            () -> assertTrue(body.contains("<div id=\"c5\"><span "), () -> "an attached client behavior forces a span wrapper, but got:\n" + body),
+            () -> assertTrue(body.contains("<div id=\"c6\"><i id=\"lb\">"), () -> "layout=block alone does not force a wrapper, but got:\n" + body)
+        );
+    }
+}


### PR DESCRIPTION
Adds TCK coverage for the `jakarta.faces.Group` (`h:panelGroup`) wrapper-element rendering contract clarified in #2182 / #2186: a wrapper `div`/`span` is rendered when the component has a renderable id, `style`, `styleClass`, any pass-through attribute, or an attached client behavior; `layout="block"` selects a `div` over a `span` but does not by itself force a wrapper.

New `faces50/misc` test `spec2182` (`spec2182.xhtml` + `Spec2182IT`) asserts, from the raw rendered markup:

- bare panelGroup → no wrapper
- `f:passThroughAttribute` only → `span` carrying the attribute
- `styleClass` → `span`
- `layout="block"` + `styleClass` → `div`
- attached `f:ajax` behavior → `span`
- `layout="block"` alone → no wrapper (guards the out-of-scope case in #2182)

Mojarra impl counterpart: eclipse-ee4j/mojarra#5792.

🤖 Generated with Claude Opus 4.8
