### PR TITLE
Specify per-row state of ui:repeat and align rowStatePreserved with UIData

### DIFF
--- a/api/src/main/vdldoc/faces.facelets.taglib.xml
+++ b/api/src/main/vdldoc/faces.facelets.taglib.xml
@@ -830,7 +830,21 @@ attribute must be an absolute path starting with "/".</span>
         <p><span class="changed_modified_2_2
         changed_modified_2_3 changed_modified_4_0">Use</span> this tag as an alternative to
         <code>h:dataTable</code> or <code>c:forEach</code></p> </div>
-        
+
+        <div class="changed_added_5_0">
+
+        <p>Whenever the current row changes, the per-row state of the descendant
+        <code>EditableValueHolder</code> components must be saved for the row being left and restored for the
+        row being entered, in the same manner as is required of
+        <code>UIData.setRowIndex()</code>, and regardless of the value of the
+        <code>rowStatePreserved</code> attribute. The state to be saved and restored consists of the
+        <code>localValue</code>, <code>localValueSet</code>, <code>valid</code> and
+        <code>submittedValue</code> properties.</p>
+
+        <p>This requirement concerns the state of the descendant components only. The state of the repeat
+        component itself, such as the <code>begin</code>, <code>end</code> and <code>var</code> attributes and
+        the current row index, is a separate concern which this requirement does not cover.</p> </div>
+
         ]]></description>
         <tag-name>repeat</tag-name>
         <handler-class />
