### PR TITLE
Resurrect 37 integration tests lost with mojarra's test folder

### DIFF
--- a/tck/faces20/el/src/main/java/ee/jakarta/tck/faces/faces20/el/Issue2835Bean.java
+++ b/tck/faces20/el/src/main/java/ee/jakarta/tck/faces/faces20/el/Issue2835Bean.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright (c) 2026 Contributors to Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.faces.faces20.el;
+
+import java.io.Serializable;
+
+import jakarta.el.ELContext;
+import jakarta.el.PropertyNotWritableException;
+import jakarta.el.ValueExpression;
+import jakarta.enterprise.context.RequestScoped;
+import jakarta.faces.context.FacesContext;
+import jakarta.inject.Named;
+
+/**
+ * Exercises {@link ValueExpression#setValue} against a session scoped target, for a plain property, a nested bean
+ * property and a read only property. Each getter reports SUCCESS or FAILED so the outcome is observable in the view.
+ */
+@Named
+@RequestScoped
+public class Issue2835Bean implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private static final String TARGET = "issue2835Target";
+    private static final String SUCCESS = "SUCCESS";
+    private static final String FAILED = "FAILED";
+
+    public static class Target implements Serializable {
+
+        private static final long serialVersionUID = 1L;
+
+        private String one;
+        private Inner inner;
+
+        public String getOne() {
+            return one;
+        }
+
+        public void setOne(String one) {
+            this.one = one;
+        }
+
+        public Inner getInner() {
+            return inner;
+        }
+
+        public void setInner(Inner inner) {
+            this.inner = inner;
+        }
+
+        public String getReadOnly() {
+            return "read only";
+        }
+    }
+
+    public static class Inner implements Serializable {
+
+        private static final long serialVersionUID = 1L;
+    }
+
+    /**
+     * Setting null through a value expression nulls a plain property.
+     */
+    public String getSetNullOnProperty() {
+        Target target = newTarget();
+        target.setOne("initial");
+
+        setValue("#{sessionScope." + TARGET + ".one}", null);
+
+        return target.getOne() == null ? SUCCESS : FAILED;
+    }
+
+    /**
+     * Setting a value through a value expression reaches a nested bean property.
+     */
+    public String getSetValueOnNestedProperty() {
+        Target target = newTarget();
+
+        setValue("#{sessionScope." + TARGET + ".inner}", new Inner());
+
+        return target.getInner() != null ? SUCCESS : FAILED;
+    }
+
+    /**
+     * Setting null through a value expression nulls a previously set nested bean property.
+     */
+    public String getSetNullOnNestedProperty() {
+        Target target = newTarget();
+
+        setValue("#{sessionScope." + TARGET + ".inner}", new Inner());
+        setValue("#{sessionScope." + TARGET + ".inner}", null);
+
+        return target.getInner() == null ? SUCCESS : FAILED;
+    }
+
+    /**
+     * Setting a read only property through a value expression raises PropertyNotWritableException.
+     */
+    public String getSetValueOnReadOnlyProperty() {
+        newTarget();
+
+        try {
+            setValue("#{sessionScope." + TARGET + ".readOnly}", "other");
+            return FAILED;
+        }
+        catch (PropertyNotWritableException e) {
+            return SUCCESS;
+        }
+    }
+
+    private static Target newTarget() {
+        Target target = new Target();
+        FacesContext.getCurrentInstance().getExternalContext().getSessionMap().put(TARGET, target);
+        return target;
+    }
+
+    private static void setValue(String expression, Object value) {
+        FacesContext context = FacesContext.getCurrentInstance();
+        ELContext elContext = context.getELContext();
+        ValueExpression valueExpression = context.getApplication().getExpressionFactory()
+                .createValueExpression(elContext, expression, Object.class);
+
+        valueExpression.setValue(elContext, value);
+    }
+}

--- a/tck/faces20/el/src/main/webapp/issue2835.xhtml
+++ b/tck/faces20/el/src/main/webapp/issue2835.xhtml
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<!--
+
+    Copyright (c) 2026 Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<html xmlns:h="jakarta.faces.html">
+    <h:head>
+        <title>Issue2835</title>
+    </h:head>
+    <h:body>
+        <h:outputText id="setNullOnProperty" value="#{issue2835Bean.setNullOnProperty}"/>
+        <h:outputText id="setValueOnNestedProperty" value="#{issue2835Bean.setValueOnNestedProperty}"/>
+        <h:outputText id="setNullOnNestedProperty" value="#{issue2835Bean.setNullOnNestedProperty}"/>
+        <h:outputText id="setValueOnReadOnlyProperty" value="#{issue2835Bean.setValueOnReadOnlyProperty}"/>
+    </h:body>
+</html>

--- a/tck/faces20/el/src/test/java/ee/jakarta/tck/faces/faces20/el/Issue2835IT.java
+++ b/tck/faces20/el/src/test/java/ee/jakarta/tck/faces/faces20/el/Issue2835IT.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2026 Contributors to Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.faces.faces20.el;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.By;
+
+import ee.jakarta.tck.faces.util.selenium.BaseITNG;
+import ee.jakarta.tck.faces.util.selenium.WebPage;
+import jakarta.el.ValueExpression;
+
+class Issue2835IT extends BaseITNG {
+
+    /**
+     * ValueExpression#setValue writes through to the target property, including writing null and including a
+     * nested bean property, and raises PropertyNotWritableException for a read only property.
+     *
+     * @see ValueExpression#setValue(jakarta.el.ELContext, Object)
+     * @see https://github.com/eclipse-ee4j/mojarra/issues/2835
+     */
+    @Test
+    void setValueWritesThroughAndRejectsReadOnlyProperties() {
+        WebPage page = getPage("issue2835.xhtml");
+
+        assertEquals("SUCCESS", page.findElement(By.id("setNullOnProperty")).getText(),
+                "Setting null must null a plain property.");
+        assertEquals("SUCCESS", page.findElement(By.id("setValueOnNestedProperty")).getText(),
+                "Setting a value must reach a nested bean property.");
+        assertEquals("SUCCESS", page.findElement(By.id("setNullOnNestedProperty")).getText(),
+                "Setting null must null a nested bean property.");
+        assertEquals("SUCCESS", page.findElement(By.id("setValueOnReadOnlyProperty")).getText(),
+                "Setting a read only property must raise PropertyNotWritableException.");
+    }
+}

--- a/tck/faces20/jstl/src/main/webapp/issue2528.xhtml
+++ b/tck/faces20/jstl/src/main/webapp/issue2528.xhtml
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<!--
+
+    Copyright (c) 2026 Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<html xmlns:c="jakarta.tags.core"
+      xmlns:h="jakarta.faces.html">
+    <h:head>
+        <title>Issue2528</title>
+    </h:head>
+    <h:body>
+        <c:set var="issue2528" value=""/>
+        <h:outputText id="rendered" value="[#{issue2528}]"/>
+    </h:body>
+</html>

--- a/tck/faces20/jstl/src/test/java/ee/jakarta/tck/faces/faces20/jstl/Issue2528IT.java
+++ b/tck/faces20/jstl/src/test/java/ee/jakarta/tck/faces/faces20/jstl/Issue2528IT.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2026 Contributors to Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.faces.faces20.jstl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.By;
+
+import ee.jakarta.tck.faces.util.selenium.BaseITNG;
+import ee.jakarta.tck.faces.util.selenium.WebPage;
+
+class Issue2528IT extends BaseITNG {
+
+    /**
+     * A c:set whose value is the empty string is a valid assignment, so the view compiles and the variable
+     * resolves to the empty string rather than the tag failing at build time.
+     *
+     * @see https://github.com/eclipse-ee4j/mojarra/issues/2528
+     */
+    @Test
+    void setWithAnEmptyValueCompilesAndResolves() {
+        WebPage page = getPage("issue2528.xhtml");
+
+        assertEquals(200, page.getResponseStatus(), "The view must render.");
+        assertEquals("[]", page.findElement(By.id("rendered")).getText(),
+                "The variable set to an empty value must resolve to the empty string.");
+    }
+}

--- a/tck/faces20/pom.xml
+++ b/tck/faces20/pom.xml
@@ -67,6 +67,9 @@
         <module>locale-config</module>
         <module>resource-locale-prefix</module>
         <module>resource-path-traversal</module>
+        <module>system-event-listener-startup</module>
+        <module>state-serialization-disabled</module>
+        <module>state-serialization-enabled</module>
         <module>string-converter</module>
         <module>view-handler-action-url</module>
         <module>view-param</module>

--- a/tck/faces20/state-serialization-disabled/pom.xml
+++ b/tck/faces20/state-serialization-disabled/pom.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2026 Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.eclipse.ee4j.tck.faces.faces20</groupId>
+        <artifactId>pom</artifactId>
+        <version>5.0.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>state-serialization-disabled</artifactId>
+    <packaging>war</packaging>
+
+    <name>Jakarta Faces TCK ${project.version} - ${test.moduleName} - ${project.artifactId}</name>
+
+    <build>
+        <finalName>test-${test.moduleName}-${project.artifactId}</finalName>
+    </build>
+</project>

--- a/tck/faces20/state-serialization-disabled/src/main/java/ee/jakarta/tck/faces/faces20/state_serialization_disabled/Spec1127Bean.java
+++ b/tck/faces20/state-serialization-disabled/src/main/java/ee/jakarta/tck/faces/faces20/state_serialization_disabled/Spec1127Bean.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2026 Contributors to Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.faces.faces20.state_serialization_disabled;
+
+import java.io.IOException;
+import java.io.NotSerializableException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serializable;
+
+import jakarta.enterprise.context.RequestScoped;
+import jakarta.faces.event.ActionEvent;
+import jakarta.inject.Named;
+
+@Named
+@RequestScoped
+public class Spec1127Bean {
+
+    public void putNonSerializableDataInState(ActionEvent event) {
+        event.getComponent().getAttributes().put("nonSerializable", new NotReallySerializable());
+    }
+
+    /**
+     * Declares Serializable so that it may be put into the component attribute map, but refuses to serialize, which is
+     * what distinguishes a runtime which serializes the server side state from one which does not.
+     */
+    private static class NotReallySerializable implements Serializable {
+
+        private static final long serialVersionUID = 1L;
+
+        private void writeObject(ObjectOutputStream out) throws IOException {
+            throw new NotSerializableException("This class is not really serializable.");
+        }
+
+        private void readObject(ObjectInputStream in) throws IOException {
+            throw new NotSerializableException("This class is not really serializable.");
+        }
+    }
+}

--- a/tck/faces20/state-serialization-disabled/src/main/webapp/WEB-INF/faces-config.xml
+++ b/tck/faces20/state-serialization-disabled/src/main/webapp/WEB-INF/faces-config.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2026 Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<faces-config
+    xmlns="https://jakarta.ee/xml/ns/jakartaee"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-facesconfig_4_1.xsd"
+    version="4.1">
+</faces-config>

--- a/tck/faces20/state-serialization-disabled/src/main/webapp/WEB-INF/web.xml
+++ b/tck/faces20/state-serialization-disabled/src/main/webapp/WEB-INF/web.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2026 Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<web-app
+    xmlns="https://jakarta.ee/xml/ns/jakartaee"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-app_6_1.xsd"
+    version="6.1">
+
+    <context-param>
+        <param-name>jakarta.faces.PROJECT_STAGE</param-name>
+        <param-value>${webapp.projectStage}</param-value>
+    </context-param>
+    <context-param>
+        <param-name>jakarta.faces.PARTIAL_STATE_SAVING</param-name>
+        <param-value>${webapp.partialStateSaving}</param-value>
+    </context-param>
+    <!-- DO NOT PARAMETERIZE STATE_SAVING_METHOD, SERIALIZE_SERVER_STATE only applies to server-side state -->
+    <context-param>
+        <param-name>jakarta.faces.STATE_SAVING_METHOD</param-name>
+        <param-value>server</param-value>
+    </context-param>
+    <!-- DO NOT PARAMETERIZE SERIALIZE_SERVER_STATE, this module exists to pin it to false; its true counterpart is faces20/state-serialization-enabled -->
+    <context-param>
+        <param-name>jakarta.faces.SERIALIZE_SERVER_STATE</param-name>
+        <param-value>false</param-value>
+    </context-param>
+</web-app>

--- a/tck/faces20/state-serialization-disabled/src/main/webapp/spec1127.xhtml
+++ b/tck/faces20/state-serialization-disabled/src/main/webapp/spec1127.xhtml
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<!--
+
+    Copyright (c) 2026 Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<html xmlns:h="jakarta.faces.html">
+    <h:head>
+        <title>Spec1127</title>
+    </h:head>
+    <h:body>
+        <h:form id="form" prependId="false">
+            <h:commandButton id="button" value="reload" actionListener="#{spec1127Bean.putNonSerializableDataInState}"/>
+            <h:outputText id="result" value="reloaded"/>
+        </h:form>
+    </h:body>
+</html>

--- a/tck/faces20/state-serialization-disabled/src/test/java/ee/jakarta/tck/faces/faces20/state_serialization_disabled/Spec1127IT.java
+++ b/tck/faces20/state-serialization-disabled/src/test/java/ee/jakarta/tck/faces/faces20/state_serialization_disabled/Spec1127IT.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2026 Contributors to Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.faces.faces20.state_serialization_disabled;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.By;
+
+import ee.jakarta.tck.faces.util.selenium.BaseITNG;
+import ee.jakarta.tck.faces.util.selenium.WebPage;
+
+/**
+ * This module pins {@code jakarta.faces.SERIALIZE_SERVER_STATE} to {@code false}, which the reactor otherwise never
+ * exercises. Its counterpart pinning it to {@code true} lives in {@code faces20/state-serialization-enabled}; the two
+ * assert opposite outcomes of the same spec issue and therefore cannot share a module.
+ */
+class Spec1127IT extends BaseITNG {
+
+    /**
+     * With server side state saving and serialization switched off, the state is held as a live object graph, so a
+     * component attribute which refuses to serialize is never asked to and the postback succeeds.
+     *
+     * @see https://github.com/jakartaee/faces/issues/1127
+     */
+    @Test
+    void nonSerializableStateSurvivesWhenSerializationIsDisabled() {
+        WebPage page = getPage("spec1127.xhtml");
+
+        page.guardHttp(page.findElement(By.id("button"))::click);
+
+        assertEquals(200, page.getResponseStatus(),
+                "Without state serialization a non serializable attribute must not fail the postback.");
+        assertEquals("reloaded", page.findElement(By.id("result")).getText(), "The view must still render.");
+    }
+}

--- a/tck/faces20/state-serialization-enabled/pom.xml
+++ b/tck/faces20/state-serialization-enabled/pom.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2026 Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.eclipse.ee4j.tck.faces.faces20</groupId>
+        <artifactId>pom</artifactId>
+        <version>5.0.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>state-serialization-enabled</artifactId>
+    <packaging>war</packaging>
+
+    <name>Jakarta Faces TCK ${project.version} - ${test.moduleName} - ${project.artifactId}</name>
+
+    <build>
+        <finalName>test-${test.moduleName}-${project.artifactId}</finalName>
+    </build>
+</project>

--- a/tck/faces20/state-serialization-enabled/src/main/java/ee/jakarta/tck/faces/faces20/state_serialization_enabled/Spec1127Bean.java
+++ b/tck/faces20/state-serialization-enabled/src/main/java/ee/jakarta/tck/faces/faces20/state_serialization_enabled/Spec1127Bean.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2026 Contributors to Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.faces.faces20.state_serialization_enabled;
+
+import java.io.IOException;
+import java.io.NotSerializableException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serializable;
+
+import jakarta.enterprise.context.RequestScoped;
+import jakarta.faces.event.ActionEvent;
+import jakarta.inject.Named;
+
+@Named
+@RequestScoped
+public class Spec1127Bean {
+
+    public void putNonSerializableDataInState(ActionEvent event) {
+        event.getComponent().getAttributes().put("nonSerializable", new NotReallySerializable());
+    }
+
+    /**
+     * Declares Serializable so that it may be put into the component attribute map, but refuses to serialize, which is
+     * what distinguishes a runtime which serializes the server side state from one which does not.
+     */
+    private static class NotReallySerializable implements Serializable {
+
+        private static final long serialVersionUID = 1L;
+
+        private void writeObject(ObjectOutputStream out) throws IOException {
+            throw new NotSerializableException("This class is not really serializable.");
+        }
+
+        private void readObject(ObjectInputStream in) throws IOException {
+            throw new NotSerializableException("This class is not really serializable.");
+        }
+    }
+}

--- a/tck/faces20/state-serialization-enabled/src/main/webapp/WEB-INF/faces-config.xml
+++ b/tck/faces20/state-serialization-enabled/src/main/webapp/WEB-INF/faces-config.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2026 Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<faces-config
+    xmlns="https://jakarta.ee/xml/ns/jakartaee"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-facesconfig_4_1.xsd"
+    version="4.1">
+</faces-config>

--- a/tck/faces20/state-serialization-enabled/src/main/webapp/WEB-INF/web.xml
+++ b/tck/faces20/state-serialization-enabled/src/main/webapp/WEB-INF/web.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2026 Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<web-app
+    xmlns="https://jakarta.ee/xml/ns/jakartaee"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-app_6_1.xsd"
+    version="6.1">
+
+    <context-param>
+        <param-name>jakarta.faces.PROJECT_STAGE</param-name>
+        <param-value>${webapp.projectStage}</param-value>
+    </context-param>
+    <context-param>
+        <param-name>jakarta.faces.PARTIAL_STATE_SAVING</param-name>
+        <param-value>${webapp.partialStateSaving}</param-value>
+    </context-param>
+    <!-- DO NOT PARAMETERIZE STATE_SAVING_METHOD, SERIALIZE_SERVER_STATE only applies to server-side state -->
+    <context-param>
+        <param-name>jakarta.faces.STATE_SAVING_METHOD</param-name>
+        <param-value>server</param-value>
+    </context-param>
+    <!-- DO NOT PARAMETERIZE SERIALIZE_SERVER_STATE, this module exists to pin it to true; its false counterpart is faces20/state-serialization-disabled -->
+    <context-param>
+        <param-name>jakarta.faces.SERIALIZE_SERVER_STATE</param-name>
+        <param-value>true</param-value>
+    </context-param>
+</web-app>

--- a/tck/faces20/state-serialization-enabled/src/main/webapp/spec1127.xhtml
+++ b/tck/faces20/state-serialization-enabled/src/main/webapp/spec1127.xhtml
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<!--
+
+    Copyright (c) 2026 Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<html xmlns:h="jakarta.faces.html">
+    <h:head>
+        <title>Spec1127</title>
+    </h:head>
+    <h:body>
+        <h:form id="form" prependId="false">
+            <h:commandButton id="button" value="reload" actionListener="#{spec1127Bean.putNonSerializableDataInState}"/>
+            <h:outputText id="result" value="reloaded"/>
+        </h:form>
+    </h:body>
+</html>

--- a/tck/faces20/state-serialization-enabled/src/test/java/ee/jakarta/tck/faces/faces20/state_serialization_enabled/Spec1127IT.java
+++ b/tck/faces20/state-serialization-enabled/src/test/java/ee/jakarta/tck/faces/faces20/state_serialization_enabled/Spec1127IT.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2026 Contributors to Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.faces.faces20.state_serialization_enabled;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.By;
+
+import ee.jakarta.tck.faces.util.selenium.BaseITNG;
+import ee.jakarta.tck.faces.util.selenium.WebPage;
+
+/**
+ * This module pins {@code jakarta.faces.SERIALIZE_SERVER_STATE} to {@code true}, which the reactor otherwise never
+ * exercises. Its counterpart pinning it to {@code false} lives in {@code faces20/state-serialization-disabled}; the two
+ * assert opposite outcomes of the same spec issue and therefore cannot share a module.
+ */
+class Spec1127IT extends BaseITNG {
+
+    /**
+     * With server side state saving and serialization switched on, the state really is serialized, so a component
+     * attribute which refuses to serialize fails the request rather than silently succeeding.
+     *
+     * @see https://github.com/jakartaee/faces/issues/1127
+     */
+    @Test
+    void nonSerializableStateFailsWhenSerializationIsEnabled() {
+        WebPage page = getPage("spec1127.xhtml");
+
+        page.findElement(By.id("button")).click();
+
+        assertEquals(500, page.getResponseStatus(),
+                "With state serialization a non serializable attribute must fail the request.");
+    }
+}

