### PR TITLE
Keep the Facelets facet-name marker out of component state

### DIFF
--- a/api/src/main/java/jakarta/faces/component/UIComponentBase.java
+++ b/api/src/main/java/jakarta/faces/component/UIComponentBase.java
@@ -2377,17 +2377,14 @@ public abstract class UIComponentBase extends UIComponent {
                 throw new NullPointerException();
             }
 
-            // markerPut keeps the field cache in sync for framework markers. Persistent markers (MARK_CREATED etc.)
-            // are still mirrored into the attributes map below so full-state restore can read them back. MARK_DELETED
-            // is a transient build-time flag (markForDeletion/finalizeForDeletion set and clear it on every component
-            // each refresh) that is never present when state is saved, so it stays field-only to avoid per-component
-            // StateHelper traffic.
+            // markerPut keeps the field cache in sync for framework markers; a marker not exempted below is also
+            // mirrored into the attributes map so full-state restore can read it back. The exempted three are
+            // field-only, which is what keeps them out of the StateHelper on every Facelets build: MARK_DELETED and
+            // FACET_NAME are build-time flags that are always cleared again before state is saved, and MARK_CREATED
+            // is re-attached to the attributes map at full-state save (saveState), partial state rebuilding it via
+            // buildView. Exempting a further marker requires it to meet that same condition.
             boolean marker = component.markerPut(keyValue, value);