@@ -1003,15 +1017,17 @@ attribute must be an absolute path starting with "/".</span>
         <attribute>
             <description>
             <![CDATA[
-                <div class="changed_added_4_1">
+                <div class="changed_added_4_1 changed_modified_5_0">
                     <p>
-                        Boolean flag directing how the per-row component state of <code>EditableValueHolder</code> children should be handled across requests on the same view.
-                        If set to <code>true</code>, then state for <code>EditableValueHolder</code> components in each row will not be discarded before a new row is rendered.
+                        Boolean flag directing whether the full per-row component state of the children of this repeat component must be preserved on a per-row basis, as specified by <code>UIData.setRowStatePreserved()</code>.
+                        If set to <code>true</code>, then <code>StateHolder.saveState()</code> and <code>TransientStateHolder.saveTransientState()</code> must be called on the children on exiting a row, and <code>StateHolder.restoreState()</code> and <code>TransientStateHolder.restoreTransientState()</code> must be called on re-entering that row, all during the processing of the row index change.
+                        This covers any per-row state of the children, not only the <code>EditableValueHolder</code> properties which are saved and restored on every row change regardless of this attribute, as specified by <code>UIData.setRowIndex()</code>.
                         If not specified, the default value is <code>false</code>.
                     </p>
                     <p>
-                        This attribute should be set only when the current repeat component contains <code>UIForm</code> children which in turn contains <code>EditableValueHolder</code> children.
-                        This will only work reliably when the data model of the current repeat component does not change across requests on the same view by e.g. sorting, adding or removing rows.
+                        This attribute should be set when the current repeat component contains <code>UIForm</code> children which in turn contains <code>EditableValueHolder</code> children, as the submitted flag of the form is itself per-row state which the default does not cover.
+                        Preserving the full per-row state does add overhead, hence this attribute should be used judiciously.
+                        Per-row state is keyed on the row index, hence this will only work reliably when the data model of the current repeat component does not change across requests on the same view by e.g. sorting, adding or removing rows.
                         The alternative is to use <code>c:forEach</code> instead.
                     </p>
                 </div>

--- a/api/src/main/vdldoc/faces.html.taglib.xml
+++ b/api/src/main/vdldoc/faces.html.taglib.xml
@@ -3165,15 +3165,17 @@
         <attribute>
             <description>
             <![CDATA[
-                <div class="changed_added_2_1">
+                <div class="changed_added_2_1 changed_modified_5_0">
                     <p>
-                        Boolean flag directing how the per-row component state of <code>EditableValueHolder</code> children should be handled across requests on the same view.
-                        If set to <code>true</code>, then state for <code>EditableValueHolder</code> components in each row will not be discarded before a new row is rendered.
+                        Boolean flag directing whether the full per-row component state of the children of this dataTable component must be preserved on a per-row basis, as specified by <code>UIData.setRowStatePreserved()</code>.
+                        If set to <code>true</code>, then <code>StateHolder.saveState()</code> and <code>TransientStateHolder.saveTransientState()</code> must be called on the children on exiting a row, and <code>StateHolder.restoreState()</code> and <code>TransientStateHolder.restoreTransientState()</code> must be called on re-entering that row, all during the processing of the row index change.
+                        This covers any per-row state of the children, not only the <code>EditableValueHolder</code> properties which are saved and restored on every row change regardless of this attribute, as specified by <code>UIData.setRowIndex()</code>.
                         If not specified, the default value is <code>false</code>.
                     </p>
                     <p>
-                        This attribute should be set only when the current dataTable component contains <code>UIForm</code> children which in turn contains <code>EditableValueHolder</code> children.
-                        This will only work reliably when the data model of the current dataTable component does not change across requests on the same view by e.g. sorting, adding or removing rows.
+                        This attribute should be set when the current dataTable component contains <code>UIForm</code> children which in turn contains <code>EditableValueHolder</code> children, as the submitted flag of the form is itself per-row state which the default does not cover.
+                        Preserving the full per-row state does add overhead, hence this attribute should be used judiciously.
+                        Per-row state is keyed on the row index, hence this will only work reliably when the data model of the current dataTable component does not change across requests on the same view by e.g. sorting, adding or removing rows.
                         The alternative is to use <code>c:forEach</code> instead.
                     </p>
                 </div>

--- a/spec/src/main/asciidoc/ChangeLog.adoc
+++ b/spec/src/main/asciidoc/ChangeLog.adoc
@@ -12,6 +12,9 @@ pre-Jakarta Faces specification under the JCP.
 
 This release contains the following backwards compatible changes:
 
+* Issue ID {issue_tracker_url}2206[2206] +
+Spec: require ui:repeat to save and restore per-row state of EditableValueHolder children, and align the rowStatePreserved attribute of ui:repeat and h:dataTable with UIData
+
 * Issue ID {issue_tracker_url}2173[2173] +
 Change: generalize Render Response resource push to allow modern mechanisms such as HTTP 103 Early Hints
 


### PR DESCRIPTION
Closes #2206, taking option 1 from that issue.

`UIData.setRowIndex()` normatively requires saving and restoring the per-row state of descendant `EditableValueHolder` components. `ui:repeat` has no spec class and its VDL said nothing about it, which is the basis on which challenge #1757 was accepted and `Issue3837IT` excluded from the TCK. This adds it to the `ui:repeat` tag description. The property list is taken verbatim from `UIData.setRowIndex()` so the two cannot drift, and the second paragraph keeps the distinction raised in #1757: the per-row state of the descendant components is in scope, the state of the repeat component itself — `begin`, `end`, `var`, the current row index — is not.

Writing that surfaced a second problem. The `rowStatePreserved` attribute documents a different feature than the one both implementations ship. Its description on `h:dataTable` (added in 2.1) and the copy of it on `ui:repeat` (added in 4.1) say the flag directs how the per-row component state of `EditableValueHolder` children is handled across requests on the same view. `UIData.setRowStatePreserved()` says something else entirely: call `StateHolder.saveState()` and `TransientStateHolder.saveTransientState()` on the children on exiting a row, and the matching restores on re-entering it, all during the processing of the row index change.

The javadoc is the one that describes reality — both implementations select the full per-row state on this flag, for `UIData` and for `UIRepeat` alike. So both attribute descriptions are replaced by the `UIData` contract, worded identically for the two components, and the `ui:repeat` tag description now states that the four `EditableValueHolder` properties are saved and restored on every row change regardless of the attribute.

No behavioral change is being asked of anyone here — this documents what Mojarra and MyFaces both already do, and the wording under `changed_modified_5_0` replaces text that never matched either.

`Issue3837IT` is unaffected. It asserts that per-row `EditableValueHolder` state survives a postback, which is a question of the *lifetime* of that state rather than its *breadth*, and neither the default contract nor `rowStatePreserved` speaks to it.

**Correction to an earlier revision of this description**, which cited `Spec1263IT` as evidence that `rowStatePreserved` is needed for an `h:form` nested inside the iteration, on the grounds that the form's `submitted` flag is per-row state the default does not cover. That is true of the spec's four-property default but not of either implementation, so the test does not in fact depend on the attribute. Mojarra includes `UIForm` in its default per-row state (`UIRepeat.collectIterationState`, mirrored in `UIData`); MyFaces re-decodes the form in `UIForm.processValidators`/`processUpdates` when the flag reads false. `NestedRepeatRepeatFormInsideIT` covers that shape without the attribute and is green. That neither mechanism is specified is a separate hole, to be filed on its own.

🤖 Generated with Claude Opus 5