--- a/tck/faces20/system-event-listener-startup/pom.xml
+++ b/tck/faces20/system-event-listener-startup/pom.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2026 Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.eclipse.ee4j.tck.faces.faces20</groupId>
+        <artifactId>pom</artifactId>
+        <version>5.0.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>system-event-listener-startup</artifactId>
+    <packaging>war</packaging>
+
+    <name>Jakarta Faces TCK ${project.version} - ${test.moduleName} - ${project.artifactId}</name>
+
+    <build>
+        <finalName>test-${test.moduleName}-${project.artifactId}</finalName>
+    </build>
+</project>

--- a/tck/faces20/system-event-listener-startup/src/main/java/ee/jakarta/tck/faces/faces20/system_event_listener_startup/Issue2648Listener.java
+++ b/tck/faces20/system-event-listener-startup/src/main/java/ee/jakarta/tck/faces/faces20/system_event_listener_startup/Issue2648Listener.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2026 Contributors to Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.faces.faces20.system_event_listener_startup;
+
+import jakarta.faces.component.UIViewRoot;
+import jakarta.faces.context.FacesContext;
+import jakarta.faces.event.AbortProcessingException;
+import jakarta.faces.event.SystemEvent;
+import jakarta.faces.event.SystemEventListener;
+
+/**
+ * Reaches for the view map of the current view root from its own constructor. The runtime instantiates a listener
+ * declared in faces-config while the application is still starting up, at which point there is no request and hence no
+ * view root, so this must degrade rather than fail the deployment.
+ */
+public class Issue2648Listener implements SystemEventListener {
+
+    static final String CONSTRUCTED = "issue2648.constructed";
+
+    public Issue2648Listener() {
+        FacesContext context = FacesContext.getCurrentInstance();
+
+        if (context == null) {
+            return;
+        }
+
+        UIViewRoot viewRoot = context.getViewRoot();
+
+        if (viewRoot != null) {
+            viewRoot.getViewMap();
+        }
+
+        context.getExternalContext().getApplicationMap().put(CONSTRUCTED, "yes");
+    }
+
+    @Override
+    public void processEvent(SystemEvent event) throws AbortProcessingException {
+        // NOOP, constructing this listener at startup is what is under test.
+    }
+
+    @Override
+    public boolean isListenerForSource(Object source) {
+        return source instanceof UIViewRoot;
+    }
+}

--- a/tck/faces20/system-event-listener-startup/src/main/webapp/WEB-INF/beans.xml
+++ b/tck/faces20/system-event-listener-startup/src/main/webapp/WEB-INF/beans.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans
+    xmlns="https://jakarta.ee/xml/ns/jakartaee"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_4_1.xsd"
+    version="4.1" bean-discovery-mode="all">
+</beans>

--- a/tck/faces20/system-event-listener-startup/src/main/webapp/WEB-INF/faces-config.xml
+++ b/tck/faces20/system-event-listener-startup/src/main/webapp/WEB-INF/faces-config.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2026 Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<faces-config
+    xmlns="https://jakarta.ee/xml/ns/jakartaee"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-facesconfig_4_1.xsd"
+    version="4.1">
+
+    <application>
+        <system-event-listener>
+            <system-event-listener-class>ee.jakarta.tck.faces.faces20.system_event_listener_startup.Issue2648Listener</system-event-listener-class>
+            <system-event-class>jakarta.faces.event.PreRenderComponentEvent</system-event-class>
+        </system-event-listener>
+    </application>
+</faces-config>

--- a/tck/faces20/system-event-listener-startup/src/main/webapp/WEB-INF/web.xml
+++ b/tck/faces20/system-event-listener-startup/src/main/webapp/WEB-INF/web.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2026 Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<web-app
+    xmlns="https://jakarta.ee/xml/ns/jakartaee"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-app_6_1.xsd"
+    version="6.1">
+
+    <context-param>
+        <param-name>jakarta.faces.PROJECT_STAGE</param-name>
+        <param-value>${webapp.projectStage}</param-value>
+    </context-param>
+    <context-param>
+        <param-name>jakarta.faces.PARTIAL_STATE_SAVING</param-name>
+        <param-value>${webapp.partialStateSaving}</param-value>
+    </context-param>
+    <context-param>
+        <param-name>jakarta.faces.STATE_SAVING_METHOD</param-name>
+        <param-value>${webapp.stateSavingMethod}</param-value>
+    </context-param>
+    <context-param>
+        <param-name>jakarta.faces.SERIALIZE_SERVER_STATE</param-name>
+        <param-value>${webapp.serializeServerState}</param-value>
+    </context-param>
+</web-app>

--- a/tck/faces20/system-event-listener-startup/src/main/webapp/issue2648.xhtml
+++ b/tck/faces20/system-event-listener-startup/src/main/webapp/issue2648.xhtml
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<!--
+
+    Copyright (c) 2026 Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<html xmlns:h="jakarta.faces.html">
+    <h:head>
+        <title>Issue2648</title>
+    </h:head>
+    <h:body>
+        <h:form id="form">
+            <h:outputText id="result" value="served"/>
+            <h:outputText id="constructed" value="[#{applicationScope['issue2648.constructed']}]"/>
+            <h:commandButton id="submit" value="Submit"/>
+        </h:form>
+    </h:body>
+</html>

--- a/tck/faces20/system-event-listener-startup/src/test/java/ee/jakarta/tck/faces/faces20/system_event_listener_startup/Issue2648IT.java
+++ b/tck/faces20/system-event-listener-startup/src/test/java/ee/jakarta/tck/faces/faces20/system_event_listener_startup/Issue2648IT.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2026 Contributors to Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.faces.faces20.system_event_listener_startup;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.By;
+
+import ee.jakarta.tck.faces.util.selenium.BaseITNG;
+import ee.jakarta.tck.faces.util.selenium.WebPage;
+import jakarta.faces.component.UIViewRoot;
+import jakarta.faces.event.SystemEventListener;
+
+/**
+ * The module registers a SystemEventListener in faces-config whose constructor reaches for the view map of the current
+ * view root. A listener declared this way is instantiated for the whole application, hence the dedicated module.
+ */
+class Issue2648IT extends BaseITNG {
+
+    /**
+     * A SystemEventListener declared in faces-config is constructed while the application is still starting, when
+     * there is no request and hence no view root to take a view map from. The application must nevertheless deploy and
+     * serve its views.
+     *
+     * @see SystemEventListener
+     * @see UIViewRoot#getViewMap()
+     * @see https://github.com/eclipse-ee4j/mojarra/issues/2648
+     */
+    @Test
+    void applicationStartsAndServesViewsWithSuchAListener() {
+        WebPage page = getPage("issue2648.xhtml");
+
+        assertEquals(200, page.getResponseStatus(), "initial render");
+        assertEquals("served", page.findElement(By.id("form:result")).getText(), "The view must be served.");
+
+        page.guardHttp(page.findElement(By.id("form:submit"))::click);
+
+        assertEquals(200, page.getResponseStatus(), "postback");
+        assertEquals("served", page.findElement(By.id("form:result")).getText(), "The view must survive a postback.");
+    }
+}

--- a/tck/faces20/templating/src/main/webapp/template/compositionBadPath.xhtml
+++ b/tck/faces20/templating/src/main/webapp/template/compositionBadPath.xhtml
@@ -1,0 +1,28 @@
+<!--
+
+    Copyright (c) 2026 Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<!DOCTYPE html>
+<html xmlns:h="jakarta.faces.html"
+      xmlns:ui="jakarta.faces.facelets">
+    <h:head>
+        <title>Composition with an unresolvable template</title>
+    </h:head>
+    <h:body>
+        <ui:composition template="foobar"/>
+    </h:body>
+</html>

--- a/tck/faces20/templating/src/main/webapp/template/compositionEmptyPath.xhtml
+++ b/tck/faces20/templating/src/main/webapp/template/compositionEmptyPath.xhtml
@@ -1,0 +1,28 @@
+<!--
+
+    Copyright (c) 2026 Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<!DOCTYPE html>
+<html xmlns:h="jakarta.faces.html"
+      xmlns:ui="jakarta.faces.facelets">
+    <h:head>
+        <title>Composition with a blank template</title>
+    </h:head>
+    <h:body>
+        <ui:composition template=" "/>
+    </h:body>
+</html>

--- a/tck/faces20/templating/src/main/webapp/template/decorateBadPath.xhtml
+++ b/tck/faces20/templating/src/main/webapp/template/decorateBadPath.xhtml
@@ -1,0 +1,28 @@
+<!--
+
+    Copyright (c) 2026 Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<!DOCTYPE html>
+<html xmlns:h="jakarta.faces.html"
+      xmlns:ui="jakarta.faces.facelets">
+    <h:head>
+        <title>Decorate with an unresolvable template</title>
+    </h:head>
+    <h:body>
+        <ui:decorate template="foobar"/>
+    </h:body>
+</html>

--- a/tck/faces20/templating/src/main/webapp/template/decorateEmptyPath.xhtml
+++ b/tck/faces20/templating/src/main/webapp/template/decorateEmptyPath.xhtml
@@ -1,0 +1,28 @@
+<!--
+
+    Copyright (c) 2026 Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<!DOCTYPE html>
+<html xmlns:h="jakarta.faces.html"
+      xmlns:ui="jakarta.faces.facelets">
+    <h:head>
+        <title>Decorate with a blank template</title>
+    </h:head>
+    <h:body>
+        <ui:decorate template=" "/>
+    </h:body>
+</html>

--- a/tck/faces20/templating/src/main/webapp/template/mismatchedComposition.xhtml
+++ b/tck/faces20/templating/src/main/webapp/template/mismatchedComposition.xhtml
@@ -1,0 +1,27 @@
+<!--
+
+    Copyright (c) 2026 Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<!DOCTYPE html>
+<html xmlns:f="jakarta.faces.core"
+      xmlns:ui="jakarta.faces.facelets">
+    <f:view>
+        <body>
+            <ui:composition template="/template/mismatchedCompositionTemplate.xhtml"/>
+        </body>
+    </f:view>
+</html>

--- a/tck/faces20/templating/src/main/webapp/template/mismatchedCompositionTemplate.xhtml
+++ b/tck/faces20/templating/src/main/webapp/template/mismatchedCompositionTemplate.xhtml
@@ -1,0 +1,27 @@
+<!--
+
+    Copyright (c) 2026 Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<!DOCTYPE html>
+<html xmlns:h="jakarta.faces.html">
+    <h:head>
+        <title>mismatched composition</title>
+    </h:head>
+    <h:body>
+        Hello from Facelets
+    </h:body>
+</html>

--- a/tck/faces20/templating/src/test/java/ee/jakarta/tck/faces/faces20/templating/Issue2029IT.java
+++ b/tck/faces20/templating/src/test/java/ee/jakarta/tck/faces/faces20/templating/Issue2029IT.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2026 Contributors to Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.faces.faces20.templating;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+import ee.jakarta.tck.faces.util.selenium.BaseITNG;
+import jakarta.faces.view.facelets.TagAttributeException;
+
+/**
+ * The VDL documentation of the {@code template} attribute of {@code ui:composition} and {@code ui:decorate}
+ * requires a {@link TagAttributeException} when the URI cannot be resolved. The request must therefore fail
+ * rather than silently render an empty page. The exception message is not asserted: these run in the
+ * Production project stage, which does not surface it.
+ */
+class Issue2029IT extends BaseITNG {
+
+    /**
+     * @see https://github.com/eclipse-ee4j/mojarra/issues/2029
+     */
+    @Test
+    void compositionWithUnresolvableTemplateFails() {
+        assertEquals(500, getPage("template/compositionBadPath.xhtml").getResponseStatus());
+    }
+
+    /**
+     * @see https://github.com/eclipse-ee4j/mojarra/issues/2029
+     */
+    @Test
+    void compositionWithBlankTemplateFails() {
+        assertEquals(500, getPage("template/compositionEmptyPath.xhtml").getResponseStatus());
+    }
+
+    /**
+     * @see https://github.com/eclipse-ee4j/mojarra/issues/2029
+     */
+    @Test
+    void decorateWithUnresolvableTemplateFails() {
+        assertEquals(500, getPage("template/decorateBadPath.xhtml").getResponseStatus());
+    }
+
+    /**
+     * @see https://github.com/eclipse-ee4j/mojarra/issues/2029
+     */
+    @Test
+    void decorateWithBlankTemplateFails() {
+        assertEquals(500, getPage("template/decorateEmptyPath.xhtml").getResponseStatus());
+    }
+}

--- a/tck/faces20/templating/src/test/java/ee/jakarta/tck/faces/faces20/templating/Issue3682IT.java
+++ b/tck/faces20/templating/src/test/java/ee/jakarta/tck/faces/faces20/templating/Issue3682IT.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2026 Contributors to Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.faces.faces20.templating;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+import ee.jakarta.tck.faces.util.selenium.BaseITNG;
+import ee.jakarta.tck.faces.util.selenium.WebPage;
+
+class Issue3682IT extends BaseITNG {
+
+    /**
+     * A ui:composition nested inside a plain body element still yields a well formed document: the template
+     * supplies the whole page, so the body opens after the html element rather than the other way round.
+     *
+     * @see https://github.com/eclipse-ee4j/mojarra/issues/3682
+     */
+    @Test
+    void compositionInsideAPlainBodyYieldsWellFormedOutput() {
+        WebPage page = getPage("template/mismatchedComposition.xhtml");
+        String source = page.getSource();
+
+        assertEquals(200, page.getResponseStatus(), "The view must render.");
+        assertTrue(page.containsText("Hello from Facelets"), "The template must have supplied the content.");
+        assertTrue(source.indexOf("<body") > source.indexOf("<html"),
+                "The body element must open after the html element.");
+    }
+}

--- a/tck/faces20/view-param/src/main/java/ee/jakarta/tck/faces/faces20/view_param/Issue3209Bean.java
+++ b/tck/faces20/view-param/src/main/java/ee/jakarta/tck/faces/faces20/view_param/Issue3209Bean.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2026 Contributors to Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.faces.faces20.view_param;
+
+import java.io.Serializable;
+
+import jakarta.enterprise.context.SessionScoped;
+import jakarta.inject.Named;
+
+/**
+ * Counts how often the preRenderView listener of the target view has run, so that a postback on the source view can be
+ * shown not to have triggered it.
+ */
+@Named
+@SessionScoped
+public class Issue3209Bean implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private String firstId;
+    private String secondId;
+    private int targetListenerCount;
+
+    public void loadTarget() {
+        targetListenerCount++;
+    }
+
+    public void justAnAction() {
+        // NOOP, the postback itself is what is under test.
+    }
+
+    public String getFirstId() {
+        return firstId;
+    }
+
+    public void setFirstId(String firstId) {
+        this.firstId = firstId;
+    }
+
+    public String getSecondId() {
+        return secondId;
+    }
+
+    public void setSecondId(String secondId) {
+        this.secondId = secondId;
+    }
+
+    public int getTargetListenerCount() {
+        return targetListenerCount;
+    }
+}

--- a/tck/faces20/view-param/src/main/webapp/issue3209-first.xhtml
+++ b/tck/faces20/view-param/src/main/webapp/issue3209-first.xhtml
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<!--
+
+    Copyright (c) 2026 Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<html xmlns:f="jakarta.faces.core"
+      xmlns:h="jakarta.faces.html">
+    <f:metadata>
+        <f:viewParam name="id" value="#{issue3209Bean.firstId}"/>
+    </f:metadata>
+    <h:head>
+        <title>Issue3209 first</title>
+    </h:head>
+    <h:body>
+        <h:form id="form" prependId="false">
+            <h:link id="link" outcome="issue3209-second" value="link to the second view" includeViewParams="true">
+                <f:param name="extraParam" value="99999"/>
+            </h:link>
+            <h:commandButton id="postbackButton" value="postback" action="#{issue3209Bean.justAnAction}"/>
+            <h:outputText id="targetListenerCount" value="#{issue3209Bean.targetListenerCount}"/>
+        </h:form>
+    </h:body>
+</html>

--- a/tck/faces20/view-param/src/main/webapp/issue3209-second.xhtml
+++ b/tck/faces20/view-param/src/main/webapp/issue3209-second.xhtml
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<!--
+
+    Copyright (c) 2026 Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<html xmlns:f="jakarta.faces.core"
+      xmlns:h="jakarta.faces.html">
+    <f:metadata>
+        <f:viewParam name="id" value="#{issue3209Bean.secondId}"/>
+        <f:event type="preRenderView" listener="#{issue3209Bean.loadTarget}"/>
+    </f:metadata>
+    <h:head>
+        <title>Issue3209 second</title>
+    </h:head>
+    <h:body>
+        <h:outputText id="secondId" value="#{issue3209Bean.secondId}"/>
+        <h:outputText id="targetListenerCount" value="#{issue3209Bean.targetListenerCount}"/>
+    </h:body>
+</html>

--- a/tck/faces20/view-param/src/test/java/ee/jakarta/tck/faces/faces20/view_param/Issue3209IT.java
+++ b/tck/faces20/view-param/src/test/java/ee/jakarta/tck/faces/faces20/view_param/Issue3209IT.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2026 Contributors to Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.faces.faces20.view_param;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.By;
+
+import ee.jakarta.tck.faces.util.selenium.BaseITNG;
+import ee.jakarta.tck.faces.util.selenium.WebPage;
+import jakarta.faces.event.PreRenderViewEvent;
+
+class Issue3209IT extends BaseITNG {
+
+    /**
+     * PreRenderViewEvent is published for the view being rendered. Building an h:link with
+     * includeViewParams reads the target view's metadata, but that must not run the target view's
+     * preRenderView listener: a postback on the source view leaves it uninvoked.
+     *
+     * @see PreRenderViewEvent
+     * @see https://github.com/eclipse-ee4j/mojarra/issues/3209
+     */
+    @Test
+    void postbackDoesNotRunThePreRenderViewListenerOfTheLinkTarget() {
+        WebPage page = getPage("issue3209-first.xhtml?id=11111");
+        int before = count(page);
+
+        page.guardHttp(page.findElement(By.id("postbackButton"))::click);
+
+        assertEquals(before, count(page),
+                "A postback on the source view must not run the target view's preRenderView listener.");
+
+        page = getPage("issue3209-second.xhtml?id=22222");
+
+        assertEquals(before + 1, count(page),
+                "Rendering the target view itself must run its preRenderView listener exactly once.");
+    }
+
+    private static int count(WebPage page) {
+        return Integer.parseInt(page.findElement(By.id("targetListenerCount")).getText());
+    }
+}

--- a/tck/faces22/composite-component/src/main/java/ee/jakarta/tck/faces/faces22/composite_component/Issue1810Bean.java
+++ b/tck/faces22/composite-component/src/main/java/ee/jakarta/tck/faces/faces22/composite_component/Issue1810Bean.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2026 Contributors to Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.faces.faces22.composite_component;
+
+import jakarta.enterprise.context.RequestScoped;
+import jakarta.inject.Named;
+
+@Named
+@RequestScoped
+public class Issue1810Bean {
+
+    public String submit() {
+        throw new IllegalStateException("Action method of the composite component failed.");
+    }
+}

--- a/tck/faces22/composite-component/src/main/java/ee/jakarta/tck/faces/faces22/composite_component/Issue2051Bean.java
+++ b/tck/faces22/composite-component/src/main/java/ee/jakarta/tck/faces/faces22/composite_component/Issue2051Bean.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2026 Contributors to Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.faces.faces22.composite_component;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+
+import jakarta.enterprise.context.SessionScoped;
+import jakarta.inject.Named;
+
+@Named
+@SessionScoped
+public class Issue2051Bean implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private final List<Issue2051Line> availableLines =
+        List.of(new Issue2051Line("1", "First"), new Issue2051Line("2", "Second"), new Issue2051Line("3", "Third"));
+
+    private List<Issue2051Line> selectedLines = new ArrayList<>();
+
+    public List<Issue2051Line> getAvailableLines() {
+        return availableLines;
+    }
+
+    public List<Issue2051Line> getSelectedLines() {
+        return selectedLines;
+    }
+
+    public void setSelectedLines(List<Issue2051Line> selectedLines) {
+        this.selectedLines = selectedLines;
+    }
+
+    public String getSelectedNames() {
+        return selectedLines.stream().map(Issue2051Line::getName).reduce((left, right) -> left + " " + right).orElse("");
+    }
+
+    public Issue2051Line findLine(String id) {
+        return availableLines.stream().filter(line -> line.getId().equals(id)).findFirst().orElse(null);
+    }
+}

