### PR TITLE
Add TCK coverage for issue 5885 multi-child facet input state

### DIFF
--- a/tck/faces50/facelets/src/main/java/ee/jakarta/tck/faces/faces50/facelets/Issue5885Bean.java
+++ b/tck/faces50/facelets/src/main/java/ee/jakarta/tck/faces/faces50/facelets/Issue5885Bean.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) Contributors to Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package ee.jakarta.tck.faces.faces50.facelets;
+
+import jakarta.enterprise.context.RequestScoped;
+import jakarta.faces.component.UIOutput;
+import jakarta.faces.context.FacesContext;
+import jakarta.faces.event.ComponentSystemEvent;
+import jakarta.inject.Named;
+
+@Named
+@RequestScoped
+public class Issue5885Bean {
+
+    public static final String MODEL_VALUE = "MODEL VALUE";
+
+    private String singleChildFacetValue = MODEL_VALUE;
+    private String multiChildFacetValue = MODEL_VALUE;
+
+    /**
+     * Programmatically adds a component to the view, so that the view holds a dynamic action and the Facelets
+     * refresh is therefore re-applied during Render Response.
+     */
+    public void addComponentResource(ComponentSystemEvent event) {
+        FacesContext context = event.getFacesContext();
+        UIOutput resource = new UIOutput();
+        resource.setRendererType("jakarta.faces.resource.Stylesheet");
+        resource.getAttributes().put("library", "issue5885");
+        resource.getAttributes().put("name", "issue5885.css");
+        context.getViewRoot().addComponentResource(context, resource, "head");
+    }
+
+    public String getSingleChildFacetValue() {
+        return singleChildFacetValue;
+    }
+
+    public void setSingleChildFacetValue(String singleChildFacetValue) {
+        this.singleChildFacetValue = singleChildFacetValue;
+    }
+
+    public String getMultiChildFacetValue() {
+        return multiChildFacetValue;
+    }
+
+    public void setMultiChildFacetValue(String multiChildFacetValue) {
+        this.multiChildFacetValue = multiChildFacetValue;
+    }
+}

--- a/tck/faces50/facelets/src/main/webapp/issue5885.xhtml
+++ b/tck/faces50/facelets/src/main/webapp/issue5885.xhtml
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<!--
+
+    Copyright (c) Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+<html lang="en"
+    xmlns:h="jakarta.faces.html"
+    xmlns:f="jakarta.faces.core"
+>
+    <h:head>
+        <title>issue5885</title>
+    </h:head>
+    <h:body>
+        <f:event type="preRenderView" listener="#{issue5885Bean.addComponentResource}" />
+
+        <h:form id="singleChildFacet">
+            <h:panelGrid id="grid">
+                <f:facet name="header">
+                    <h:inputText id="input" value="#{issue5885Bean.singleChildFacetValue}" required="true" />
+                </f:facet>
+                <h:message id="message" for="input" />
+            </h:panelGrid>
+            <h:commandButton id="submit" value="submit">
+                <f:ajax execute="@form" render="@form" />
+            </h:commandButton>
+        </h:form>
+
+        <h:form id="multiChildFacet">
+            <h:panelGrid id="grid">
+                <f:facet name="header">
+                    <h:inputText id="input" value="#{issue5885Bean.multiChildFacetValue}" required="true" />
+                    <h:outputText id="output" value="second facet child" />
+                </f:facet>
+                <h:message id="message" for="input" />
+            </h:panelGrid>
+            <h:commandButton id="submit" value="submit">
+                <f:ajax execute="@form" render="@form" />
+            </h:commandButton>
+        </h:form>
+    </h:body>
+</html>

--- a/tck/faces50/facelets/src/main/webapp/resources/issue5885/issue5885.css
+++ b/tck/faces50/facelets/src/main/webapp/resources/issue5885/issue5885.css
@@ -1,0 +1,3 @@
+body {
+    font-family: sans-serif;
+}