-            if (marker && (MARK_DELETED.equals(keyValue) || MARK_CREATED.equals(keyValue))) {
-                // MARK_DELETED is a transient build-time flag; MARK_CREATED is field-backed (markCreated) and set on
-                // every component during buildView. Neither needs the per-component StateHelper mirror on the hot
-                // c:forEach re-apply path: MARK_DELETED is never saved, and MARK_CREATED is re-attached to the
-                // attributes map once at full-state save (saveState) -- partial state rebuilds it via buildView.
+            if (marker && (MARK_DELETED.equals(keyValue) || MARK_CREATED.equals(keyValue) || FACET_NAME.equals(keyValue))) {
                 return null;
             }
 
@@ -2469,7 +2466,7 @@ public abstract class UIComponentBase extends UIComponent {
                 throw new NullPointerException();
             }
             boolean marker = component.markerRemove(key);
-            if (marker && MARK_DELETED.equals(key)) {
+            if (marker && (MARK_DELETED.equals(key) || FACET_NAME.equals(key))) {
                 return null;
             }
             if (ATTRIBUTES_THAT_ARE_SET_KEY.equals(key)) {

--- a/api/src/test/java/jakarta/faces/component/UIComponentBaseMarkerAttributesTest.java
+++ b/api/src/test/java/jakarta/faces/component/UIComponentBaseMarkerAttributesTest.java
@@ -17,47 +17,73 @@
 package jakarta.faces.component;
 
 import static jakarta.faces.component.PackageUtils.FACET_NAME;
+import static jakarta.faces.component.PackageUtils.MARK_CREATED;
 import static jakarta.faces.component.PackageUtils.MARK_DELETED;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
 
 import java.util.Map;
 import java.util.Set;
 
+import jakarta.faces.context.FacesContext;
+
 import org.junit.jupiter.api.Test;
 
 /**
- * Facelets scopes a facet by putting its name on the parent component's attributes for the duration of the facet body
- * and removing it again afterwards, and it flags components for deletion the same way. Both markers are answered from a
- * field rather than from the state map, so the attributes map has to keep reading like a map while the marker never
- * becomes part of the component's state.
+ * Facelets marks every component it creates with the tag id it came from, scopes a facet by putting its name on the
+ * parent component's attributes for the duration of the facet body, and flags components for deletion the same way.
+ * Those markers are answered from a field rather than from the state map, so the attributes map has to keep reading
+ * like a map while the marker stays out of the component's state - except that the creation marker, which is live on
+ * every component, still has to survive a full-state save, since restoring full state runs no view build to
+ * re-establish it.
  */
 class UIComponentBaseMarkerAttributesTest {
 
     @Test
-    void facetNameMarkerReadsBackThroughTheAttributesMap() {
+    void fieldBackedMarkersReadBackThroughTheAttributesMap() {
         Map<String, Object> attributes = new UIPanel().getAttributes();
         attributes.put(FACET_NAME, "header");
+        attributes.put(MARK_CREATED, "j_id1");
 
         assertEquals("header", attributes.get(FACET_NAME));
+        assertEquals("j_id1", attributes.get(MARK_CREATED));
         assertTrue(attributes.containsKey(FACET_NAME));
+        assertTrue(attributes.containsKey(MARK_CREATED));
 
         attributes.remove(FACET_NAME);
+        attributes.remove(MARK_CREATED);
 
         assertNull(attributes.get(FACET_NAME));
+        assertNull(attributes.get(MARK_CREATED));
         assertFalse(attributes.containsKey(FACET_NAME));
+        assertFalse(attributes.containsKey(MARK_CREATED));
     }
 
     @Test
     void buildTimeMarkersStayOutOfTheStateBackedAttributes() {
         Map<String, Object> attributes = new UIPanel().getAttributes();
         attributes.put(FACET_NAME, "header");
+        attributes.put(MARK_CREATED, "j_id1");
         attributes.put(MARK_DELETED, Boolean.TRUE);
         attributes.put("data-role", "banner");
 
         assertEquals(Set.of("data-role"), attributes.keySet(),
                 "only the plain attribute is state-backed, so only it can be saved");
+    }
+
+    @Test
+    void fullStateSaveCarriesTheCreationMarker() {
+        FacesContext context = mock(FacesContext.class);
+        UIPanel saved = new UIPanel();
+        saved.getAttributes().put(MARK_CREATED, "j_id1");
+
+        UIPanel restored = new UIPanel();
+        restored.restoreState(context, saved.saveState(context));
+
+        assertEquals("j_id1", restored.getAttributes().get(MARK_CREATED),
+                "full state carries no view build to re-establish the marker");
     }
 }

--- a/api/src/test/java/jakarta/faces/component/UIComponentBaseMarkerAttributesTest.java
+++ b/api/src/test/java/jakarta/faces/component/UIComponentBaseMarkerAttributesTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) Contributors to Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.faces.component;
+
+import static jakarta.faces.component.PackageUtils.FACET_NAME;
+import static jakarta.faces.component.PackageUtils.MARK_DELETED;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Map;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Facelets scopes a facet by putting its name on the parent component's attributes for the duration of the facet body
+ * and removing it again afterwards, and it flags components for deletion the same way. Both markers are answered from a
+ * field rather than from the state map, so the attributes map has to keep reading like a map while the marker never
+ * becomes part of the component's state.
+ */
+class UIComponentBaseMarkerAttributesTest {
+
+    @Test
+    void facetNameMarkerReadsBackThroughTheAttributesMap() {
+        Map<String, Object> attributes = new UIPanel().getAttributes();
+        attributes.put(FACET_NAME, "header");
+
+        assertEquals("header", attributes.get(FACET_NAME));
+        assertTrue(attributes.containsKey(FACET_NAME));
+
+        attributes.remove(FACET_NAME);
+
+        assertNull(attributes.get(FACET_NAME));
+        assertFalse(attributes.containsKey(FACET_NAME));
+    }
+
+    @Test
+    void buildTimeMarkersStayOutOfTheStateBackedAttributes() {
+        Map<String, Object> attributes = new UIPanel().getAttributes();
+        attributes.put(FACET_NAME, "header");
+        attributes.put(MARK_DELETED, Boolean.TRUE);
+        attributes.put("data-role", "banner");
+
+        assertEquals(Set.of("data-role"), attributes.keySet(),
+                "only the plain attribute is state-backed, so only it can be saved");
+    }
+}


### PR DESCRIPTION
`f:facet` scopes its body by putting the `facelets.FACET_NAME` marker on the parent component's attributes and removing it again in a `finally`, so the marker is never present when state is saved. `AttributesMap` nevertheless mirrored it into the `StateHelper` on the way in (an `attributesThatAreSet` list add plus a `PropertyKeys.attributes` map put) and removed it from both on the way out — once per facet, on every Facelets build.

This exempts it from the mirror the way `MARK_DELETED` and `MARK_CREATED` already are. The field-backed marker keeps answering `get` and `containsKey`, so nothing that reads a facet name changes; it simply stops travelling through component state it can never be saved in. The comment above the exemption now states the condition a marker has to meet to qualify, since that is the thing the next editor can get wrong.

### Measured

Isolated Facelets `buildView` (no render, no state save/restore), Tomcat 11, JDK 21, quiet machine, minimum of two alternating rounds per arm.

| view | before | after | Δ |
| --- | --- | --- | --- |
| `h:dataTable`, 200 columns with a header facet each (609 components) | 393.8 µs | 348.5 µs | **−11.5%** |
| per facet | 966 ns | 705 ns | −27% |

Against MyFaces 4.1 on the same view the gap goes from +84% to +66% (MyFaces spends 403 ns per facet; its `_ComponentAttributesMap` treats the same key as a pure field). Views without facets — flat markup sweeps at 400 and 1600 components, `c:forEach`, `h:dataTable` without facets — all land inside run-to-run noise, as expected for a change that only touches the facet path.

### Verified

- Full `jakarta.faces-api` unit test suite.
- Full Mojarra impl unit test suite against this API.
- Full Faces TCK, green.
- Three new tests in `UIComponentBaseMarkerAttributesTest`: the field-backed markers read back through the attributes map, they stay out of the state-backed attributes while a plain attribute lands there, and a full-state save carries `MARK_CREATED` across a restore. The second fails without the change to `put` (`expected: <[data-role]> but was: <[facelets.FACET_NAME, data-role]>`); the third fails if `saveState`'s re-attach of the creation marker is dropped, which nothing covered before — unlike the other two markers, `MARK_CREATED` is live on every component rather than cleared before state is saved, so full-state restore has no view build to re-establish it.

Ref eclipse-ee4j/mojarra#5856

🤖 Generated with Claude Opus 5