--- a/tck/faces22/composite-component/src/main/java/ee/jakarta/tck/faces/faces22/composite_component/Issue2051Line.java
+++ b/tck/faces22/composite-component/src/main/java/ee/jakarta/tck/faces/faces22/composite_component/Issue2051Line.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2026 Contributors to Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.faces.faces22.composite_component;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+public class Issue2051Line implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private final String id;
+    private final String name;
+
+    public Issue2051Line(String id, String name) {
+        this.id = id;
+        this.name = name;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other instanceof Issue2051Line && Objects.equals(id, ((Issue2051Line) other).id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(id);
+    }
+}

--- a/tck/faces22/composite-component/src/main/java/ee/jakarta/tck/faces/faces22/composite_component/Issue2051LineConverter.java
+++ b/tck/faces22/composite-component/src/main/java/ee/jakarta/tck/faces/faces22/composite_component/Issue2051LineConverter.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2026 Contributors to Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.faces.faces22.composite_component;
+
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.context.FacesContext;
+import jakarta.faces.convert.Converter;
+import jakarta.faces.convert.FacesConverter;
+import jakarta.inject.Inject;
+
+@FacesConverter(Issue2051LineConverter.CONVERTER_ID)
+public class Issue2051LineConverter implements Converter<Issue2051Line> {
+
+    public static final String CONVERTER_ID = "issue2051LineConverter";
+
+    @Inject
+    private Issue2051Bean bean;
+
+    @Override
+    public Issue2051Line getAsObject(FacesContext context, UIComponent component, String value) {
+        return bean.findLine(value);
+    }
+
+    @Override
+    public String getAsString(FacesContext context, UIComponent component, Issue2051Line value) {
+        return value == null ? "" : value.getId();
+    }
+}

--- a/tck/faces22/composite-component/src/main/java/ee/jakarta/tck/faces/faces22/composite_component/Issue2180Bean.java
+++ b/tck/faces22/composite-component/src/main/java/ee/jakarta/tck/faces/faces22/composite_component/Issue2180Bean.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2026 Contributors to Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.faces.faces22.composite_component;
+
+import java.beans.BeanInfo;
+import java.io.Serializable;
+import java.util.Collection;
+
+import jakarta.enterprise.context.SessionScoped;
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.component.visit.VisitContext;
+import jakarta.faces.component.visit.VisitResult;
+import jakarta.faces.context.FacesContext;
+import jakarta.inject.Named;
+
+/**
+ * Counts, across the whole view, how many attribute names the composite components declare a default value for. The
+ * count is a property of the view declaration and must therefore be identical on every postback.
+ */
+@Named
+@SessionScoped
+public class Issue2180Bean implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private int previousCount = -1;
+
+    public String getStatus() {
+        int observedCount = countAttributesWithDeclaredDefaultValues();
+
+        try {
+            return previousCount == -1 || observedCount == previousCount ? "SUCCESS" : "FAILED";
+        }
+        finally {
+            previousCount = observedCount;
+        }
+    }
+
+    private static int countAttributesWithDeclaredDefaultValues() {
+        FacesContext context = FacesContext.getCurrentInstance();
+        int[] count = { 0 };
+
+        context.getViewRoot().visitTree(VisitContext.createVisitContext(context), (visitContext, target) -> {
+            if (UIComponent.isCompositeComponent(target)) {
+                BeanInfo beanInfo = (BeanInfo) target.getAttributes().get(UIComponent.BEANINFO_KEY);
+
+                @SuppressWarnings("unchecked")
+                Collection<String> names =
+                    (Collection<String>) beanInfo.getBeanDescriptor().getValue(UIComponent.ATTRS_WITH_DECLARED_DEFAULT_VALUES);
+
+                if (names != null) {
+                    count[0] += names.size();
+                }
+            }
+
+            return VisitResult.ACCEPT;
+        });
+
+        return count[0];
+    }
+}

--- a/tck/faces22/composite-component/src/main/java/ee/jakarta/tck/faces/faces22/composite_component/Issue2324IdUniquenessListener.java
+++ b/tck/faces22/composite-component/src/main/java/ee/jakarta/tck/faces/faces22/composite_component/Issue2324IdUniquenessListener.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2026 Contributors to Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.faces.faces22.composite_component;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import jakarta.faces.application.FacesMessage;
+import jakarta.faces.application.FacesMessage.Severity;
+import jakarta.faces.component.visit.VisitContext;
+import jakarta.faces.component.visit.VisitResult;
+import jakarta.faces.context.FacesContext;
+import jakarta.faces.event.PhaseEvent;
+import jakarta.faces.event.PhaseId;
+import jakarta.faces.event.PhaseListener;
+
+/**
+ * Asserts, over the fully built view, that no two components share a client id. Client id uniqueness across the view is
+ * equivalent to component id uniqueness within each naming container, so this expresses the specification requirement
+ * using only public API.
+ */
+public class Issue2324IdUniquenessListener implements PhaseListener {
+
+    private static final long serialVersionUID = 1L;
+
+    static final String UNIQUE = "IDS ARE UNIQUE";
+    static final String DUPLICATE = "DUPLICATE CLIENT ID: ";
+
+    @Override
+    public void beforePhase(PhaseEvent event) {
+        FacesContext context = event.getFacesContext();
+        Set<String> clientIds = new HashSet<>();
+        Set<String> duplicates = new HashSet<>();
+
+        context.getViewRoot().visitTree(VisitContext.createVisitContext(context), (visitContext, target) -> {
+            if (!clientIds.add(target.getClientId(context))) {
+                duplicates.add(target.getClientId(context));
+            }
+
+            return VisitResult.ACCEPT;
+        });
+
+        if (duplicates.isEmpty()) {
+            context.addMessage(null, new FacesMessage(UNIQUE));
+        }
+        else {
+            for (String duplicate : duplicates) {
+                context.addMessage(null, new FacesMessage(Severity.ERROR, DUPLICATE + duplicate, null));
+            }
+        }
+    }
+
+    @Override
+    public void afterPhase(PhaseEvent event) {
+        // NOOP.
+    }
+
+    @Override
+    public PhaseId getPhaseId() {
+        return PhaseId.RENDER_RESPONSE;
+    }
+}

--- a/tck/faces22/composite-component/src/main/java/ee/jakarta/tck/faces/faces22/composite_component/Issue3104Bean.java
+++ b/tck/faces22/composite-component/src/main/java/ee/jakarta/tck/faces/faces22/composite_component/Issue3104Bean.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2026 Contributors to Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.faces.faces22.composite_component;
+
+import jakarta.enterprise.context.RequestScoped;
+import jakarta.inject.Named;
+
+@Named
+@RequestScoped
+public class Issue3104Bean {
+
+    private String value;
+
+    public String getValue() {
+        return value;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
+    }
+
+    public void ajaxMe() {
+        throw new IllegalStateException("Ajax listener of the nested composite component failed.");
+    }
+}

--- a/tck/faces22/composite-component/src/main/webapp/issue1810.xhtml
+++ b/tck/faces22/composite-component/src/main/webapp/issue1810.xhtml
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<!--
+
+    Copyright (c) 2026 Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<html xmlns:h="jakarta.faces.html"
+      xmlns:ez="jakarta.faces.composite/issue1810">
+    <h:head>
+        <title>Issue1810</title>
+    </h:head>
+    <h:body>
+        <ez:action id="action" action="#{issue1810Bean.submit}"/>
+    </h:body>
+</html>

--- a/tck/faces22/composite-component/src/main/webapp/issue1858.xhtml
+++ b/tck/faces22/composite-component/src/main/webapp/issue1858.xhtml
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<!--
+
+    Copyright (c) 2026 Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<html xmlns:h="jakarta.faces.html"
+      xmlns:ez="jakarta.faces.composite/issue1858">
+    <h:head>
+        <title>Issue1858</title>
+    </h:head>
+    <h:body>
+        <ez:link id="composite" onclick="markOneClick()"/>
+    </h:body>
+</html>

--- a/tck/faces22/composite-component/src/main/webapp/issue2051.xhtml
+++ b/tck/faces22/composite-component/src/main/webapp/issue2051.xhtml
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<!--
+
+    Copyright (c) 2026 Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<html xmlns:h="jakarta.faces.html"
+      xmlns:ez="jakarta.faces.composite/issue2051">
+    <h:head>
+        <title>Issue2051</title>
+    </h:head>
+    <h:body>
+        <h:form id="form">
+            <ez:listBox id="composite"
+                        source="#{issue2051Bean.availableLines}"
+                        target="#{issue2051Bean.selectedLines}"
+                        converterId="issue2051LineConverter"/>
+            <h:commandButton id="submit" value="Submit"/>
+            <h:outputText id="selected" value="#{issue2051Bean.selectedNames}"/>
+        </h:form>
+    </h:body>
+</html>

--- a/tck/faces22/composite-component/src/main/webapp/issue2180.xhtml
+++ b/tck/faces22/composite-component/src/main/webapp/issue2180.xhtml
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<!--
+
+    Copyright (c) 2026 Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<html xmlns:h="jakarta.faces.html"
+      xmlns:ez="jakarta.faces.composite/issue2180">
+    <h:head>
+        <title>Issue2180</title>
+    </h:head>
+    <h:body>
+        <h:form id="form">
+            <ez:nested>
+                <ez:nested>
+                    <ez:nested>
+                        <ez:nested>
+                            <ez:nested/>
+                        </ez:nested>
+                    </ez:nested>
+                </ez:nested>
+            </ez:nested>
+            <h:outputText id="status" value="#{issue2180Bean.status}"/>
+            <h:commandButton id="submit" value="Submit"/>
+        </h:form>
+    </h:body>
+</html>

--- a/tck/faces22/composite-component/src/main/webapp/issue2324.xhtml
+++ b/tck/faces22/composite-component/src/main/webapp/issue2324.xhtml
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<!--
+
+    Copyright (c) 2026 Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<html xmlns:f="jakarta.faces.core"
+      xmlns:h="jakarta.faces.html"
+      xmlns:ez="jakarta.faces.composite/issue2324">
+    <h:head>
+        <title>Issue2324</title>
+    </h:head>
+    <h:body>
+        <f:phaseListener type="ee.jakarta.tck.faces.faces22.composite_component.Issue2324IdUniquenessListener"/>
+
+        <h:panelGroup id="outer1">
+            <f:facet name="header">
+                <h:outputText value="Hello"/>
+            </f:facet>
+            <h:outputText value="World"/>
+        </h:panelGroup>
+
+        <h:panelGroup id="outer2">
+            <f:facet name="header">
+                <h:outputText value="Hello"/>
+            </f:facet>
+            <h:outputText value="World"/>
+        </h:panelGroup>
+
+        <ez:facets id="composite">
+            <f:facet name="header">
+                <h:outputText value="Hello"/>
+                <h:outputText value="World"/>
+            </f:facet>
+        </ez:facets>
+
+        <h:messages id="messages" globalOnly="true"/>
+    </h:body>
+</html>

--- a/tck/faces22/composite-component/src/main/webapp/issue3104.xhtml
+++ b/tck/faces22/composite-component/src/main/webapp/issue3104.xhtml
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<!--
+
+    Copyright (c) 2026 Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<html xmlns:h="jakarta.faces.html"
+      xmlns:ez="jakarta.faces.composite/issue3104">
+    <h:head>
+        <title>Issue3104</title>
+    </h:head>
+    <h:body>
+        <h:form id="form">
+            <ez:outer id="nesting0"
+                      value="#{issue3104Bean.value}"
+                      listener="#{issue3104Bean.ajaxMe()}"/>
+        </h:form>
+        <div id="errorName"></div>
+        <h:outputScript>
+            faces.ajax.addOnError(function(data) {
+                document.getElementById("errorName").appendChild(document.createTextNode(data.errorName));
+            });
+        </h:outputScript>
+    </h:body>
+</html>

--- a/tck/faces22/composite-component/src/main/webapp/resources/issue1810/action.xhtml
+++ b/tck/faces22/composite-component/src/main/webapp/resources/issue1810/action.xhtml
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<!--
+
+    Copyright (c) 2026 Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<html xmlns:h="jakarta.faces.html"
+      xmlns:cc="jakarta.faces.composite">
+    <cc:interface>
+        <cc:attribute name="action" required="true" method-signature="java.lang.String action()"/>
+    </cc:interface>
+    <cc:implementation>
+        <h:form id="form1">
+            <h:commandButton id="submit" value="Submit" action="#{cc.attrs.action}"/>
+        </h:form>
+    </cc:implementation>
+</html>

--- a/tck/faces22/composite-component/src/main/webapp/resources/issue1858/link.xhtml
+++ b/tck/faces22/composite-component/src/main/webapp/resources/issue1858/link.xhtml
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<!--
+
+    Copyright (c) 2026 Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<html xmlns:h="jakarta.faces.html"
+      xmlns:cc="jakarta.faces.composite">
+    <cc:interface>
+        <cc:attribute name="onclick"/>
+    </cc:interface>
+    <cc:implementation>
+        <h:link id="link" value="Link" onclick="#{cc.attrs.onclick}"/>
+    </cc:implementation>
+</html>

--- a/tck/faces22/composite-component/src/main/webapp/resources/issue2051/listBox.xhtml
+++ b/tck/faces22/composite-component/src/main/webapp/resources/issue2051/listBox.xhtml
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<!--
+
+    Copyright (c) 2026 Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<html xmlns:f="jakarta.faces.core"
+      xmlns:h="jakarta.faces.html"
+      xmlns:cc="jakarta.faces.composite">
+    <cc:interface>
+        <cc:attribute name="source" required="true"/>
+        <cc:attribute name="target" required="true"/>
+        <cc:attribute name="converterId"/>
+    </cc:interface>
+    <cc:implementation>
+        <h:selectManyListbox id="listBox" value="#{cc.attrs.target}">
+            <f:converter converterId="#{cc.attrs.converterId}" rendered="#{cc.attrs.converterId != null}"/>
+            <f:selectItems var="item" value="#{cc.attrs.source}" itemLabel="#{item.name}" itemValue="#{item}"/>
+        </h:selectManyListbox>
+    </cc:implementation>
+</html>

--- a/tck/faces22/composite-component/src/main/webapp/resources/issue2180/nested.xhtml
+++ b/tck/faces22/composite-component/src/main/webapp/resources/issue2180/nested.xhtml
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<!--
+
+    Copyright (c) 2026 Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<html xmlns:h="jakarta.faces.html"
+      xmlns:cc="jakarta.faces.composite">
+    <cc:interface>
+        <cc:attribute name="text" default="DEFAULT" type="java.lang.String"/>
+    </cc:interface>
+    <cc:implementation>
+        <h:outputText value="#{cc.attrs.text}"/>
+        <cc:insertChildren/>
+    </cc:implementation>
+</html>

--- a/tck/faces22/composite-component/src/main/webapp/resources/issue2324/facets.xhtml
+++ b/tck/faces22/composite-component/src/main/webapp/resources/issue2324/facets.xhtml
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<!--
+
+    Copyright (c) 2026 Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<html xmlns:cc="jakarta.faces.composite">
+    <cc:interface/>
+    <cc:implementation>
+        Composite body
+    </cc:implementation>
+</html>

--- a/tck/faces22/composite-component/src/main/webapp/resources/issue3104/inner.xhtml
+++ b/tck/faces22/composite-component/src/main/webapp/resources/issue3104/inner.xhtml
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<!--
+
+    Copyright (c) 2026 Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<html xmlns:f="jakarta.faces.core"
+      xmlns:h="jakarta.faces.html"
+      xmlns:cc="jakarta.faces.composite">
+    <cc:interface>
+        <cc:attribute name="value"/>
+        <cc:attribute name="listener" method-signature="void listener()"/>
+    </cc:interface>
+    <cc:implementation>
+        <h:inputText id="inputText" value="#{cc.attrs.value}">
+            <f:ajax immediate="true" listener="#{cc.attrs.listener}"/>
+        </h:inputText>
+    </cc:implementation>
+</html>

--- a/tck/faces22/composite-component/src/main/webapp/resources/issue3104/outer.xhtml
+++ b/tck/faces22/composite-component/src/main/webapp/resources/issue3104/outer.xhtml
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<!--
+
+    Copyright (c) 2026 Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<html xmlns:cc="jakarta.faces.composite"
+      xmlns:ez="jakarta.faces.composite/issue3104">
+    <cc:interface>
+        <cc:attribute name="value"/>
+        <cc:attribute name="listener" method-signature="void listener()"/>
+    </cc:interface>
+    <cc:implementation>
+        <ez:inner id="nesting1" value="#{cc.attrs.value}" listener="#{cc.attrs.listener}"/>
+    </cc:implementation>
+</html>

--- a/tck/faces22/composite-component/src/test/java/ee/jakarta/tck/faces/faces22/composite_component/Issue1810IT.java
+++ b/tck/faces22/composite-component/src/test/java/ee/jakarta/tck/faces/faces22/composite_component/Issue1810IT.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2026 Contributors to Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.faces.faces22.composite_component;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.By;
+
+import ee.jakarta.tck.faces.util.selenium.BaseITNG;
+import ee.jakarta.tck.faces.util.selenium.WebPage;
+
+class Issue1810IT extends BaseITNG {
+
+    /**
+     * A RuntimeException thrown by the action method bound to a composite component's declared action
+     * attribute must reach the ExceptionHandler rather than being swallowed by the retargeting, so the
+     * postback yields a 500.
+     *
+     * @see jakarta.faces.view.facelets.FaceletContext
+     * @see https://github.com/eclipse-ee4j/mojarra/issues/1810
+     */
+    @Test
+    void exceptionFromRetargetedActionPropagates() {
+        WebPage page = getPage("issue1810.xhtml");
+
+        page.findElement(By.id("action:form1:submit")).click();
+
+        assertEquals(500, page.getResponseStatus(),
+                "An exception from the retargeted action method must not be swallowed.");
+    }
+}

--- a/tck/faces22/composite-component/src/test/java/ee/jakarta/tck/faces/faces22/composite_component/Issue1858IT.java
+++ b/tck/faces22/composite-component/src/test/java/ee/jakarta/tck/faces/faces22/composite_component/Issue1858IT.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2026 Contributors to Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.faces.faces22.composite_component;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.By;
+
+import ee.jakarta.tck.faces.util.selenium.BaseITNG;
+import ee.jakarta.tck.faces.util.selenium.WebPage;
+import jakarta.faces.component.html.HtmlOutcomeTargetLink;
+
+class Issue1858IT extends BaseITNG {
+
+    private static final String MARKER = "markOneClick()";
+
+    /**
+     * An onclick supplied as a composite component attribute and forwarded to a nested h:link is wired to
+     * the anchor, and its handler appears in the response exactly once. Whether the handler is rendered as
+     * an inline attribute or wired from a script block is left to the implementation by jakartaee/faces#2167.
+     *
+     * @see HtmlOutcomeTargetLink#getOnclick()
+     * @see https://github.com/eclipse-ee4j/mojarra/issues/1858
+     */
+    @Test
+    void onclickForwardedThroughCompositeIsRenderedOnce() {
+        WebPage page = getPage("issue1858.xhtml");
+
+        assertTrue(page.isAttributeWired(page.findElement(By.id("composite:link")), "onclick"),
+                "The forwarded onclick must be wired to the anchor.");
+        assertEquals(1, countOccurrences(page.getSource(), MARKER),
+                "The forwarded onclick handler must appear exactly once.");
+    }
+
+    private static int countOccurrences(String source, String token) {
+        int count = 0;
+
+        for (int index = source.indexOf(token); index != -1; index = source.indexOf(token, index + token.length())) {
+            count++;
+        }
+
+        return count;
+    }
+}