--- a/tck/faces50/facelets/src/test/java/ee/jakarta/tck/faces/faces50/facelets/Issue5885IT.java
+++ b/tck/faces50/facelets/src/test/java/ee/jakarta/tck/faces/faces50/facelets/Issue5885IT.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GPL-2.0 with Classpath-exception-2.0 which
+ * is available at https://openjdk.java.net/legal/gplv2+ce.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 or Apache-2.0
+ */
+package ee.jakarta.tck.faces.faces50.facelets;
+
+import static ee.jakarta.tck.faces.faces50.facelets.Issue5885Bean.MODEL_VALUE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.FindBy;
+
+import ee.jakarta.tck.faces.util.selenium.BaseITNG;
+
+class Issue5885IT extends BaseITNG {
+
+    @FindBy(id = "singleChildFacet:input")
+    private WebElement singleChildFacetInput;
+
+    @FindBy(id = "singleChildFacet:message")
+    private WebElement singleChildFacetMessage;
+
+    @FindBy(id = "singleChildFacet:submit")
+    private WebElement singleChildFacetSubmit;
+
+    @FindBy(id = "multiChildFacet:input")
+    private WebElement multiChildFacetInput;
+
+    @FindBy(id = "multiChildFacet:message")
+    private WebElement multiChildFacetMessage;
+
+    @FindBy(id = "multiChildFacet:submit")
+    private WebElement multiChildFacetSubmit;
+
+    /**
+     * An input which is the sole child of a facet must, after a failed validation on an ajax postback, re-render
+     * the submitted value instead of the model value.
+     *
+     * @see https://github.com/eclipse-ee4j/mojarra/issues/5885
+     */
+    @Test
+    void testSingleChildFacet() {
+        var page = getPage("issue5885.xhtml");
+        assertEquals(MODEL_VALUE, singleChildFacetInput.getDomProperty("value"));
+
+        singleChildFacetInput.clear();
+        page.guardAjax(singleChildFacetSubmit::click);
+
+        assertFalse(singleChildFacetMessage.getText().isBlank());
+        assertEquals("", singleChildFacetInput.getDomProperty("value"));
+    }
+
+    /**
+     * An input in a facet with more than one child, which Facelets wraps in an implicit panel, must behave the
+     * same as one in a single child facet: after a failed validation on an ajax postback it must re-render the
+     * submitted value instead of the model value, also when the view holds a programmatically added component
+     * and the Facelets refresh is therefore re-applied during Render Response.
+     *
+     * @see https://github.com/eclipse-ee4j/mojarra/issues/5885
+     */
+    @Test
+    void testMultiChildFacet() {
+        var page = getPage("issue5885.xhtml");
+        assertEquals(MODEL_VALUE, multiChildFacetInput.getDomProperty("value"));
+
+        multiChildFacetInput.clear();
+        page.guardAjax(multiChildFacetSubmit::click);
+
+        assertFalse(multiChildFacetMessage.getText().isBlank());
+        assertEquals("", multiChildFacetInput.getDomProperty("value"));
+    }
+}


### PR DESCRIPTION
## What

Adds `faces50/facelets` coverage for eclipse-ee4j/mojarra#5885: a `UIInput` inside an `<f:facet>` with more than one child loses its submitted value and its invalid state during Render Response, so a failed ajax validation re-renders the model value next to the error message.

`issue5885.xhtml` puts the same required input in two forms — one as the sole child of a `panelGrid` header facet (the control), one alongside a second child, which is what makes Facelets wrap the facet in an implicit `UIPanel`. A `preRenderView` listener calls `UIViewRoot.addComponentResource`, so the view carries a dynamic action and the render-time Facelets refresh is therefore not skipped; without that the refresh never runs and the defect stays hidden. Each test clears its input, submits over ajax, and asserts that the message is rendered and that the input re-renders the submitted (empty) value rather than `MODEL VALUE`.

The implicit panel is specified behaviour: the `f:facet` VDLDoc has said since 2.3 that "When the facet contains more than one child the children will be automatically put in a container UIPanel". The older prose in Standard Tag Libraries, "Using Facets" — "one and only one child UIComponent tag", with footnote 10 pointing at `<h:panelGroup>` — predates that and was never reconciled with it. The test is named for the Mojarra issue that surfaced it, but what it asserts is the VDLDoc behaviour.

## Testing

Against Mojarra master (`5.0.0-SNAPSHOT`):

| | `testSingleChildFacet` | `testMultiChildFacet` |
| --- | --- | --- |
| before the impl fix | pass | **fail** — `expected: <> but was: <MODEL VALUE>` |
| after the impl fix | pass | pass |

The impl fix is the `ComponentSupport` refresh-index change in eclipse-ee4j/mojarra#5886, with which the full Jakarta Faces TCK passes.

🤖 Generated with Claude Opus 5