--- a/tck/faces22/composite-component/src/test/java/ee/jakarta/tck/faces/faces22/composite_component/Issue2051IT.java
+++ b/tck/faces22/composite-component/src/test/java/ee/jakarta/tck/faces/faces22/composite_component/Issue2051IT.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2026 Contributors to Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.faces.faces22.composite_component;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.support.ui.Select;
+
+import ee.jakarta.tck.faces.util.selenium.BaseITNG;
+import ee.jakarta.tck.faces.util.selenium.WebPage;
+
+class Issue2051IT extends BaseITNG {
+
+    /**
+     * A converterId supplied as a composite component attribute, evaluated by both the converterId and the
+     * rendered attribute of a nested f:converter, is applied to the enclosing h:selectManyListbox: the view
+     * renders and the selection converts back to the model on postback.
+     *
+     * @see jakarta.faces.convert.Converter
+     * @see https://github.com/eclipse-ee4j/mojarra/issues/2051
+     */
+    @Test
+    void converterIdFromCompositeAttributeIsApplied() {
+        WebPage page = getPage("issue2051.xhtml");
+
+        assertEquals(200, page.getResponseStatus(), "initial render");
+
+        new Select(page.findElement(By.id("form:composite:listBox"))).selectByVisibleText("Second");
+        page.guardHttp(page.findElement(By.id("form:submit"))::click);
+
+        assertEquals(200, page.getResponseStatus(), "postback");
+        assertEquals("Second", page.findElement(By.id("form:selected")).getText(),
+                "The selection must have been converted back into the model.");
+    }
+}

--- a/tck/faces22/composite-component/src/test/java/ee/jakarta/tck/faces/faces22/composite_component/Issue2180IT.java
+++ b/tck/faces22/composite-component/src/test/java/ee/jakarta/tck/faces/faces22/composite_component/Issue2180IT.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2026 Contributors to Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.faces.faces22.composite_component;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.By;
+
+import ee.jakarta.tck.faces.util.selenium.BaseITNG;
+import ee.jakarta.tck.faces.util.selenium.WebPage;
+import jakarta.faces.component.UIComponent;
+
+class Issue2180IT extends BaseITNG {
+
+    /**
+     * The attribute names a composite component declares a default value for are a property of its view
+     * declaration, so the collection under ATTRS_WITH_DECLARED_DEFAULT_VALUES must not accumulate entries
+     * across postbacks of composites nested through cc:insertChildren.
+     *
+     * @see UIComponent#ATTRS_WITH_DECLARED_DEFAULT_VALUES
+     * @see https://github.com/eclipse-ee4j/mojarra/issues/2180
+     */
+    @Test
+    void declaredDefaultsDoNotAccumulateAcrossPostbacks() {
+        WebPage page = getPage("issue2180.xhtml");
+
+        assertEquals("SUCCESS", page.findElement(By.id("form:status")).getText(), "initial render");
+
+        for (int postback = 1; postback <= 3; postback++) {
+            page.guardHttp(page.findElement(By.id("form:submit"))::click);
+            assertEquals("SUCCESS", page.findElement(By.id("form:status")).getText(), "postback " + postback);
+        }
+    }
+}

--- a/tck/faces22/composite-component/src/test/java/ee/jakarta/tck/faces/faces22/composite_component/Issue2324IT.java
+++ b/tck/faces22/composite-component/src/test/java/ee/jakarta/tck/faces/faces22/composite_component/Issue2324IT.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2026 Contributors to Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.faces.faces22.composite_component;
+
+import static ee.jakarta.tck.faces.faces22.composite_component.Issue2324IdUniquenessListener.DUPLICATE;
+import static ee.jakarta.tck.faces.faces22.composite_component.Issue2324IdUniquenessListener.UNIQUE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.By;
+
+import ee.jakarta.tck.faces.util.selenium.BaseITNG;
+import ee.jakarta.tck.faces.util.selenium.WebPage;
+import jakarta.faces.component.UIComponent;
+
+class Issue2324IT extends BaseITNG {
+
+    /**
+     * Facet children of sibling components and of a composite component get distinct generated ids, so the
+     * view contains no two components sharing a client id.
+     *
+     * @see UIComponent#getClientId()
+     * @see https://github.com/eclipse-ee4j/mojarra/issues/2324
+     */
+    @Test
+    void facetsAroundAndInsideACompositeYieldUniqueIds() {
+        WebPage page = getPage("issue2324.xhtml");
+
+        assertEquals(200, page.getResponseStatus(), "The view must render.");
+        assertFalse(page.containsText(DUPLICATE), "No two components may share a client id.");
+        assertEquals(UNIQUE, page.findElement(By.id("messages")).getText(), "id uniqueness verdict");
+    }
+}

--- a/tck/faces22/composite-component/src/test/java/ee/jakarta/tck/faces/faces22/composite_component/Issue3104IT.java
+++ b/tck/faces22/composite-component/src/test/java/ee/jakarta/tck/faces/faces22/composite_component/Issue3104IT.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2026 Contributors to Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.faces.faces22.composite_component;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.By;
+
+import ee.jakarta.tck.faces.util.selenium.BaseITNG;
+import ee.jakarta.tck.faces.util.selenium.WebPage;
+
+class Issue3104IT extends BaseITNG {
+
+    /**
+     * A listener MethodExpression forwarded through two levels of composite component into f:ajax must not
+     * fail silently: when the listener throws, the client-side error handler registered with
+     * faces.ajax.addOnError is invoked and receives the error name.
+     *
+     * @see https://github.com/eclipse-ee4j/mojarra/issues/3104
+     */
+    @Test
+    void ajaxListenerFailureReachesTheErrorHandler() {
+        WebPage page = getPage("issue3104.xhtml");
+
+        page.findElement(By.id("form:nesting0:nesting1:inputText")).sendKeys("12345");
+        page.executeScript("document.getElementById('form:nesting0:nesting1:inputText').blur();");
+        page.waitForCondition(driver -> !driver.findElement(By.id("errorName")).getText().isEmpty());
+
+        assertFalse(page.findElement(By.id("errorName")).getText().isEmpty(),
+                "The failing ajax listener must surface an error to the registered onerror handler.");
+    }
+}

--- a/tck/faces22/facelets/src/main/webapp/issue2055-not-rendered.xhtml
+++ b/tck/faces22/facelets/src/main/webapp/issue2055-not-rendered.xhtml
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<!--
+
+    Copyright (c) 2026 Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<html xmlns:h="jakarta.faces.html"
+      xmlns:ui="jakarta.faces.facelets">
+    <h:head>
+        <title>Issue2055</title>
+    </h:head>
+    <h:body>
+        <ui:debug rendered="false"/>
+    </h:body>
+</html>

--- a/tck/faces22/facelets/src/main/webapp/issue2055-rendered.xhtml
+++ b/tck/faces22/facelets/src/main/webapp/issue2055-rendered.xhtml
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<!--
+
+    Copyright (c) 2026 Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<html xmlns:h="jakarta.faces.html"
+      xmlns:ui="jakarta.faces.facelets">
+    <h:head>
+        <title>Issue2055</title>
+    </h:head>
+    <h:body>
+        <ui:debug/>
+    </h:body>
+</html>

--- a/tck/faces22/facelets/src/test/java/ee/jakarta/tck/faces/faces22/facelets/Issue2055IT.java
+++ b/tck/faces22/facelets/src/test/java/ee/jakarta/tck/faces/faces22/facelets/Issue2055IT.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2026 Contributors to Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.faces.faces22.facelets;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+import ee.jakarta.tck.faces.util.selenium.BaseITNG;
+
+class Issue2055IT extends BaseITNG {
+
+    private static final String DEBUG_MARKER = "faceletsDebug";
+
+    /**
+     * The VDL documentation of ui:debug states that the debug component is not rendered in the page when
+     * the rendered attribute evaluates to false, and rendered otherwise.
+     *
+     * @see https://github.com/eclipse-ee4j/mojarra/issues/2055
+     */
+    @Test
+    void debugIsEmittedByDefault() {
+        assertTrue(getPage("issue2055-rendered.xhtml").containsSource(DEBUG_MARKER),
+                "ui:debug must emit its debug output by default.");
+    }
+
+    /**
+     * @see https://github.com/eclipse-ee4j/mojarra/issues/2055
+     */
+    @Test
+    void debugIsSuppressedWhenNotRendered() {
+        assertFalse(getPage("issue2055-not-rendered.xhtml").containsSource(DEBUG_MARKER),
+                "ui:debug must emit nothing when rendered is false.");
+    }
+}

--- a/tck/faces22/file-upload/src/test/java/ee/jakarta/tck/faces/faces22/file_upload/Spec802IT.java
+++ b/tck/faces22/file-upload/src/test/java/ee/jakarta/tck/faces/faces22/file_upload/Spec802IT.java
@@ -18,6 +18,7 @@ package ee.jakarta.tck.faces.faces22.file_upload;
 
 import static ee.jakarta.tck.faces.faces22.file_upload.Spec802Validator.MARKER;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
@@ -101,6 +102,28 @@ class Spec802IT extends BaseITNG {
             assertEquals(content, page.findElement(By.id("form:fileText")).getText(),
                     "Upload " + i + " on the same view must yield its own bytes.");
         }
+    }
+
+    /**
+     * The File renderer must render the client id as the name attribute and must not render a value
+     * attribute at all, neither on an initial render nor after a postback.
+     *
+     * @see HtmlInputFile
+     * @see https://github.com/jakartaee/faces/issues/802
+     */
+    @Test
+    void valueAttributeIsNotRendered() throws IOException {
+        WebPage page = getPage(VIEW);
+
+        assertEquals("form:file", page.findElement(By.id("form:file")).getDomAttribute("name"),
+                "The client id must be rendered as the name attribute.");
+        assertNull(page.findElement(By.id("form:file")).getDomAttribute("value"),
+                "The value attribute must not be rendered on an initial render.");
+
+        submit(page, MARKER + " reaches the model");
+
+        assertNull(page.findElement(By.id("form:file")).getDomAttribute("value"),
+                "The value attribute must not be rendered after a postback.");
     }
 
     /**

--- a/tck/faces22/full-state-saving/pom.xml
+++ b/tck/faces22/full-state-saving/pom.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2026 Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.eclipse.ee4j.tck.faces.faces22</groupId>
+        <artifactId>pom</artifactId>
+        <version>5.0.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>full-state-saving</artifactId>
+    <packaging>war</packaging>
+
+    <name>Jakarta Faces TCK ${project.version} - ${test.moduleName} - ${project.artifactId}</name>
+
+    <build>
+        <finalName>test-${test.moduleName}-${project.artifactId}</finalName>
+    </build>
+</project>

--- a/tck/faces22/full-state-saving/src/main/java/ee/jakarta/tck/faces/faces22/full_state_saving/Issue1641ActionListener.java
+++ b/tck/faces22/full-state-saving/src/main/java/ee/jakarta/tck/faces/faces22/full_state_saving/Issue1641ActionListener.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2026 Contributors to Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.faces.faces22.full_state_saving;
+
+import jakarta.faces.context.FacesContext;
+import jakarta.faces.event.AbortProcessingException;
+import jakarta.faces.event.ActionEvent;
+import jakarta.faces.event.ActionListener;
+
+public class Issue1641ActionListener implements ActionListener {
+
+    @Override
+    public void processAction(ActionEvent ae) throws AbortProcessingException {
+        FacesContext context = FacesContext.getCurrentInstance();
+        Issue1641Bean bean = context.getApplication()
+                .evaluateExpressionGet(context, "#{issue1641Bean}", Issue1641Bean.class);
+        bean.increment();
+    }
+}

--- a/tck/faces22/full-state-saving/src/main/java/ee/jakarta/tck/faces/faces22/full_state_saving/Issue1641Bean.java
+++ b/tck/faces22/full-state-saving/src/main/java/ee/jakarta/tck/faces/faces22/full_state_saving/Issue1641Bean.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2026 Contributors to Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.faces.faces22.full_state_saving;
+
+import jakarta.enterprise.context.RequestScoped;
+import jakarta.inject.Named;
+
+@Named
+@RequestScoped
+public class Issue1641Bean {
+
+    private int count;
+
+    public void increment() {
+        count++;
+    }
+
+    public int getCount() {
+        return count;
+    }
+}

--- a/tck/faces22/full-state-saving/src/main/webapp/WEB-INF/faces-config.xml
+++ b/tck/faces22/full-state-saving/src/main/webapp/WEB-INF/faces-config.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2026 Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<faces-config
+    xmlns="https://jakarta.ee/xml/ns/jakartaee"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-facesconfig_4_1.xsd"
+    version="4.1">
+</faces-config>

--- a/tck/faces22/full-state-saving/src/main/webapp/WEB-INF/web.xml
+++ b/tck/faces22/full-state-saving/src/main/webapp/WEB-INF/web.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2026 Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<web-app
+    xmlns="https://jakarta.ee/xml/ns/jakartaee"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-app_6_1.xsd"
+    version="6.1">
+
+    <context-param>
+        <param-name>jakarta.faces.PROJECT_STAGE</param-name>
+        <param-value>${webapp.projectStage}</param-value>
+    </context-param>
+    <!-- DO NOT PARAMETERIZE PARTIAL_STATE_SAVING, Issue1641IT and Issue2918IT both regress against full state saving -->
+    <context-param>
+        <param-name>jakarta.faces.PARTIAL_STATE_SAVING</param-name>
+        <param-value>false</param-value>
+    </context-param>
+    <context-param>
+        <param-name>jakarta.faces.STATE_SAVING_METHOD</param-name>
+        <param-value>${webapp.stateSavingMethod}</param-value>
+    </context-param>
+    <context-param>
+        <param-name>jakarta.faces.SERIALIZE_SERVER_STATE</param-name>
+        <param-value>${webapp.serializeServerState}</param-value>
+    </context-param>
+</web-app>

--- a/tck/faces22/full-state-saving/src/main/webapp/contracts/siteLayout/cssLayout.css
+++ b/tck/faces22/full-state-saving/src/main/webapp/contracts/siteLayout/cssLayout.css
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2026 Contributors to Eclipse Foundation.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+#top {
+    position: relative;
+    background-color: #036fab;
+    color: white;
+    padding: 5px;
+}
+
+#left {
+    float: left;
+    background-color: #ece3a5;
+    padding: 5px;
+    width: 150px;
+}

--- a/tck/faces22/full-state-saving/src/main/webapp/contracts/siteLayout/default.css
+++ b/tck/faces22/full-state-saving/src/main/webapp/contracts/siteLayout/default.css
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2026 Contributors to Eclipse Foundation.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+body {
+    background-color: #ffffff;
+    color: #000000;
+    margin: 10px;
+}
+
+h1 {
+    border-bottom: 1px solid #AFAFAF;
+    font-weight: bold;
+    color: #D20005;
+}

--- a/tck/faces22/full-state-saving/src/main/webapp/contracts/siteLayout/leftNav_foo.xhtml
+++ b/tck/faces22/full-state-saving/src/main/webapp/contracts/siteLayout/leftNav_foo.xhtml
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<!--
+
+    Copyright (c) 2026 Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+<html xmlns:h="jakarta.faces.html"
+      xmlns:ui="jakarta.faces.facelets">
+    <h:head>
+        <h:outputStylesheet name="default.css"/>
+        <h:outputStylesheet name="cssLayout.css"/>
+        <title><ui:insert name="title">title</ui:insert></title>
+    </h:head>
+    <h:body>
+        <div id="left">
+            <p>Left Side Navigation Menu</p>
+            <ui:insert name="nav">Nav Content</ui:insert>
+        </div>
+        <div id="content" class="left_content">
+            <ui:insert name="content">Content</ui:insert>
+        </div>
+    </h:body>
+</html>

--- a/tck/faces22/full-state-saving/src/main/webapp/contracts/siteLayout/topNav_Template.xhtml
+++ b/tck/faces22/full-state-saving/src/main/webapp/contracts/siteLayout/topNav_Template.xhtml
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<!--
+
+    Copyright (c) 2026 Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+<html xmlns:h="jakarta.faces.html"
+      xmlns:ui="jakarta.faces.facelets">
+    <h:head>
+        <h:outputStylesheet id="default" name="default.css"/>
+        <h:outputStylesheet name="cssLayout.css"/>
+        <title><ui:insert name="title">title</ui:insert></title>
+    </h:head>
+    <h:body>
+        <div id="top" class="top">
+            <p>Top Navigation Menu</p>
+            <ui:insert name="nav">Nav content</ui:insert>
+        </div>
+        <div id="content" class="center_content">
+            <ui:insert name="content">Content</ui:insert>
+        </div>
+    </h:body>
+</html>

--- a/tck/faces22/full-state-saving/src/main/webapp/issue1641.xhtml
+++ b/tck/faces22/full-state-saving/src/main/webapp/issue1641.xhtml
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<!--
+
+    Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2026 Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<html xmlns:f="jakarta.faces.core"
+      xmlns:h="jakarta.faces.html"
+      xmlns:ez="jakarta.faces.composite/issue1641">
+    <h:head>
+        <title>Issue1641</title>
+    </h:head>
+    <h:body>
+        <h:form id="form" prependId="false">
+            <ez:actionButton id="button">
+                <f:actionListener for="abutton" type="ee.jakarta.tck.faces.faces22.full_state_saving.Issue1641ActionListener"/>
+            </ez:actionButton>
+            <h:outputText id="result" value="count=#{issue1641Bean.count}"/>
+        </h:form>
+    </h:body>
+</html>

--- a/tck/faces22/full-state-saving/src/main/webapp/issue2918.xhtml
+++ b/tck/faces22/full-state-saving/src/main/webapp/issue2918.xhtml
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<!--
+
+    Copyright (c) 2026 Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<html xmlns:h="jakarta.faces.html"
+      xmlns:ui="jakarta.faces.facelets">
+    <ui:composition template="/topNav_Template.xhtml">
+        <ui:define name="title">issue2918</ui:define>
+        <ui:define name="content">
+            <h:form id="form" prependId="false">
+                <h:commandButton id="currentButton" value="Stay here"/>
+                <h:outputText id="result" value="rendered from the contract"/>
+            </h:form>
+        </ui:define>
+    </ui:composition>
+</html>

--- a/tck/faces22/full-state-saving/src/main/webapp/resources/issue1641/actionButton.xhtml
+++ b/tck/faces22/full-state-saving/src/main/webapp/resources/issue1641/actionButton.xhtml
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<!--
+
+    Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2026 Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<html xmlns:cc="jakarta.faces.composite"
+      xmlns:h="jakarta.faces.html">
+
+    <cc:interface>
+        <cc:actionSource name="abutton"/>
+    </cc:interface>
+
+    <cc:implementation>
+        <h:commandButton id="abutton" value="Click Me"/>
+    </cc:implementation>
+
+</html>

--- a/tck/faces22/full-state-saving/src/test/java/ee/jakarta/tck/faces/faces22/full_state_saving/FullStateSavingIT.java
+++ b/tck/faces22/full-state-saving/src/test/java/ee/jakarta/tck/faces/faces22/full_state_saving/FullStateSavingIT.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2026 Contributors to Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.faces.faces22.full_state_saving;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.By;
+
+import ee.jakarta.tck.faces.util.selenium.BaseITNG;
+import ee.jakarta.tck.faces.util.selenium.WebPage;
+import jakarta.faces.application.ResourceHandler;
+import jakarta.faces.component.UIComponent;
+
+/**
+ * Behaviour which only breaks with partial state saving switched off. This module pins
+ * {@code jakarta.faces.PARTIAL_STATE_SAVING} to {@code false}, a combination the reactor otherwise never exercises, so
+ * the tests are grouped by that shared condition rather than one class per ticket.
+ */
+class FullStateSavingIT extends BaseITNG {
+
+    /**
+     * A composite component and its retargeted action source survive a postback: the inner command button keeps its
+     * value and its action listener fires.
+     *
+     * @see UIComponent
+     * @see https://github.com/eclipse-ee4j/mojarra/issues/1641
+     */
+    @Test
+    void compositeComponentSurvivesPostback() {
+        WebPage page = getPage("issue1641.xhtml");
+
+        assertTrue(page.containsText("count=0"), "counter on initial render");
+        assertTrue(page.containsSource("Click Me"), "composite on initial render");
+
+        page.guardHttp(page.findElement(By.id("button:abutton"))::click);
+
+        assertTrue(page.containsText("count=1"), "counter after postback");
+        assertTrue(page.containsSource("Click Me"), "composite after postback");
+    }
+
+    /**
+     * A single contracts directory with no contract-mapping in faces-config is discovered implicitly, and the template
+     * it supplies keeps resolving on a postback rather than only on the initial render.
+     *
+     * @see ResourceHandler#WEBAPP_CONTRACTS_DIRECTORY_PARAM_NAME
+     * @see https://github.com/eclipse-ee4j/mojarra/issues/2918
+     */
+    @Test
+    void implicitResourceLibraryContractResolvesOnPostback() {
+        WebPage page = getPage("issue2918.xhtml");
+
+        assertEquals(200, page.getResponseStatus(), "initial render");
+        assertTrue(page.containsText("rendered from the contract"), "The contract template must have been used.");
+
+        page.guardHttp(page.findElement(By.id("currentButton"))::click);
+
+        assertEquals(200, page.getResponseStatus(), "postback");
+        assertTrue(page.containsText("rendered from the contract"), "The contract must still resolve on a postback.");
+    }
+}

--- a/tck/faces22/init-request-parameter-map/pom.xml
+++ b/tck/faces22/init-request-parameter-map/pom.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2026 Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.eclipse.ee4j.tck.faces.faces22</groupId>
+        <artifactId>pom</artifactId>
+        <version>5.0.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>init-request-parameter-map</artifactId>
+    <packaging>war</packaging>
+
+    <name>Jakarta Faces TCK ${project.version} - ${test.moduleName} - ${project.artifactId}</name>
+
+    <build>
+        <finalName>test-${test.moduleName}-${project.artifactId}</finalName>
+    </build>
+</project>

--- a/tck/faces22/init-request-parameter-map/src/main/java/ee/jakarta/tck/faces/faces22/init_request_parameter_map/Issue3436ExternalContext.java
+++ b/tck/faces22/init-request-parameter-map/src/main/java/ee/jakarta/tck/faces/faces22/init_request_parameter_map/Issue3436ExternalContext.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2026 Contributors to Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.faces.faces22.init_request_parameter_map;
+
+import jakarta.faces.context.ExternalContext;
+import jakarta.faces.context.ExternalContextWrapper;
+
+public class Issue3436ExternalContext extends ExternalContextWrapper {
+
+    private final ExternalContext wrapped;
+
+    public Issue3436ExternalContext(ExternalContext wrapped) {
+        this.wrapped = wrapped;
+    }
+
+    @Override
+    public ExternalContext getWrapped() {
+        return wrapped;
+    }
+}

--- a/tck/faces22/init-request-parameter-map/src/main/java/ee/jakarta/tck/faces/faces22/init_request_parameter_map/Issue3436ExternalContextFactory.java
+++ b/tck/faces22/init-request-parameter-map/src/main/java/ee/jakarta/tck/faces/faces22/init_request_parameter_map/Issue3436ExternalContextFactory.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2026 Contributors to Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.faces.faces22.init_request_parameter_map;
+
+import jakarta.faces.FacesException;
+import jakarta.faces.context.ExternalContext;
+import jakarta.faces.context.ExternalContextFactory;
+
+/**
+ * Reads the request parameter map while creating the external context, which is before the faces context it belongs to
+ * has been established.
+ */
+public class Issue3436ExternalContextFactory extends ExternalContextFactory {
+
+    private final ExternalContextFactory wrapped;
+
+    public Issue3436ExternalContextFactory(ExternalContextFactory wrapped) {
+        this.wrapped = wrapped;
+    }
+
+    @Override
+    public ExternalContext getExternalContext(Object context, Object request, Object response) throws FacesException {
+        ExternalContext externalContext = new Issue3436ExternalContext(wrapped.getExternalContext(context, request, response));
+        externalContext.getRequestParameterMap().get("issue3436");
+        return externalContext;
+    }
+
+    @Override
+    public ExternalContextFactory getWrapped() {
+        return wrapped;
+    }
+}

--- a/tck/faces22/init-request-parameter-map/src/main/java/ee/jakarta/tck/faces/faces22/init_request_parameter_map/Issue3436FacesContext.java
+++ b/tck/faces22/init-request-parameter-map/src/main/java/ee/jakarta/tck/faces/faces22/init_request_parameter_map/Issue3436FacesContext.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2026 Contributors to Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.faces.faces22.init_request_parameter_map;
+
+import jakarta.faces.context.FacesContext;
+import jakarta.faces.context.FacesContextWrapper;
+
+public class Issue3436FacesContext extends FacesContextWrapper {
+
+    private final FacesContext wrapped;
+
+    public Issue3436FacesContext(FacesContext wrapped) {
+        this.wrapped = wrapped;
+        setCurrentInstance(this);
+    }
+
+    @Override
+    public FacesContext getWrapped() {
+        return wrapped;
+    }
+}

--- a/tck/faces22/init-request-parameter-map/src/main/java/ee/jakarta/tck/faces/faces22/init_request_parameter_map/Issue3436FacesContextFactory.java
+++ b/tck/faces22/init-request-parameter-map/src/main/java/ee/jakarta/tck/faces/faces22/init_request_parameter_map/Issue3436FacesContextFactory.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2026 Contributors to Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.faces.faces22.init_request_parameter_map;
+
+import jakarta.faces.FacesException;
+import jakarta.faces.context.FacesContext;
+import jakarta.faces.context.FacesContextFactory;
+import jakarta.faces.lifecycle.Lifecycle;
+
+public class Issue3436FacesContextFactory extends FacesContextFactory {
+
+    private final FacesContextFactory wrapped;
+
+    public Issue3436FacesContextFactory(FacesContextFactory wrapped) {
+        this.wrapped = wrapped;
+    }
+
+    @Override
+    public FacesContext getFacesContext(Object context, Object request, Object response, Lifecycle lifecycle)
+        throws FacesException
+    {
+        return new Issue3436FacesContext(wrapped.getFacesContext(context, request, response, lifecycle));
+    }
+
+    @Override
+    public FacesContextFactory getWrapped() {
+        return wrapped;
+    }
+}

--- a/tck/faces22/init-request-parameter-map/src/main/webapp/WEB-INF/beans.xml
+++ b/tck/faces22/init-request-parameter-map/src/main/webapp/WEB-INF/beans.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans
+    xmlns="https://jakarta.ee/xml/ns/jakartaee"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_4_1.xsd"
+    version="4.1" bean-discovery-mode="all">
+</beans>

--- a/tck/faces22/init-request-parameter-map/src/main/webapp/WEB-INF/faces-config.xml
+++ b/tck/faces22/init-request-parameter-map/src/main/webapp/WEB-INF/faces-config.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2026 Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<faces-config
+    xmlns="https://jakarta.ee/xml/ns/jakartaee"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-facesconfig_4_1.xsd"
+    version="4.1">
+
+    <factory>
+        <faces-context-factory>ee.jakarta.tck.faces.faces22.init_request_parameter_map.Issue3436FacesContextFactory</faces-context-factory>
+        <external-context-factory>ee.jakarta.tck.faces.faces22.init_request_parameter_map.Issue3436ExternalContextFactory</external-context-factory>
+    </factory>
+</faces-config>

--- a/tck/faces22/init-request-parameter-map/src/main/webapp/WEB-INF/web.xml
+++ b/tck/faces22/init-request-parameter-map/src/main/webapp/WEB-INF/web.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2026 Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<web-app
+    xmlns="https://jakarta.ee/xml/ns/jakartaee"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-app_6_1.xsd"
+    version="6.1">
+
+    <context-param>
+        <param-name>jakarta.faces.PROJECT_STAGE</param-name>
+        <param-value>${webapp.projectStage}</param-value>
+    </context-param>
+    <context-param>
+        <param-name>jakarta.faces.PARTIAL_STATE_SAVING</param-name>
+        <param-value>${webapp.partialStateSaving}</param-value>
+    </context-param>
+    <context-param>
+        <param-name>jakarta.faces.STATE_SAVING_METHOD</param-name>
+        <param-value>${webapp.stateSavingMethod}</param-value>
+    </context-param>
+    <context-param>
+        <param-name>jakarta.faces.SERIALIZE_SERVER_STATE</param-name>
+        <param-value>${webapp.serializeServerState}</param-value>
+    </context-param>
+</web-app>

--- a/tck/faces22/init-request-parameter-map/src/main/webapp/issue3436.xhtml
+++ b/tck/faces22/init-request-parameter-map/src/main/webapp/issue3436.xhtml
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<!--
+
+    Copyright (c) 2026 Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<html xmlns:h="jakarta.faces.html">
+    <h:head>
+        <title>Issue3436</title>
+    </h:head>
+    <h:body>
+        <h:form id="form">
+            <h:commandButton id="submit" value="Submit"/>
+            <h:outputText id="result" value="served"/>
+            <h:outputText id="parameter" value="[#{param.issue3436}]"/>
+        </h:form>
+    </h:body>
+</html>

--- a/tck/faces22/init-request-parameter-map/src/test/java/ee/jakarta/tck/faces/faces22/init_request_parameter_map/Issue3436IT.java
+++ b/tck/faces22/init-request-parameter-map/src/test/java/ee/jakarta/tck/faces/faces22/init_request_parameter_map/Issue3436IT.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2026 Contributors to Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.faces.faces22.init_request_parameter_map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.By;
+
+import ee.jakarta.tck.faces.util.selenium.BaseITNG;
+import ee.jakarta.tck.faces.util.selenium.WebPage;
+import jakarta.faces.context.ExternalContext;
+import jakarta.faces.context.ExternalContextFactory;
+
+/**
+ * The module decorates both the faces context factory and the external context factory, and the latter reads the
+ * request parameter map while it is still creating the external context. Factories apply to every view of their
+ * webapp, hence the dedicated module.
+ */
+class Issue3436IT extends BaseITNG {
+
+    /**
+     * An ExternalContextFactory may consult the request parameter map of the ExternalContext it is creating, before
+     * the FacesContext that will own it exists. The application starts and serves views regardless.
+     *
+     * @see ExternalContextFactory#getExternalContext(Object, Object, Object)
+     * @see ExternalContext#getRequestParameterMap()
+     * @see https://github.com/eclipse-ee4j/mojarra/issues/3436
+     */
+    @Test
+    void requestParameterMapIsReadableWhileTheExternalContextIsBeingCreated() {
+        WebPage page = getPage("issue3436.xhtml?issue3436=value");
+
+        assertEquals(200, page.getResponseStatus(), "initial render");
+        assertEquals("served", page.findElement(By.id("form:result")).getText(), "The view must be served.");
+        assertEquals("[value]", page.findElement(By.id("form:parameter")).getText(),
+                "The request parameter must still be readable from the view.");
+
+        page.guardHttp(page.findElement(By.id("form:submit"))::click);
+
+        assertEquals(200, page.getResponseStatus(), "postback");
+        assertEquals("served", page.findElement(By.id("form:result")).getText(), "The view must survive a postback.");
+    }
+}

--- a/tck/faces22/iteration/src/main/java/ee/jakarta/tck/faces/faces22/iteration/Issue3219Bean.java
+++ b/tck/faces22/iteration/src/main/java/ee/jakarta/tck/faces/faces22/iteration/Issue3219Bean.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2026 Contributors to Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.faces.faces22.iteration;
+
+import java.io.Serializable;
+import java.util.List;
+
+import jakarta.enterprise.context.SessionScoped;
+import jakarta.inject.Named;
+
+/**
+ * A ui:repeat over items of two different kinds, each rendered by a mutually exclusive h:panelGroup, so that only one
+ * of the two inputs of a row is ever rendered.
+ */
+@Named
+@SessionScoped
+public class Issue3219Bean implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    public static class Item implements Serializable {
+
+        private static final long serialVersionUID = 1L;
+
+        private final String kind;
+        private String a;
+        private String b;
+
+        public Item(String kind, String a, String b) {
+            this.kind = kind;
+            this.a = a;
+            this.b = b;
+        }
+
+        public String getKind() {
+            return kind;
+        }
+
+        public String getA() {
+            return a;
+        }
+
+        public void setA(String a) {
+            this.a = a;
+        }
+
+        public String getB() {
+            return b;
+        }
+
+        public void setB(String b) {
+            this.b = b;
+        }
+    }
+
+    private final List<Item> items = List.of(
+        new Item("A", "a0", null),
+        new Item("B", null, "b1"),
+        new Item("A", "a2", null),
+        new Item("B", null, "b3"));
+
+    public List<Item> getItems() {
+        return items;
+    }
+}

--- a/tck/faces22/iteration/src/main/webapp/issue3219.xhtml
+++ b/tck/faces22/iteration/src/main/webapp/issue3219.xhtml
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<!--
+
+    Copyright (c) 2026 Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<html xmlns:h="jakarta.faces.html"
+      xmlns:ui="jakarta.faces.facelets">
+    <h:head>
+        <title>Issue3219</title>
+    </h:head>
+    <h:body>
+        <h:form id="form">
+            <ui:repeat id="repeat" var="item" value="#{issue3219Bean.items}" varStatus="status">
+                <h:panelGroup rendered="#{item.kind eq 'A'}">
+                    <h:inputText id="a" value="#{item.a}"/>
+                </h:panelGroup>
+                <h:panelGroup rendered="#{item.kind eq 'B'}">
+                    <h:inputText id="b" value="#{item.b}"/>
+                </h:panelGroup>
+            </ui:repeat>
+            <h:commandButton id="submit" value="Submit"/>
+        </h:form>
+    </h:body>
+</html>

--- a/tck/faces22/iteration/src/test/java/ee/jakarta/tck/faces/faces22/iteration/Issue3219IT.java
+++ b/tck/faces22/iteration/src/test/java/ee/jakarta/tck/faces/faces22/iteration/Issue3219IT.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2026 Contributors to Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.faces.faces22.iteration;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.By;
+
+import ee.jakarta.tck.faces.util.selenium.BaseITNG;
+import ee.jakarta.tck.faces.util.selenium.WebPage;
+
+class Issue3219IT extends BaseITNG {
+
+    /**
+     * When the inputs of a ui:repeat row sit in mutually exclusive rendered panels, only the panel belonging
+     * to that row's kind contributes an input, and saving the state of the repeat must not carry a value
+     * from one row over into another.
+     *
+     * @see https://github.com/eclipse-ee4j/mojarra/issues/3219
+     */
+    @Test
+    void perRowStateDoesNotLeakBetweenRows() {
+        WebPage page = getPage("issue3219.xhtml");
+
+        assertEquals(200, page.getResponseStatus(), "initial render");
+        assertRowValues(page);
+
+        page.guardHttp(page.findElement(By.id("form:submit"))::click);
+
+        assertEquals(200, page.getResponseStatus(), "postback");
+        assertRowValues(page);
+    }
+
+    private static void assertRowValues(WebPage page) {
+        assertEquals("a0", page.findElement(By.id("form:repeat:0:a")).getDomProperty("value"), "row 0");
+        assertEquals("b1", page.findElement(By.id("form:repeat:1:b")).getDomProperty("value"), "row 1");
+        assertEquals("a2", page.findElement(By.id("form:repeat:2:a")).getDomProperty("value"), "row 2");
+        assertEquals("b3", page.findElement(By.id("form:repeat:3:b")).getDomProperty("value"), "row 3");
+        assertEquals(4, page.findElements(By.cssSelector("#form input[type=text]")).size(),
+                "Only the panel matching each row's kind may contribute an input.");
+    }
+}

--- a/tck/faces22/pom.xml
+++ b/tck/faces22/pom.xml
@@ -54,6 +54,7 @@
         <module>implicit-bean-archive</module>
         <module>client-window</module>
         <module>empty-as-null</module>
+        <module>init-request-parameter-map</module>
         <module>injection</module>
         <module>phase-listener</module>
         <module>iteration</module>
@@ -78,6 +79,7 @@
         <module>webapp-resources-directory</module>
         <module>flow-defining-document-id-jar1</module>
         <module>flow-defining-document-id-jar2</module>
+        <module>full-state-saving</module>
         <module>flow-defining-document-id</module>
     </modules>
 

--- a/tck/faces22/render-kit/src/main/webapp/issue3274.xhtml
+++ b/tck/faces22/render-kit/src/main/webapp/issue3274.xhtml
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<!--
+
+    Copyright (c) 2026 Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<html xmlns:h="jakarta.faces.html">
+    <h:head>
+        <title>Issue3274</title>
+    </h:head>
+    <h:body>
+        <h:panelGroup id="group" layout="block" styleClass="foo" style="width: 100px; height: 60px">
+            Hello World
+        </h:panelGroup>
+    </h:body>
+</html>

--- a/tck/faces22/render-kit/src/main/webapp/spec1134.xhtml
+++ b/tck/faces22/render-kit/src/main/webapp/spec1134.xhtml
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<!--
+
+    Copyright (c) 2026 Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<html xmlns:h="jakarta.faces.html">
+    <h:head>
+        <title>Spec1134</title>
+    </h:head>
+    <h:body>
+        <h:form id="form" prependId="false">
+            <h:panelGrid id="grid" columns="2" role="presentation">
+                <h:commandButton id="one" value="one"/>
+                <h:commandButton id="two" value="two"/>
+                <h:commandButton id="three" value="three"/>
+                <h:commandButton id="four" value="four"/>
+            </h:panelGrid>
+        </h:form>
+    </h:body>
+</html>

--- a/tck/faces22/render-kit/src/test/java/ee/jakarta/tck/faces/faces22/render_kit/Issue3274IT.java
+++ b/tck/faces22/render-kit/src/test/java/ee/jakarta/tck/faces/faces22/render_kit/Issue3274IT.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2026 Contributors to Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.faces.faces22.render_kit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.By;
+
+import ee.jakarta.tck.faces.util.selenium.BaseITNG;
+import ee.jakarta.tck.faces.util.selenium.WebPage;
+import jakarta.faces.component.html.HtmlPanelGroup;
+
+class Issue3274IT extends BaseITNG {
+
+    private static final String STYLE = "width: 100px; height: 60px";
+
+    /**
+     * The Group renderer writes styleClass out as the class attribute and style as the style attribute, each
+     * exactly once, also when both are given on a block layout.
+     *
+     * @see HtmlPanelGroup#getStyle()
+     * @see https://github.com/eclipse-ee4j/mojarra/issues/3274
+     */
+    @Test
+    void styleAndStyleClassAreEachRenderedOnce() {
+        WebPage page = getPage("issue3274.xhtml");
+
+        assertEquals(STYLE, page.findElement(By.id("group")).getDomAttribute("style"), "style attribute");
+        assertEquals("foo", page.findElement(By.id("group")).getDomAttribute("class"), "class attribute");
+        assertEquals(1, countOccurrences(page.getSource(), "style="), "occurrences of style=");
+    }
+
+    private static int countOccurrences(String source, String token) {
+        int count = 0;
+
+        for (int index = source.indexOf(token); index != -1; index = source.indexOf(token, index + token.length())) {
+            count++;
+        }
+
+        return count;
+    }
+}

--- a/tck/faces22/render-kit/src/test/java/ee/jakarta/tck/faces/faces22/render_kit/Spec1134IT.java
+++ b/tck/faces22/render-kit/src/test/java/ee/jakarta/tck/faces/faces22/render_kit/Spec1134IT.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2026 Contributors to Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.faces.faces22.render_kit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.By;
+
+import ee.jakarta.tck.faces.util.selenium.BaseITNG;
+import ee.jakarta.tck.faces.util.selenium.WebPage;
+import jakarta.faces.component.html.HtmlPanelGrid;
+
+class Spec1134IT extends BaseITNG {
+
+    /**
+     * The Grid renderer declares the ARIA role attribute, which it must write onto the generated table.
+     *
+     * @see HtmlPanelGrid#getRole()
+     * @see https://github.com/jakartaee/faces/issues/1134
+     */
+    @Test
+    void panelGridRendersItsRoleOntoTheTable() {
+        WebPage page = getPage("spec1134.xhtml");
+
+        assertEquals("table", page.findElement(By.id("grid")).getTagName(), "h:panelGrid renders a table");
+        assertEquals("presentation", page.findElement(By.id("grid")).getDomAttribute("role"), "role attribute");
+    }
+}

--- a/tck/faces22/resource-library-contracts/src/main/java/ee/jakarta/tck/faces/faces22/resource_library_contracts/Issue2740Bean.java
+++ b/tck/faces22/resource-library-contracts/src/main/java/ee/jakarta/tck/faces/faces22/resource_library_contracts/Issue2740Bean.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2026 Contributors to Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.faces.faces22.resource_library_contracts;
+
+import jakarta.enterprise.context.RequestScoped;
+import jakarta.inject.Named;
+
+@Named
+@RequestScoped
+public class Issue2740Bean {
+
+    public String getContracts() {
+        return null;
+    }
+}

--- a/tck/faces22/resource-library-contracts/src/main/webapp/issue2740.xhtml
+++ b/tck/faces22/resource-library-contracts/src/main/webapp/issue2740.xhtml
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<!--
+
+    Copyright (c) 2026 Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<html xmlns:f="jakarta.faces.core"
+      xmlns:h="jakarta.faces.html">
+    <f:view contracts="#{issue2740Bean.contracts}">
+        <h:head>
+            <title>issue2740</title>
+        </h:head>
+        <h:body>
+            main content
+        </h:body>
+    </f:view>
+</html>

--- a/tck/faces22/resource-library-contracts/src/test/java/ee/jakarta/tck/faces/faces22/resource_library_contracts/Issue2740IT.java
+++ b/tck/faces22/resource-library-contracts/src/test/java/ee/jakarta/tck/faces/faces22/resource_library_contracts/Issue2740IT.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2026 Contributors to Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.faces.faces22.resource_library_contracts;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+import ee.jakarta.tck.faces.util.selenium.BaseITNG;
+import ee.jakarta.tck.faces.util.selenium.WebPage;
+
+class Issue2740IT extends BaseITNG {
+
+    /**
+     * A contracts attribute on f:view whose expression evaluates to null leaves the eligible contracts as
+     * they were, so the templated view still renders.
+     *
+     * @see jakarta.faces.context.FacesContext#setResourceLibraryContracts(java.util.List)
+     * @see https://github.com/eclipse-ee4j/mojarra/issues/2740
+     */
+    @Test
+    void nullContractsExpressionStillRendersTheView() {
+        WebPage page = getPage("issue2740.xhtml");
+
+        assertEquals(200, page.getResponseStatus(), "The view must render.");
+        assertTrue(page.containsText("main content"), "The templated content must be rendered.");
+    }
+}

--- a/tck/faces23/ajax-content-type/pom.xml
+++ b/tck/faces23/ajax-content-type/pom.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2026 Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.eclipse.ee4j.tck.faces.faces23</groupId>
+        <artifactId>pom</artifactId>
+        <version>5.0.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>ajax-content-type</artifactId>
+    <packaging>war</packaging>
+
+    <name>Jakarta Faces TCK ${project.version} - ${test.moduleName} - ${project.artifactId}</name>
+
+    <build>
+        <finalName>test-${test.moduleName}-${project.artifactId}</finalName>
+    </build>
+</project>

--- a/tck/faces23/ajax-content-type/src/main/java/ee/jakarta/tck/faces/faces23/ajax_content_type/Issue4358Bean.java
+++ b/tck/faces23/ajax-content-type/src/main/java/ee/jakarta/tck/faces/faces23/ajax_content_type/Issue4358Bean.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2026 Contributors to Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.faces.faces23.ajax_content_type;
+
+import static ee.jakarta.tck.faces.faces23.ajax_content_type.RecordingExternalContext.GET_RESPONSE_OUTPUT_STREAM;
+import static ee.jakarta.tck.faces.faces23.ajax_content_type.RecordingExternalContext.GET_RESPONSE_OUTPUT_WRITER;
+
+import java.util.List;
+
+import jakarta.enterprise.context.RequestScoped;
+import jakarta.faces.context.FacesContext;
+import jakarta.inject.Named;
+
+@Named
+@RequestScoped
+public class Issue4358Bean {
+
+    private static final String PARTIAL_CONTENT_TYPE = "text/xml";
+    private static final String HTML_CONTENT_TYPE = "text/html";
+
+    public List<String> getExternalContextCalls() {
+        return calls(FacesContext.getCurrentInstance());
+    }
+
+    /**
+     * Reports SUCCESS when the content type set most recently before the response output was first obtained is the one
+     * required for this kind of request: text/xml for a partial response, text/html otherwise.
+     */
+    public String getResult() {
+        FacesContext context = FacesContext.getCurrentInstance();
+        List<String> calls = calls(context);
+        int firstOutput = firstResponseOutputCall(calls);
+
+        if (firstOutput <= 0) {
+            return "FAILURE: response output obtained at index " + firstOutput;
+        }
+
+        String whenObtained = calls.get(firstOutput - 1);
+        String effective = context.getExternalContext().getResponseContentType();
+        String expected = context.getPartialViewContext().isPartialRequest() ? PARTIAL_CONTENT_TYPE : HTML_CONTENT_TYPE;
+
+        return effective != null && effective.contains(expected)
+            ? "SUCCESS"
+            : "FAILURE: expected " + expected + " but effective was " + effective + " and when obtained " + whenObtained;
+    }
+
+    private static int firstResponseOutputCall(List<String> calls) {
+        int writer = calls.indexOf(GET_RESPONSE_OUTPUT_WRITER);
+        int stream = calls.indexOf(GET_RESPONSE_OUTPUT_STREAM);
+
+        if (writer < 0) {
+            return stream;
+        }
+
+        return stream < 0 ? writer : Math.min(writer, stream);
+    }
+
+    private static List<String> calls(FacesContext context) {
+        return ((RecordingExternalContext) context.getExternalContext()).getCalls();
+    }
+}

--- a/tck/faces23/ajax-content-type/src/main/java/ee/jakarta/tck/faces/faces23/ajax_content_type/RecordingExternalContext.java
+++ b/tck/faces23/ajax-content-type/src/main/java/ee/jakarta/tck/faces/faces23/ajax_content_type/RecordingExternalContext.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2026 Contributors to Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.faces.faces23.ajax_content_type;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.Writer;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import jakarta.faces.context.ExternalContext;
+import jakarta.faces.context.ExternalContextWrapper;
+
+/**
+ * Records the order in which the response content type is set and the response output is first obtained, so that a test
+ * can assert the content type was already set by the time the runtime asked for the writer or stream.
+ */
+public class RecordingExternalContext extends ExternalContextWrapper {
+
+    static final String GET_RESPONSE_OUTPUT_WRITER = "getResponseOutputWriter()";
+    static final String GET_RESPONSE_OUTPUT_STREAM = "getResponseOutputStream()";
+    static final String SET_RESPONSE_CONTENT_TYPE = "setResponseContentType(";
+
+    private final ExternalContext wrapped;
+    private final List<String> calls = new CopyOnWriteArrayList<>();
+
+    public RecordingExternalContext(ExternalContext wrapped) {
+        this.wrapped = wrapped;
+    }
+
+    @Override
+    public void setResponseContentType(String contentType) {
+        calls.add(SET_RESPONSE_CONTENT_TYPE + contentType + ")");
+        super.setResponseContentType(contentType);
+    }
+
+    @Override
+    public Writer getResponseOutputWriter() throws IOException {
+        calls.add(GET_RESPONSE_OUTPUT_WRITER);
+        return super.getResponseOutputWriter();
+    }
+
+    @Override
+    public OutputStream getResponseOutputStream() throws IOException {
+        calls.add(GET_RESPONSE_OUTPUT_STREAM);
+        return super.getResponseOutputStream();
+    }
+
+    List<String> getCalls() {
+        return calls;
+    }
+
+    @Override
+    public ExternalContext getWrapped() {
+        return wrapped;
+    }
+}

--- a/tck/faces23/ajax-content-type/src/main/java/ee/jakarta/tck/faces/faces23/ajax_content_type/RecordingExternalContextFactory.java
+++ b/tck/faces23/ajax-content-type/src/main/java/ee/jakarta/tck/faces/faces23/ajax_content_type/RecordingExternalContextFactory.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2026 Contributors to Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.faces.faces23.ajax_content_type;
+
+import jakarta.faces.FacesException;
+import jakarta.faces.context.ExternalContext;
+import jakarta.faces.context.ExternalContextFactory;
+
+public class RecordingExternalContextFactory extends ExternalContextFactory {
+
+    private final ExternalContextFactory wrapped;
+
+    public RecordingExternalContextFactory(ExternalContextFactory wrapped) {
+        this.wrapped = wrapped;
+    }
+
+    @Override
+    public ExternalContext getExternalContext(Object context, Object request, Object response) throws FacesException {
+        return new RecordingExternalContext(wrapped.getExternalContext(context, request, response));
+    }
+
+    @Override
+    public ExternalContextFactory getWrapped() {
+        return wrapped;
+    }
+}

--- a/tck/faces23/ajax-content-type/src/main/webapp/WEB-INF/faces-config.xml
+++ b/tck/faces23/ajax-content-type/src/main/webapp/WEB-INF/faces-config.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2026 Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<faces-config
+    xmlns="https://jakarta.ee/xml/ns/jakartaee"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-facesconfig_4_1.xsd"
+    version="4.1">
+
+    <factory>
+        <external-context-factory>ee.jakarta.tck.faces.faces23.ajax_content_type.RecordingExternalContextFactory</external-context-factory>
+    </factory>
+</faces-config>

--- a/tck/faces23/ajax-content-type/src/main/webapp/WEB-INF/web.xml
+++ b/tck/faces23/ajax-content-type/src/main/webapp/WEB-INF/web.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2026 Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<web-app
+    xmlns="https://jakarta.ee/xml/ns/jakartaee"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-app_6_1.xsd"
+    version="6.1">
+
+    <context-param>
+        <param-name>jakarta.faces.PROJECT_STAGE</param-name>
+        <param-value>${webapp.projectStage}</param-value>
+    </context-param>
+    <context-param>
+        <param-name>jakarta.faces.PARTIAL_STATE_SAVING</param-name>
+        <param-value>${webapp.partialStateSaving}</param-value>
+    </context-param>
+    <context-param>
+        <param-name>jakarta.faces.STATE_SAVING_METHOD</param-name>
+        <param-value>${webapp.stateSavingMethod}</param-value>
+    </context-param>
+    <context-param>
+        <param-name>jakarta.faces.SERIALIZE_SERVER_STATE</param-name>
+        <param-value>${webapp.serializeServerState}</param-value>
+    </context-param>
+</web-app>

--- a/tck/faces23/ajax-content-type/src/main/webapp/issue4358.xhtml
+++ b/tck/faces23/ajax-content-type/src/main/webapp/issue4358.xhtml
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<!--
+
+    Copyright (c) 2026 Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<html xmlns:f="jakarta.faces.core"
+      xmlns:h="jakarta.faces.html"
+      xmlns:ui="jakarta.faces.facelets">
+    <h:head>
+        <title>Issue4358</title>
+    </h:head>
+    <h:body>
+        <h:form id="form">
+            <h:commandButton id="ajaxButton" value="default ajax request">
+                <f:ajax render="@form"/>
+            </h:commandButton>
+            <h:commandButton id="ajaxExecuteAllButton" value="execute all ajax request">
+                <f:ajax execute="@all" render="@form"/>
+            </h:commandButton>
+            <h:commandButton id="nonAjaxButton" value="non ajax request"/>
+            <div id="result">#{issue4358Bean.result}</div>
+            <ol id="calls">
+                <ui:repeat value="#{issue4358Bean.externalContextCalls}" var="call">
+                    <li>#{call}</li>
+                </ui:repeat>
+            </ol>
+        </h:form>
+    </h:body>
+</html>

--- a/tck/faces23/ajax-content-type/src/test/java/ee/jakarta/tck/faces/faces23/ajax_content_type/Issue4358IT.java
+++ b/tck/faces23/ajax-content-type/src/test/java/ee/jakarta/tck/faces/faces23/ajax_content_type/Issue4358IT.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2026 Contributors to Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.faces.faces23.ajax_content_type;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.By;
+
+import ee.jakarta.tck.faces.util.selenium.BaseITNG;
+import ee.jakarta.tck.faces.util.selenium.WebPage;
+import jakarta.faces.context.ExternalContext;
+
+/**
+ * The module registers an ExternalContextFactory so that the view can report the content type the response actually
+ * carries, per kind of request. A factory applies to every view of its webapp, hence the dedicated module.
+ *
+ * <p>
+ * The recorded call list the view also renders is diagnostic only. It is deliberately not asserted on: a wrapper does
+ * not observe every path by which the runtime sets the content type, so the order of calls through the wrapper says
+ * nothing about the response the client receives.
+ */
+class Issue4358IT extends BaseITNG {
+
+    private static final String VIEW = "issue4358.xhtml";
+
+    /**
+     * An initial render carries text/html.
+     *
+     * @see ExternalContext#setResponseContentType(String)
+     * @see https://github.com/eclipse-ee4j/mojarra/issues/4358
+     */
+    @Test
+    void responseContentTypeIsHtmlOnInitialRender() {
+        assertEquals("SUCCESS", getPage(VIEW).findElement(By.id("result")).getText());
+    }
+
+    /**
+     * A partial response carries text/xml, as required for the ajax response format.
+     *
+     * @see ExternalContext#setResponseContentType(String)
+     * @see https://github.com/eclipse-ee4j/mojarra/issues/4358
+     */
+    @Test
+    void responseContentTypeIsXmlOnAjaxRequest() {
+        WebPage page = getPage(VIEW);
+
+        page.guardAjax(page.findElement(By.id("form:ajaxButton"))::click);
+
+        assertEquals("SUCCESS", page.findElement(By.id("result")).getText());
+    }
+
+    /**
+     * The same holds for an ajax request executing the whole view, which is the case the issue was reported for.
+     *
+     * @see ExternalContext#setResponseContentType(String)
+     * @see https://github.com/eclipse-ee4j/mojarra/issues/4358
+     */
+    @Test
+    void responseContentTypeIsXmlOnExecuteAllAjaxRequest() {
+        WebPage page = getPage(VIEW);
+
+        page.guardAjax(page.findElement(By.id("form:ajaxExecuteAllButton"))::click);
+
+        assertEquals("SUCCESS", page.findElement(By.id("result")).getText(),
+                "recorded calls: " + page.findElement(By.id("calls")).getText());
+    }
+
+    /**
+     * A non ajax postback carries text/html again.
+     *
+     * @see ExternalContext#setResponseContentType(String)
+     * @see https://github.com/eclipse-ee4j/mojarra/issues/4358
+     */
+    @Test
+    void responseContentTypeIsHtmlOnNonAjaxPostback() {
+        WebPage page = getPage(VIEW);
+
+        page.guardHttp(page.findElement(By.id("form:nonAjaxButton"))::click);
+
+        assertEquals("SUCCESS", page.findElement(By.id("result")).getText());
+    }
+}

--- a/tck/faces23/ajax/src/main/java/ee/jakarta/tck/faces/faces23/ajax/Issue2617Bean.java
+++ b/tck/faces23/ajax/src/main/java/ee/jakarta/tck/faces/faces23/ajax/Issue2617Bean.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2026 Contributors to Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.faces.faces23.ajax;
+
+import java.util.TreeSet;
+import java.util.stream.Collectors;
+
+import jakarta.enterprise.context.RequestScoped;
+import jakarta.faces.context.FacesContext;
+import jakarta.inject.Named;
+
+/**
+ * Echoes the names of the request parameters of the current request, so that a test can assert exactly which form
+ * controls {@code faces.getViewState} collected and encoded.
+ */
+@Named
+@RequestScoped
+public class Issue2617Bean {
+
+    public String getParameterNames() {
+        return new TreeSet<>(FacesContext.getCurrentInstance().getExternalContext().getRequestParameterMap().keySet())
+                .stream().collect(Collectors.joining(", "));
+    }
+}

--- a/tck/faces23/ajax/src/main/webapp/issue2617.xhtml
+++ b/tck/faces23/ajax/src/main/webapp/issue2617.xhtml
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<!--
+
+    Copyright (c) 2026 Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<html xmlns:h="jakarta.faces.html">
+    <h:head>
+        <title>Issue2617</title>
+        <h:outputScript library="jakarta.faces" name="faces.js" target="head"/>
+    </h:head>
+    <h:body>
+        <h:form id="form" prependId="false">
+            <fieldset></fieldset>
+            <label for="name">Name</label>
+            <input id="name" name="name" type="text" value="aaa"/>
+            <input id="tel" name="tel" type="tel" value="bbb"/>
+            <input id="email" name="email" type="email" value="ccc"/>
+            <input id="checked" name="checked" type="checkbox" value="on" checked="checked"/>
+            <input id="unchecked" name="unchecked" type="checkbox" value="on"/>
+            <select id="select" name="select">
+                <option value="one" selected="selected">one</option>
+                <option value="two">two</option>
+            </select>
+        </h:form>
+    </h:body>
+</html>

--- a/tck/faces23/ajax/src/main/webapp/issue2725.xhtml
+++ b/tck/faces23/ajax/src/main/webapp/issue2725.xhtml
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<!--
+
+    Copyright (c) 2026 Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<html xmlns:h="jakarta.faces.html">
+    <h:head>
+        <title>Issue2725</title>
+    </h:head>
+    <h:body>
+        <script id="script">
+            var issue2725 = "This has a \" in it";
+        </script>
+    </h:body>
+</html>

--- a/tck/faces23/ajax/src/test/java/ee/jakarta/tck/faces/faces23/ajax/Issue2617IT.java
+++ b/tck/faces23/ajax/src/test/java/ee/jakarta/tck/faces/faces23/ajax/Issue2617IT.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2026 Contributors to Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.faces.faces23.ajax;
+
+import static java.util.stream.Collectors.toCollection;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Set;
+import java.util.TreeSet;
+
+import org.junit.jupiter.api.Test;
+
+import ee.jakarta.tck.faces.util.selenium.BaseITNG;
+import ee.jakarta.tck.faces.util.selenium.WebPage;
+
+class Issue2617IT extends BaseITNG {
+
+    /**
+     * faces.getViewState collects and encodes the form controls of the given form together with the view
+     * state, and nothing else: markup which is not a form control contributes nothing, and an unchecked
+     * checkbox is left out while a checked one and a select with a selected option are included.
+     *
+     * @see https://github.com/eclipse-ee4j/mojarra/issues/2617
+     */
+    @Test
+    void getViewStateCollectsExactlyTheFormControls() {
+        WebPage page = getPage("issue2617.xhtml");
+
+        String viewState = (String) page.executeScript(
+                "return faces.getViewState(document.getElementById('form'));");
+
+        assertEquals(Set.of("checked", "email", "form", "jakarta.faces.ViewState", "name", "select", "tel"),
+                parameterNames(viewState),
+                "faces.getViewState must collect exactly the form controls plus the view state.");
+    }
+
+    private static Set<String> parameterNames(String viewState) {
+        return Arrays.stream(viewState.split("&"))
+                .map(parameter -> parameter.split("=", 2)[0])
+                .map(name -> URLDecoder.decode(name, StandardCharsets.UTF_8))
+                .collect(toCollection(TreeSet::new));
+    }
+}

--- a/tck/faces23/ajax/src/test/java/ee/jakarta/tck/faces/faces23/ajax/Issue2725IT.java
+++ b/tck/faces23/ajax/src/test/java/ee/jakarta/tck/faces/faces23/ajax/Issue2725IT.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2026 Contributors to Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.faces.faces23.ajax;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+import ee.jakarta.tck.faces.util.selenium.BaseITNG;
+import ee.jakarta.tck.faces.util.selenium.WebPage;
+
+class Issue2725IT extends BaseITNG {
+
+    private static final String SCRIPT_BODY = "var issue2725 = \"This has a";
+
+    /**
+     * A double quote inside the body of an inline script is written through unescaped on an initial render.
+     *
+     * @see jakarta.faces.context.ResponseWriter
+     * @see https://github.com/eclipse-ee4j/mojarra/issues/2725
+     */
+    @Test
+    void quoteInScriptSurvivesInitialRender() {
+        WebPage page = getPage("issue2725.xhtml");
+
+        assertTrue(page.getSource().contains(SCRIPT_BODY),
+                "The quote inside the script must be written through unescaped.");
+    }
+
+}

--- a/tck/faces23/build-time-component-handler/src/main/java/ee/jakarta/tck/faces/faces23/build_time_component_handler/Issue3982Bean.java
+++ b/tck/faces23/build-time-component-handler/src/main/java/ee/jakarta/tck/faces/faces23/build_time_component_handler/Issue3982Bean.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2026 Contributors to Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.faces.faces23.build_time_component_handler;
+
+import java.io.Serializable;
+
+import jakarta.enterprise.context.SessionScoped;
+import jakarta.inject.Named;
+
+@Named
+@SessionScoped
+public class Issue3982Bean implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private boolean clicked;
+
+    public boolean isClicked() {
+        return clicked;
+    }
+
+    public void click() {
+        clicked = true;
+    }
+}

--- a/tck/faces23/build-time-component-handler/src/main/webapp/issue3982.xhtml
+++ b/tck/faces23/build-time-component-handler/src/main/webapp/issue3982.xhtml
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<!--
+
+    Copyright (c) 2026 Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<html xmlns:c="jakarta.tags.core"
+      xmlns:h="jakarta.faces.html"
+      xmlns:ez="jakarta.faces.composite/issue3982">
+    <h:head>
+        <title>Issue3982</title>
+    </h:head>
+    <h:body>
+        <h:form id="form">
+            <c:if test="#{issue3982Bean.clicked}">
+                <ez:panel id="panel1"/>
+            </c:if>
+            <ez:panel id="panel2"/>
+            <h:commandLink id="click" value="Click" action="#{issue3982Bean.click}"/>
+        </h:form>
+    </h:body>
+</html>

--- a/tck/faces23/build-time-component-handler/src/main/webapp/resources/issue3982/panel.xhtml
+++ b/tck/faces23/build-time-component-handler/src/main/webapp/resources/issue3982/panel.xhtml
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<!--
+
+    Copyright (c) 2026 Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<html xmlns:h="jakarta.faces.html"
+      xmlns:cc="jakarta.faces.composite">
+    <cc:interface/>
+    <cc:implementation>
+        <h:panelGrid id="grid"/>
+    </cc:implementation>
+</html>

--- a/tck/faces23/build-time-component-handler/src/test/java/ee/jakarta/tck/faces/faces23/build_time_component_handler/Issue3982IT.java
+++ b/tck/faces23/build-time-component-handler/src/test/java/ee/jakarta/tck/faces/faces23/build_time_component_handler/Issue3982IT.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2026 Contributors to Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.faces.faces23.build_time_component_handler;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.By;
+
+import ee.jakarta.tck.faces.util.selenium.BaseITNG;
+import ee.jakarta.tck.faces.util.selenium.WebPage;
+
+class Issue3982IT extends BaseITNG {
+
+    /**
+     * A composite component which a build time c:if adds to the view on a postback takes its place beside an
+     * unconditional sibling composite without colliding with it: both keep their own ids and the tree stays
+     * intact.
+     *
+     * @see https://github.com/eclipse-ee4j/mojarra/issues/3982
+     */
+    @Test
+    void conditionallyBuiltCompositeDoesNotCollideWithItsSibling() {
+        WebPage page = getPage("issue3982.xhtml");
+
+        assertEquals(200, page.getResponseStatus(), "initial render");
+        assertEquals(1, page.findElements(By.id("form:panel2:grid")).size(), "the unconditional composite");
+        assertEquals(0, page.findElements(By.id("form:panel1:grid")).size(), "the conditional composite is absent");
+
+        page.guardHttp(page.findElement(By.id("form:click"))::click);
+
+        assertEquals(200, page.getResponseStatus(), "postback");
+        assertEquals(1, page.findElements(By.id("form:panel1:grid")).size(), "the conditional composite appeared");
+        assertEquals(1, page.findElements(By.id("form:panel2:grid")).size(), "the unconditional composite survived");
+    }
+}

--- a/tck/faces23/cdi/src/main/webapp/spec1328.xhtml
+++ b/tck/faces23/cdi/src/main/webapp/spec1328.xhtml
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<!--
+
+    Copyright (c) 2026 Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<html xmlns:h="jakarta.faces.html">
+    <h:head>
+        <title>Spec1328</title>
+    </h:head>
+    <h:body>
+        <h:outputText id="session" value="#{session}"/>
+        <h:outputText id="sessionId" value="#{session.id}"/>
+    </h:body>
+</html>

--- a/tck/faces23/cdi/src/test/java/ee/jakarta/tck/faces/faces23/cdi/Spec1328IT.java
+++ b/tck/faces23/cdi/src/test/java/ee/jakarta/tck/faces/faces23/cdi/Spec1328IT.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2026 Contributors to Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.faces.faces23.cdi;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.By;
+
+import ee.jakarta.tck.faces.util.selenium.BaseITNG;
+import ee.jakarta.tck.faces.util.selenium.WebPage;
+
+class Spec1328IT extends BaseITNG {
+
+    /**
+     * The session implicit object resolves through the CDI resolver chain to the HttpSession of the current
+     * request, so it can be dereferenced like any other bean.
+     *
+     * @see https://github.com/jakartaee/faces/issues/1328
+     */
+    @Test
+    void sessionImplicitObjectResolvesThroughCdi() {
+        WebPage page = getPage("spec1328.xhtml");
+
+        assertEquals(200, page.getResponseStatus(), "The view must render.");
+        assertFalse(page.findElement(By.id("session")).getText().isEmpty(),
+                "The session implicit object must resolve.");
+        assertFalse(page.findElement(By.id("sessionId")).getText().isEmpty(),
+                "The resolved session must be an HttpSession, so its id is readable.");
+    }
+}

--- a/tck/faces23/dynamic-components/src/main/java/ee/jakarta/tck/faces/faces23/dynamic_components/Issue2475Bean.java
+++ b/tck/faces23/dynamic-components/src/main/java/ee/jakarta/tck/faces/faces23/dynamic_components/Issue2475Bean.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2026 Contributors to Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.faces.faces23.dynamic_components;
+
+import java.util.List;
+
+import jakarta.enterprise.context.RequestScoped;
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.component.UIViewRoot;
+import jakarta.faces.context.FacesContext;
+import jakarta.inject.Named;
+
+@Named
+@RequestScoped
+public class Issue2475Bean {
+
+    private static final String HEAD = "head";
+
+    public void removeComponentResources() {
+        FacesContext context = FacesContext.getCurrentInstance();
+        UIViewRoot viewRoot = context.getViewRoot();
+
+        for (UIComponent componentResource : List.copyOf(viewRoot.getComponentResources(context, HEAD))) {
+            viewRoot.removeComponentResource(context, componentResource, HEAD);
+        }
+    }
+}

--- a/tck/faces23/dynamic-components/src/main/java/ee/jakarta/tck/faces/faces23/dynamic_components/Issue3484Bean.java
+++ b/tck/faces23/dynamic-components/src/main/java/ee/jakarta/tck/faces/faces23/dynamic_components/Issue3484Bean.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2026 Contributors to Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.faces.faces23.dynamic_components;
+
+import java.io.Serializable;
+import java.util.List;
+
+import jakarta.enterprise.context.RequestScoped;
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.context.FacesContext;
+import jakarta.inject.Named;
+
+/**
+ * Removes a Facelets created child from its parent and adds it straight back at the very index it came from,
+ * which must leave the view exactly as it was.
+ */
+@Named
+@RequestScoped
+public class Issue3484Bean implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private static final String TARGET = "form:outputText";
+
+    public void removeAndReAdd() {
+        UIComponent target = FacesContext.getCurrentInstance().getViewRoot().findComponent(TARGET);
+        List<UIComponent> siblings = target.getParent().getChildren();
+        int index = siblings.indexOf(target);
+
+        siblings.remove(index);
+        siblings.add(index, target);
+    }
+
+    public int getIndex() {
+        UIComponent target = FacesContext.getCurrentInstance().getViewRoot().findComponent(TARGET);
+        return target == null ? -1 : target.getParent().getChildren().indexOf(target);
+    }
+}

--- a/tck/faces23/dynamic-components/src/main/webapp/issue2475.xhtml
+++ b/tck/faces23/dynamic-components/src/main/webapp/issue2475.xhtml
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<!--
+
+    Copyright (c) 2026 Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<html xmlns:f="jakarta.faces.core"
+      xmlns:h="jakarta.faces.html">
+    <h:head>
+        <title>Issue2475</title>
+    </h:head>
+    <h:body>
+        <h:outputScript name="issue2475.js" target="head"/>
+        <f:event type="preRenderView" listener="#{issue2475Bean.removeComponentResources}"/>
+        <h:form id="form">
+            <h:commandButton id="submit" value="Submit"/>
+            <h:outputText id="result" value="submitted"/>
+        </h:form>
+    </h:body>
+</html>

--- a/tck/faces23/dynamic-components/src/main/webapp/issue3484.xhtml
+++ b/tck/faces23/dynamic-components/src/main/webapp/issue3484.xhtml
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<!--
+
+    Copyright (c) 2026 Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<html xmlns:h="jakarta.faces.html">
+    <h:head>
+        <title>Issue3484</title>
+    </h:head>
+    <h:body>
+        <h:form id="form">
+            <h:outputText id="outputText" value="facelets created child"/>
+            <h:commandButton id="submit" actionListener="#{issue3484Bean.removeAndReAdd}" value="Remove and re-add"/>
+        </h:form>
+        <h:outputText id="index" value="#{issue3484Bean.index}"/>
+    </h:body>
+</html>

--- a/tck/faces23/dynamic-components/src/main/webapp/resources/issue2475.js
+++ b/tck/faces23/dynamic-components/src/main/webapp/resources/issue2475.js
@@ -1,0 +1,2 @@
+// Head component resource which the preRenderView listener removes again.
+var issue2475 = true;

--- a/tck/faces23/dynamic-components/src/test/java/ee/jakarta/tck/faces/faces23/dynamic_components/Issue2475IT.java
+++ b/tck/faces23/dynamic-components/src/test/java/ee/jakarta/tck/faces/faces23/dynamic_components/Issue2475IT.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2026 Contributors to Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.faces.faces23.dynamic_components;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.By;
+
+import ee.jakarta.tck.faces.util.selenium.BaseITNG;
+import ee.jakarta.tck.faces.util.selenium.WebPage;
+import jakarta.faces.component.UIViewRoot;
+
+class Issue2475IT extends BaseITNG {
+
+    /**
+     * Component resources removed from the view root during preRenderView stay removed and leave the view
+     * postbackable: saving the state of a view whose component resources were dropped must not fail.
+     *
+     * @see UIViewRoot#removeComponentResource(jakarta.faces.context.FacesContext, jakarta.faces.component.UIComponent, String)
+     * @see https://github.com/eclipse-ee4j/mojarra/issues/2475
+     */
+    @Test
+    void viewStaysPostbackableAfterRemovingComponentResources() {
+        WebPage page = getPage("issue2475.xhtml");
+
+        assertEquals(200, page.getResponseStatus(), "initial render");
+        assertFalse(page.containsSource("issue2475.js"), "The head component resource must have been removed.");
+
+        page.guardHttp(page.findElement(By.id("form:submit"))::click);
+
+        assertEquals(200, page.getResponseStatus(), "postback");
+        assertEquals("submitted", page.findElement(By.id("form:result")).getText(), "The view must still render.");
+    }
+}

--- a/tck/faces23/dynamic-components/src/test/java/ee/jakarta/tck/faces/faces23/dynamic_components/Issue3484IT.java
+++ b/tck/faces23/dynamic-components/src/test/java/ee/jakarta/tck/faces/faces23/dynamic_components/Issue3484IT.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2026 Contributors to Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.faces.faces23.dynamic_components;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.By;
+
+import ee.jakarta.tck.faces.util.selenium.BaseITNG;
+import ee.jakarta.tck.faces.util.selenium.WebPage;
+
+class Issue3484IT extends BaseITNG {
+
+    /**
+     * Removing a Facelets created child and adding it straight back at the same index is a no-op: the child
+     * keeps its identity and its position, and the view still restores on the next postback.
+     *
+     * @see jakarta.faces.component.UIComponent#getChildren()
+     * @see https://github.com/eclipse-ee4j/mojarra/issues/3484
+     */
+    @Test
+    void removeAndReAddAtSameIndexLeavesTheViewUnchanged() {
+        WebPage page = getPage("issue3484.xhtml");
+
+        assertEquals("0", page.findElement(By.id("index")).getText(), "index on initial render");
+        assertEquals("facelets created child", page.findElement(By.id("form:outputText")).getText(),
+                "child on initial render");
+
+        page.guardHttp(page.findElement(By.id("form:submit"))::click);
+
+        assertEquals("0", page.findElement(By.id("index")).getText(), "index after remove and re-add");
+        assertEquals("facelets created child", page.findElement(By.id("form:outputText")).getText(),
+                "child after remove and re-add");
+
+        page.guardHttp(page.findElement(By.id("form:submit"))::click);
+
+        assertEquals("0", page.findElement(By.id("index")).getText(), "index after a second postback");
+        assertEquals("facelets created child", page.findElement(By.id("form:outputText")).getText(),
+                "child after a second postback");
+    }
+}

--- a/tck/faces23/el/src/main/java/ee/jakarta/tck/faces/faces23/el/Issue3139Bean.java
+++ b/tck/faces23/el/src/main/java/ee/jakarta/tck/faces/faces23/el/Issue3139Bean.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2026 Contributors to Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.faces.faces23.el;
+
+import java.text.MessageFormat;
+
+import jakarta.enterprise.context.RequestScoped;
+import jakarta.inject.Named;
+
+@Named
+@RequestScoped
+public class Issue3139Bean {
+
+    public String format(String pattern, Object argument) {
+        return MessageFormat.format(pattern, argument);
+    }
+}

--- a/tck/faces23/el/src/main/webapp/issue2895.xhtml
+++ b/tck/faces23/el/src/main/webapp/issue2895.xhtml
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<!--
+
+    Copyright (c) 2026 Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<html xmlns:h="jakarta.faces.html">
+    <h:head>
+        <title>Issue2895</title>
+    </h:head>
+    <h:body>
+        <h:panelGroup id="assignment">
+            #{v = {1,2}}
+        </h:panelGroup>
+    </h:body>
+</html>

--- a/tck/faces23/el/src/main/webapp/issue3139.xhtml
+++ b/tck/faces23/el/src/main/webapp/issue3139.xhtml
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<!--
+
+    Copyright (c) 2026 Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<html xmlns:h="jakarta.faces.html">
+    <h:head>
+        <title>Issue3139</title>
+    </h:head>
+    <h:body>
+        <h:panelGroup id="plain">#{'{0}'}</h:panelGroup>
+        <h:panelGroup id="openingEntity">#{'&#123;'}</h:panelGroup>
+        <h:panelGroup id="closingEntity">#{'&#125;'}</h:panelGroup>
+        <h:panelGroup id="bothEntities">#{'&#123;0&#125;'}</h:panelGroup>
+        <h:outputText id="formatted" value="#{issue3139Bean.format('Answer: {0}', 'Expression Language')}"/>
+    </h:body>
+</html>

--- a/tck/faces23/el/src/test/java/ee/jakarta/tck/faces/faces23/el/Issue2895IT.java
+++ b/tck/faces23/el/src/test/java/ee/jakarta/tck/faces/faces23/el/Issue2895IT.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2026 Contributors to Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.faces.faces23.el;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.By;
+
+import ee.jakarta.tck.faces.util.selenium.BaseITNG;
+import ee.jakarta.tck.faces.util.selenium.WebPage;
+
+class Issue2895IT extends BaseITNG {
+
+    /**
+     * Facelets delegates expression parsing to the Jakarta Expression Language implementation, so an
+     * assignment expression with a set literal in inline template text is parsed and evaluated rather than
+     * mistaken for template text delimiters.
+     *
+     * @see https://github.com/eclipse-ee4j/mojarra/issues/2895
+     */
+    @Test
+    void assignmentExpressionInInlineTextIsEvaluated() {
+        WebPage page = getPage("issue2895.xhtml");
+
+        assertEquals(200, page.getResponseStatus(), "The view must render.");
+        assertEquals("[1, 2]", page.findElement(By.id("assignment")).getText(),
+                "The assignment expression must evaluate to the assigned set.");
+    }
+}

--- a/tck/faces23/el/src/test/java/ee/jakarta/tck/faces/faces23/el/Issue3139IT.java
+++ b/tck/faces23/el/src/test/java/ee/jakarta/tck/faces/faces23/el/Issue3139IT.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2026 Contributors to Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.faces.faces23.el;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.By;
+
+import ee.jakarta.tck.faces.util.selenium.BaseITNG;
+import ee.jakarta.tck.faces.util.selenium.WebPage;
+
+class Issue3139IT extends BaseITNG {
+
+    /**
+     * Curly braces inside a string literal of an inline expression, written either literally or as character
+     * entities, belong to the literal and must not be taken for expression delimiters.
+     *
+     * @see https://github.com/eclipse-ee4j/mojarra/issues/3139
+     */
+    @Test
+    void bracesInsideStringLiteralsAreParsed() {
+        WebPage page = getPage("issue3139.xhtml");
+
+        assertEquals(200, page.getResponseStatus(), "The view must render.");
+        assertEquals("{0}", page.findElement(By.id("plain")).getText(), "literal braces");
+        assertEquals("{", page.findElement(By.id("openingEntity")).getText(), "opening brace entity");
+        assertEquals("}", page.findElement(By.id("closingEntity")).getText(), "closing brace entity");
+        assertEquals("{0}", page.findElement(By.id("bothEntities")).getText(), "both brace entities");
+        assertEquals("Answer: Expression Language", page.findElement(By.id("formatted")).getText(),
+                "A pattern containing braces must survive being passed as a method argument.");
+    }
+}

--- a/tck/faces23/facelets/src/main/webapp/issue2972.xhtml
+++ b/tck/faces23/facelets/src/main/webapp/issue2972.xhtml
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<!--
+
+    Copyright (c) 2026 Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<html xmlns:h="jakarta.faces.html">
+    <h:head>
+        <title>Issue2972</title>
+    </h:head>
+    <h:body>
+        <ul>
+            <li>
+                <svg xmlns="http://www.w3.org/2000/svg" version="1.1" id="svg"></svg>
+            </li>
+        </ul>
+        <h:outputText id="after" value="after the nested namespace"/>
+    </h:body>
+</html>

--- a/tck/faces23/facelets/src/test/java/ee/jakarta/tck/faces/faces23/facelets/Issue2972IT.java
+++ b/tck/faces23/facelets/src/test/java/ee/jakarta/tck/faces/faces23/facelets/Issue2972IT.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2026 Contributors to Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.faces.faces23.facelets;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.By;
+
+import ee.jakarta.tck.faces.util.selenium.BaseITNG;
+import ee.jakarta.tck.faces.util.selenium.WebPage;
+
+class Issue2972IT extends BaseITNG {
+
+    /**
+     * Facelets is an XML view declaration language and must honour XML namespace scoping: an element which
+     * redeclares the default namespace for its own subtree does not end the document, and the markup which
+     * follows it is compiled and rendered as usual.
+     *
+     * @see https://github.com/eclipse-ee4j/mojarra/issues/2972
+     */
+    @Test
+    void nestedDefaultNamespaceDeclarationStillYieldsACompleteDocument() {
+        WebPage page = getPage("issue2972.xhtml");
+
+        assertEquals(200, page.getResponseStatus(), "The view must render.");
+        assertTrue(page.containsSource("</html>"), "The document must be complete.");
+        assertEquals("after the nested namespace", page.findElement(By.id("after")).getText(),
+                "Markup after the nested namespace declaration must still be rendered.");
+    }
+}

--- a/tck/faces23/passthrough/src/main/java/ee/jakarta/tck/faces/faces23/passthrough/Issue3127Bean.java
+++ b/tck/faces23/passthrough/src/main/java/ee/jakarta/tck/faces/faces23/passthrough/Issue3127Bean.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2026 Contributors to Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.faces.faces23.passthrough;
+
+import java.time.LocalDate;
+
+import jakarta.enterprise.context.RequestScoped;
+import jakarta.inject.Named;
+
+@Named
+@RequestScoped
+public class Issue3127Bean {
+
+    public static final LocalDate DATE = LocalDate.of(2026, 8, 5);
+
+    public LocalDate getDate() {
+        return DATE;
+    }
+}

--- a/tck/faces23/passthrough/src/main/java/ee/jakarta/tck/faces/faces23/passthrough/Issue3173Bean.java
+++ b/tck/faces23/passthrough/src/main/java/ee/jakarta/tck/faces/faces23/passthrough/Issue3173Bean.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2026 Contributors to Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.faces.faces23.passthrough;
+
+import jakarta.enterprise.context.RequestScoped;
+import jakarta.inject.Named;
+
+@Named
+@RequestScoped
+public class Issue3173Bean {
+
+    public static final String VALUE = "123";
+
+    public String getValue() {
+        return VALUE;
+    }
+
+    public void submit() {
+        // NOOP, the test only asserts the rendered markup.
+    }
+}

--- a/tck/faces23/passthrough/src/main/java/ee/jakarta/tck/faces/faces23/passthrough/Issue3212Bean.java
+++ b/tck/faces23/passthrough/src/main/java/ee/jakarta/tck/faces/faces23/passthrough/Issue3212Bean.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2026 Contributors to Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.faces.faces23.passthrough;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import jakarta.enterprise.context.RequestScoped;
+import jakarta.inject.Named;
+
+@Named
+@RequestScoped
+public class Issue3212Bean {
+
+    public static class Entity {
+
+        private final String name;
+        private final LocalDate modifiedOn;
+
+        public Entity(String name, LocalDate modifiedOn) {
+            this.name = name;
+            this.modifiedOn = modifiedOn;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public LocalDate getModifiedOn() {
+            return modifiedOn;
+        }
+    }
+
+    private final List<Entity> entities = List.of(
+        new Entity("first", LocalDate.of(2026, 1, 1)),
+        new Entity("second", LocalDate.of(2026, 2, 2)),
+        new Entity("third", LocalDate.of(2026, 3, 3)));
+
+    public List<Entity> getEntities() {
+        return entities;
+    }
+}

--- a/tck/faces23/passthrough/src/main/webapp/issue3029.xhtml
+++ b/tck/faces23/passthrough/src/main/webapp/issue3029.xhtml
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<!--
+
+    Copyright (c) 2026 Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<html xmlns:h="jakarta.faces.html"
+      xmlns:jsf="jakarta.faces">
+    <h:head>
+        <title>Issue3029</title>
+    </h:head>
+    <h:body>
+        <div class="myclass" jsf:id="bar">This should not blow up</div>
+    </h:body>
+</html>

--- a/tck/faces23/passthrough/src/main/webapp/issue3127.xhtml
+++ b/tck/faces23/passthrough/src/main/webapp/issue3127.xhtml
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<!--
+
+    Copyright (c) 2026 Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<html xmlns:f="jakarta.faces.core"
+      xmlns:h="jakarta.faces.html">
+    <h:head>
+        <title>Issue3127</title>
+    </h:head>
+    <h:body>
+        <h:form id="form">
+            <h:inputText id="input">
+                <f:passThroughAttribute name="placeholder" value="#{issue3127Bean.date}"/>
+            </h:inputText>
+        </h:form>
+    </h:body>
+</html>

--- a/tck/faces23/passthrough/src/main/webapp/issue3173.xhtml
+++ b/tck/faces23/passthrough/src/main/webapp/issue3173.xhtml
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<!--
+
+    Copyright (c) 2026 Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<html xmlns:h="jakarta.faces.html"
+      xmlns:jsf="jakarta.faces">
+    <h:head>
+        <title>Issue3173</title>
+    </h:head>
+    <h:body>
+        <h:form id="form" prependId="false">
+            <div>
+                <button jsf:id="before" jsf:action="#{issue3173Bean.submit}"><span>Before</span></button>
+            </div>
+            <div>
+                <input type="text" jsf:id="date" disabled="disabled" value="#{issue3173Bean.value}"/>
+            </div>
+            <div>
+                <button jsf:id="after" jsf:action="#{issue3173Bean.submit}"><span>After</span></button>
+            </div>
+        </h:form>
+    </h:body>
+</html>

--- a/tck/faces23/passthrough/src/main/webapp/issue3212.xhtml
+++ b/tck/faces23/passthrough/src/main/webapp/issue3212.xhtml
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<!--
+
+    Copyright (c) 2026 Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<html xmlns:f="jakarta.faces.core"
+      xmlns:h="jakarta.faces.html">
+    <h:head>
+        <title>Issue3212</title>
+    </h:head>
+    <h:body>
+        <h:dataTable id="table" value="#{issue3212Bean.entities}" var="entity">
+            <h:column>
+                <f:facet name="header">Name</f:facet>
+                <f:facet name="footer">Name</f:facet>
+                <f:passThroughAttribute name="data-order" value="#{entity.modifiedOn}"/>
+                <h:outputText value="#{entity.name}"/>
+            </h:column>
+        </h:dataTable>
+        <h:messages id="messages"/>
+    </h:body>
+</html>

--- a/tck/faces23/passthrough/src/main/webapp/issue3727.xhtml
+++ b/tck/faces23/passthrough/src/main/webapp/issue3727.xhtml
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<!--
+
+    Copyright (c) 2026 Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<html xmlns:h="jakarta.faces.html"
+      xmlns:jsf="jakarta.faces">
+    <h:head>
+        <title>Issue3727</title>
+    </h:head>
+    <h:body>
+        <h:form id="form">
+            <button jsf:id="myId">Button</button>
+            <select id="plain">
+                <option value="1">1</option>
+                <option value="2">2</option>
+                <option value="3">3</option>
+            </select>
+        </h:form>
+    </h:body>
+</html>

--- a/tck/faces23/passthrough/src/test/java/ee/jakarta/tck/faces/faces23/passthrough/Issue3029IT.java
+++ b/tck/faces23/passthrough/src/test/java/ee/jakarta/tck/faces/faces23/passthrough/Issue3029IT.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2026 Contributors to Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.faces.faces23.passthrough;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.By;
+
+import ee.jakarta.tck.faces.util.selenium.BaseITNG;
+import ee.jakarta.tck.faces.util.selenium.WebPage;
+import jakarta.faces.view.facelets.TagDecorator;
+
+class Issue3029IT extends BaseITNG {
+
+    /**
+     * A plain HTML element decorated with jsf:id keeps a class attribute of its own: promoting the element
+     * to a component must not let class collide with the styleClass the renderer writes out.
+     *
+     * @see TagDecorator
+     * @see https://github.com/eclipse-ee4j/mojarra/issues/3029
+     */
+    @Test
+    void classAttributeSurvivesPromotionToAComponent() {
+        WebPage page = getPage("issue3029.xhtml");
+
+        assertEquals(200, page.getResponseStatus(), "The view must render.");
+        assertEquals("myclass", page.findElement(By.id("bar")).getDomAttribute("class"),
+                "The class attribute must be rendered verbatim on the promoted element.");
+    }
+}

--- a/tck/faces23/passthrough/src/test/java/ee/jakarta/tck/faces/faces23/passthrough/Issue3127IT.java
+++ b/tck/faces23/passthrough/src/test/java/ee/jakarta/tck/faces/faces23/passthrough/Issue3127IT.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2026 Contributors to Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.faces.faces23.passthrough;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.By;
+
+import ee.jakarta.tck.faces.util.selenium.BaseITNG;
+import ee.jakarta.tck.faces.util.selenium.WebPage;
+import jakarta.faces.component.UIComponent;
+
+class Issue3127IT extends BaseITNG {
+
+    /**
+     * A pass through attribute whose expression resolves to something other than a String is rendered by
+     * calling toString() on the value, rather than failing the request.
+     *
+     * @see UIComponent#getPassThroughAttributes()
+     * @see https://github.com/eclipse-ee4j/mojarra/issues/3127
+     */
+    @Test
+    void nonStringPassThroughAttributeIsRenderedViaToString() {
+        WebPage page = getPage("issue3127.xhtml");
+
+        assertEquals(200, page.getResponseStatus(), "The view must render.");
+        assertEquals(Issue3127Bean.DATE.toString(),
+                page.findElement(By.id("form:input")).getDomAttribute("placeholder"),
+                "A non-String pass through attribute value must be rendered via toString().");
+    }
+}

--- a/tck/faces23/passthrough/src/test/java/ee/jakarta/tck/faces/faces23/passthrough/Issue3173IT.java
+++ b/tck/faces23/passthrough/src/test/java/ee/jakarta/tck/faces/faces23/passthrough/Issue3173IT.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2026 Contributors to Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.faces.faces23.passthrough;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.By;
+
+import ee.jakarta.tck.faces.util.selenium.BaseITNG;
+import ee.jakarta.tck.faces.util.selenium.WebPage;
+import jakarta.faces.view.facelets.TagDecorator;
+
+class Issue3173IT extends BaseITNG {
+
+    /**
+     * An input element decorated with jsf:id is a void element, so promoting it to a component must not
+     * emit a closing tag for it, which would nest the following markup inside it.
+     *
+     * @see TagDecorator
+     * @see https://github.com/eclipse-ee4j/mojarra/issues/3173
+     */
+    @Test
+    void promotedVoidElementGetsNoClosingTag() {
+        WebPage page = getPage("issue3173.xhtml");
+
+        assertEquals(200, page.getResponseStatus(), "The view must render.");
+        assertFalse(page.getSource().contains("</input"), "A void element must not be given a closing tag.");
+        assertEquals(Issue3173Bean.VALUE, page.findElement(By.id("date")).getDomAttribute("value"),
+                "The promoted input must keep its value.");
+        assertEquals("Before", page.findElement(By.id("before")).getText(), "button before the input");
+        assertEquals("After", page.findElement(By.id("after")).getText(), "button after the input");
+    }
+}

--- a/tck/faces23/passthrough/src/test/java/ee/jakarta/tck/faces/faces23/passthrough/Issue3212IT.java
+++ b/tck/faces23/passthrough/src/test/java/ee/jakarta/tck/faces/faces23/passthrough/Issue3212IT.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2026 Contributors to Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.faces.faces23.passthrough;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+
+import ee.jakarta.tck.faces.util.selenium.BaseITNG;
+import ee.jakarta.tck.faces.util.selenium.WebPage;
+import jakarta.faces.component.UIComponent;
+
+class Issue3212IT extends BaseITNG {
+
+    /**
+     * A pass through attribute on an h:column whose value expression is row scoped is evaluated per row and
+     * written onto that row's cell, also when the column declares facets.
+     *
+     * @see UIComponent#getPassThroughAttributes()
+     * @see https://github.com/eclipse-ee4j/mojarra/issues/3212
+     */
+    @Test
+    void rowScopedPassThroughAttributeIsEvaluatedPerRow() {
+        WebPage page = getPage("issue3212.xhtml");
+
+        assertEquals(200, page.getResponseStatus(), "The view must render.");
+
+        List<WebElement> cells = page.findElements(By.cssSelector("#table tbody td"));
+        List<Issue3212Bean.Entity> entities = new Issue3212Bean().getEntities();
+
+        assertEquals(entities.size(), cells.size(), "One rendered cell per row.");
+
+        for (int row = 0; row < entities.size(); row++) {
+            assertEquals(entities.get(row).getModifiedOn().toString(), cells.get(row).getDomAttribute("data-order"),
+                    "Row " + row + " must carry its own pass through attribute value.");
+        }
+    }
+}

--- a/tck/faces23/passthrough/src/test/java/ee/jakarta/tck/faces/faces23/passthrough/Issue3727IT.java
+++ b/tck/faces23/passthrough/src/test/java/ee/jakarta/tck/faces/faces23/passthrough/Issue3727IT.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2026 Contributors to Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.faces.faces23.passthrough;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.By;
+
+import ee.jakarta.tck.faces.util.selenium.BaseITNG;
+import ee.jakarta.tck.faces.util.selenium.WebPage;
+import jakarta.faces.view.facelets.TagDecorator;
+
+class Issue3727IT extends BaseITNG {
+
+    /**
+     * A plain select/option block in a view that also decorates elements with jsf:id is emitted with its
+     * tags correctly nested: the closing select tag follows the last closing option tag.
+     *
+     * @see TagDecorator
+     * @see https://github.com/eclipse-ee4j/mojarra/issues/3727
+     */
+    @Test
+    void plainSelectKeepsItsOptionsNested() {
+        WebPage page = getPage("issue3727.xhtml");
+        String source = page.getSource();
+
+        assertEquals(200, page.getResponseStatus(), "The view must render.");
+        assertTrue(source.indexOf("</select>") > source.lastIndexOf("</option>"),
+                "The closing select tag must follow the last closing option tag.");
+        assertEquals(3, page.findElements(By.cssSelector("#plain option")).size(),
+                "All options must remain children of the select.");
+    }
+}

--- a/tck/faces23/pom.xml
+++ b/tck/faces23/pom.xml
@@ -44,6 +44,7 @@
         <module>facelets</module>
         <module>ui-input</module>
         <module>ajax</module>
+        <module>ajax-content-type</module>
         <module>localized-composite</module>
         <module>datetime-converter</module>
         <module>get-views</module>

--- a/tck/faces23/process-as-xml/src/main/webapp/WEB-INF/web.xml
+++ b/tck/faces23/process-as-xml/src/main/webapp/WEB-INF/web.xml
@@ -46,15 +46,6 @@
         <param-name>jakarta.faces.DEFAULT_SUFFIX</param-name>
         <param-value>.xhtml .view.xml</param-value>
     </context-param>
-    <context-param>
-        <param-name>jakarta.faces.FACELETS_VIEW_MAPPINGS</param-name>
-        <param-value>*.xhtml;*.view.xml</param-value>
-    </context-param>
-
-    <context-param>
-        <param-name>jakarta.faces.DEFAULT_SUFFIX</param-name>
-        <param-value>.xhtml .view.xml</param-value>
-    </context-param>
 
     <servlet>
         <servlet-name>facesServlet</servlet-name>

--- a/tck/faces40/extensionless-mapping/src/main/webapp/WEB-INF/web.xml
+++ b/tck/faces40/extensionless-mapping/src/main/webapp/WEB-INF/web.xml
@@ -37,12 +37,7 @@
         <param-name>jakarta.faces.SERIALIZE_SERVER_STATE</param-name>
         <param-value>${webapp.serializeServerState}</param-value>
     </context-param>
-    
-    <context-param>
-        <param-name>jakarta.faces.SERIALIZE_SERVER_STATE</param-name>
-        <param-value>${webapp.serializeServerState}</param-value>
-    </context-param>
-    
+
     <context-param>
         <param-name>jakarta.faces.AUTOMATIC_EXTENSIONLESS_MAPPING</param-name>
         <param-value>true</param-value>

--- a/tck/faces40/input/src/test/java/ee/jakarta/tck/faces/faces40/input/Spec1555IT.java
+++ b/tck/faces40/input/src/test/java/ee/jakarta/tck/faces/faces40/input/Spec1555IT.java
@@ -65,7 +65,7 @@ class Spec1555IT extends BaseITNG {
         input.sendKeys(file.getAbsolutePath());
 
         page.guardAjax(page.findElement(By.id(form + ":submit"))::click);
-        assertEquals("", page.findElement(By.id(form + ":input")).getDomProperty("value"), "Value attribute is NOT set");
+        assertNull(page.findElement(By.id(form + ":input")).getDomAttribute("value"), "Value attribute is NOT rendered");
 
         WebElement messages = page.findElement(By.id("messages"));
 
@@ -111,7 +111,7 @@ class Spec1555IT extends BaseITNG {
         input.sendKeys(files);
         page.guardAjax(page.findElement(By.id(form + ":submit"))::click);
 
-        assertEquals("", page.findElement(By.id(form + ":input")).getDomProperty("value"), "Value attribute is NOT set");
+        assertNull(page.findElement(By.id(form + ":input")).getDomAttribute("value"), "Value attribute is NOT rendered");
 
         WebElement messages = page.findElement(By.id("messages"));
         List childElements = messages.findElements(By.cssSelector("*"));


### PR DESCRIPTION
Ports the portable remainder of the integration tests deleted by mojarra `ed55113a3`, after #2181 and #2215 recovered the v3-and-up set. **37 tests land** — 36 new IT classes plus one folded onto an existing class — across 21 existing modules and 6 new ones. Two candidates were dropped on evidence rather than ported.

**This round expands TCK coverage rather than exposing defects.** Every ported test passes against current mojarra, where #2215 caught four bugs. Full reactor is green with 6332 tests in less than 5 minutes with `-T8`.

## How the names were resolved

From the commit which added each test in the `javaee-mojarra` java.net history, then verified against the live GitHub issue title — not by +4 arithmetic, which is ~30% wrong. 44 resolve to `eclipse-ee4j/mojarra`, 3 to `jakartaee/faces` (spec numbers map 1:1). The file names lie in several places: two unrelated deleted tests both named `Issue2973IT` resolve to #2977 and #3266, and `Issue2698IT` resolves to #1641 — which turned out to be already ported in #2181 under its canonical name, so the number-based audit had missed it.

## Six new modules

Each exists because it must pin a webapp configuration the reactor otherwise never exercises, or because it registers an application-wide artifact that cannot be shared with unrelated tests:

| Module | Why |
|---|---|
| `faces20/state-serialization-enabled` | `SERIALIZE_SERVER_STATE=true` |
| `faces20/state-serialization-disabled` | `SERIALIZE_SERVER_STATE=false` |
| `faces20/system-event-listener-startup` | faces-config `system-event-listener` |
| `faces22/full-state-saving` | `PARTIAL_STATE_SAVING=false` |
| `faces22/init-request-parameter-map` | `FacesContext`/`ExternalContext` factories |
| `faces23/ajax-content-type` | `ExternalContextFactory` |

Pinned values carry `DO NOT PARAMETERIZE` comments naming the test that depends on them, following the existing convention. `SERIALIZE_SERVER_STATE=true` had **never been executed anywhere in the reactor** — `tck/pom.xml` defines each `webapp.*` property once and no profile overrides them.

Worth knowing: `-Dwebapp.partialStateSaving=false` already flips the whole reactor today (`filteringDeploymentDescriptors=true` plus CLI properties outranking pom properties), and the `DO NOT PARAMETERIZE` comments are that design's opt-out half. Nothing uses it — no profile, and CI builds only `api/`. A documented `-Pfull-state` / `-Pclient-state` profile would be worth adding as a breadth tool, complementary to these pinned modules.

## h:inputFile value attribute, ported inverted

The deleted `Issue2420IT` asserted that `h:inputFile` **renders** its `value` attribute. The HTML_BASIC render kit documentation says the opposite, under Encode Behavior: *"Render the clientId of the component as the value of the "name" attribute. Do not render the "value" attribute."* Porting it as written would have encoded a spec violation.

The rule was introduced by JAVASERVERFACES_SPEC_PUBLIC-802 → #802, commit `ee4328cf1d` (2012-05-22), whose message reads *"Specify that for h:inputFile, the "value" attribute must not be rendered"* — one day before the mojarra issue was filed. So the test is inverted and folded onto `Spec802IT`, its own ticket.

While there, `Spec1555IT`'s four `getDomProperty("value")` assertions move to `getDomAttribute`. They were labelled "Value attribute is NOT set" but `getDomProperty` is always empty for a file input regardless of what the renderer emitted, so they could never have detected the regression.

## Assertions reframed off mojarra internals

Several originals asserted on `com.sun.faces` internals and were rewritten against public API:

- `Issue2324IT` — replaces `Util.checkIdUniqueness` with a `visitTree` walk over client ids
- `Issue3484IT` — drops `ComponentSupport.MARK_CREATED`/`REMOVED_CHILDREN` for component identity and index across postbacks
- `Issue3104IT` — asserts the ajax error handler fires, not the `IllegalStateException` type
- `Issue2648IT` — drops an `InitFacesContext` class-name check

Originals that asserted only HTTP 200 were given load-bearing assertions instead.

## Dropped

**`Issue2675IT`** — premise inverted. An `f:view` nested in a `ui:define` now yields a 500 as per updated Faces 5.0 spec, where the test requires it to be *silently* ignored while the view still renders. `issue2644.xhtml` in the same module proves the template plus `ui:define` shape renders fine on its own, so the nested `f:view` is what fails. Neither behaviour is spec-mandated, so there is nothing left to guard — same call #2215 made on `Issue2642IT`.

**`Issue2388IT`** — client-side state saving was the reporter's environment, not the mechanism. Converter resolution order is not state-saving specific, so a module pinned purely to host it adds a deployment without adding coverage.

🤖 Generated with Claude Opus 5
