### PR TITLE
Specify how component tree manipulations are saved and restored

### DIFF
--- a/api/src/main/java/jakarta/faces/view/StateManagementStrategy.java
+++ b/api/src/main/java/jakarta/faces/view/StateManagementStrategy.java
@@ -32,17 +32,19 @@ import jakarta.faces.context.FacesContext;
  * </p>
  *
  * <p class="changed_added_5_0">
- * The <em>rendering build</em> is the build which precedes Render Response and produces the view that
- * {@link #saveView} saves. The <em>restoring build</em> is the build which {@link #restoreView} performs to recover
- * that view on the next request.
+ * The <em>rendering build</em> is the build which Render Response performs before publishing
+ * {@link jakarta.faces.event.PreRenderViewEvent}, and which produces the view that {@link #saveView} saves. The
+ * <em>restoring build</em> is the build which {@link #restoreView} performs to recover that view on the next
+ * request.
  * </p>
  *
  * <p class="changed_added_5_0">
  * What a build produces follows in part from the <em>build time conditions</em> it evaluates, and the value such a
- * condition produces is its <em>decision</em>. The build time conditions the implementation itself provides are the
- * test of a conditional, the branch of a choice, the range or the items of an iteration, and the path of a dynamic
- * inclusion. For these, the rendering build evaluates the condition and the restoring build reproduces the decision
- * the rendering build reached.
+ * condition produces is its <em>decision</em>. A build time condition is an expression in a tag attribute which
+ * decides what components the build produces, for example the test of a conditional, the branch of a choice, the
+ * range or the items of an iteration, and the path of a dynamic inclusion. For the build time conditions the
+ * implementation itself provides, the rendering build evaluates the condition and the restoring build reproduces the
+ * decision the rendering build reached.
  * </p>
  *
  * @since 2.0
@@ -83,18 +85,18 @@ public abstract class StateManagementStrategy {
      * can be restored given only its client id. <span class="changed_modified_5_0">Record, in addition, each addition,
      * removal and move the application performed after the view was built, so that {@link #restoreView} can reproduce
      * it. A move records the new parent, the facet name if the component is a facet, and the index among its siblings.
-     * An addition records the added component along with its state, since the restoring build does not produce that
-     * component and therefore cannot restore state into it.</span>
+     * An addition records the type of the added component, so that it can be recreated, along with its state, since
+     * the restoring build does not produce that component and therefore cannot restore state into it.</span>
      * </p>
      * </li>
      *
      * </ol>
      *
      * <p class="changed_added_5_0">
-     * The manipulations must be recorded in the order in which the application performed them, and the recorded
-     * position must travel with the manipulation rather than with the component it applies to. Each build creates the
-     * components it produces anew, at the position the markup declares for them, so anything kept on such a component
-     * may be lost before the manipulation is replayed.
+     * The manipulations must be recorded as the application performs them, since the tree afterwards shows neither
+     * the order they came in nor the position each one had. The recorded position must travel with the
+     * manipulation rather than with the component it applies to: each build creates the components it produces anew,
+     * so anything kept on such a component may be lost before the manipulation is replayed.
      * </p>
      *
      * <p class="changed_added_5_0">
@@ -158,15 +160,17 @@ public abstract class StateManagementStrategy {
      * <span class="changed_modified_5_0">This is the restoring build, and the view it produces holds the components
      * added, removed or moved while the view was being built. It does not reflect the manipulations the application
      * performed after the view was built: components added afterwards are absent, components removed afterwards are
-     * present, and components moved afterwards are at the position the markup declares for them. All of these cases
-     * must be handled.</span>
+     * present, and components moved afterwards are where this build put them. All of these cases must be
+     * handled.</span>
      * </p>
      *
      * <p class="changed_added_5_0">
      * What the restoring build produces also follows from the build time conditions it evaluates. For those the
-     * implementation provides, it must reproduce the decision the rendering build reached, rather than evaluate the
-     * condition again. The rendering build that follows evaluates them again, and it is that build which produces the
-     * view the current state of the model asks for, and which is saved in turn.
+     * implementation provides, it must reproduce the decision the rendering build reached, taken from the state
+     * <code>Object</code> returned from {@link jakarta.faces.render.ResponseStateManager#getState}, rather than
+     * evaluate the condition again. The rendering build that follows
+     * evaluates them again, and it is that build which produces the view the current state of the model asks for, and
+     * which is saved in turn.
      * </p>
      *
      * <p class="changed_added_5_0">
@@ -199,8 +203,8 @@ public abstract class StateManagementStrategy {
      * <span class="changed_modified_5_0">Replay the manipulations recorded by {@link #saveView}, in the order in which
      * the application performed them: ensure that removed components are removed, that added components are added with
      * the state recorded for them, and that moved components are at the recorded parent, facet name and index among
-     * their siblings. A component that the restoring build already produced at its recorded position must not be added
-     * a second time.</span>
+     * their siblings. A component that the restoring build already produced must not be added a second time; where
+     * that build produced it at another position, move it to the recorded one.</span>
      * </p>
      * </li>
      *
@@ -208,8 +212,8 @@ public abstract class StateManagementStrategy {
      *
      * <p>
      * The implementation must ensure that the {@link jakarta.faces.component.UIComponent#restoreState} method is called
-     * for each node in the tree, <span class="changed_modified_5_0">except for those the application removed after the
-     * view was built.</span>
+     * for each node <span class="changed_modified_5_0">the restoring build produced. No state is recorded for a
+     * component the application removed after the view was built.</span>
      * </p>
      *
      * </div>

--- a/api/src/main/java/jakarta/faces/view/StateManagementStrategy.java
+++ b/api/src/main/java/jakarta/faces/view/StateManagementStrategy.java
@@ -139,6 +139,22 @@ public abstract class StateManagementStrategy {
      * handled.</span>
      * </p>
      *
+     * <p class="changed_added_5_0">
+     * What the build produces also follows from the build time conditions it evaluates: the test of a conditional, the
+     * branch of a choice, the range or the items of an iteration, the path of a dynamic inclusion. Whether this build
+     * evaluates such a condition against the current state of the model, or reproduces the value it had in the build
+     * which rendered the view, is implementation dependent, and an application must not depend on either. It is
+     * responsible for a build time condition evaluating over a value which survives the postback.
+     * </p>
+     *
+     * <p class="changed_added_5_0">
+     * A component this build does not produce is therefore not necessarily one the application removed. It may be one
+     * whose build time condition no longer holds, in which case the state saved for it has no node to be restored into
+     * and a value submitted for it is not decoded. Reproducing the view that was rendered is in particular not
+     * required: an iteration over items the model no longer holds cannot be reproduced at all, since the components it
+     * produced read their item from those items.
+     * </p>
+     *
      *
      * </li>
      *

--- a/api/src/main/java/jakarta/faces/view/StateManagementStrategy.java
+++ b/api/src/main/java/jakarta/faces/view/StateManagementStrategy.java
@@ -31,6 +31,20 @@ import jakarta.faces.context.FacesContext;
  * and {@link #restoreView} methods, respectively.
  * </p>
  *
+ * <p class="changed_added_5_0">
+ * The <em>rendering build</em> is the build which precedes Render Response and produces the view that
+ * {@link #saveView} saves. The <em>restoring build</em> is the build which {@link #restoreView} performs to recover
+ * that view on the next request.
+ * </p>
+ *
+ * <p class="changed_added_5_0">
+ * What a build produces follows in part from the <em>build time conditions</em> it evaluates, and the value such a
+ * condition produces is its <em>decision</em>. The build time conditions the implementation itself provides are the
+ * test of a conditional, the branch of a choice, the range or the items of an iteration, and the path of a dynamic
+ * inclusion. For these, the rendering build evaluates the condition and the restoring build reproduces the decision
+ * the rendering build reached.
+ * </p>
+ *
  * @since 2.0
  */
 public abstract class StateManagementStrategy {
@@ -66,26 +80,27 @@ public abstract class StateManagementStrategy {
      * <p>
      * Visit the tree using {@link jakarta.faces.component.UIComponent#visitTree}. For each node, call
      * {@link jakarta.faces.component.UIComponent#saveState}, saving the returned <code>Object</code> in a way such that it
-     * can be restored given only its client id. <span class="changed_modified_5_0">Record, in addition, every component
-     * that the application added to, removed from or moved within the view after the view was built, so that
-     * {@link #restoreView} can reproduce those manipulations. For a move, record the new parent, the facet name if the
-     * component is a facet, and the index among its siblings.</span>
+     * can be restored given only its client id. <span class="changed_modified_5_0">Record, in addition, each addition,
+     * removal and move the application performed after the view was built, so that {@link #restoreView} can reproduce
+     * it. A move records the new parent, the facet name if the component is a facet, and the index among its siblings.
+     * An addition records the added component along with its state, since the restoring build does not produce that
+     * component and therefore cannot restore state into it.</span>
      * </p>
      * </li>
      *
      * </ol>
      *
      * <p class="changed_added_5_0">
-     * The manipulations must be recorded in the order in which the application performed them, and the recorded position
-     * must travel with the manipulation rather than with the component it applies to. The view build recreates the
-     * components it created at their declared position on every build, so information kept on such a component may be
-     * lost before the manipulation is replayed.
+     * The manipulations must be recorded in the order in which the application performed them, and the recorded
+     * position must travel with the manipulation rather than with the component it applies to. Each build creates the
+     * components it produces anew, at the position the markup declares for them, so anything kept on such a component
+     * may be lost before the manipulation is replayed.
      * </p>
      *
      * <p class="changed_added_5_0">
-     * A component whose manipulation the view build performs again on the next request need not be recorded, since the
-     * build reproduces it. This is the case for components added, removed or moved while the view is being built, for
-     * example from a listener for {@link jakarta.faces.event.PostAddToViewEvent}.
+     * A manipulation that the restoring build performs again need not be recorded, since that build reproduces it.
+     * This is the case for the manipulations performed while the view is being built, for example from a listener for
+     * {@link jakarta.faces.event.PostAddToViewEvent}.
      * </p>
      *
      * <p>
@@ -114,6 +129,14 @@ public abstract class StateManagementStrategy {
      * implementation must perform the following algorithm or its semantic equivalent.
      * </p>
      *
+     * <p class="changed_added_5_0">
+     * This method returns the view that was saved: restoring the <code>Object</code> that {@link #saveView} returned
+     * for a view must produce that view again, holding the same components at the same positions with the same state.
+     * The algorithm below produces it by performing the restoring build and reconciling from the saved state what that
+     * build does not produce. Where the restoring build cannot reproduce a decision of the rendering build, this
+     * method returns the view it could build, as described below.
+     * </p>
+     *
      * <div class="changed_added_2_0">
      *
      * <ol>
@@ -132,27 +155,25 @@ public abstract class StateManagementStrategy {
      * <p>
      * Build the view from the markup. For all components in the view that do not have an explicitly assigned id in the
      * markup, the values of those ids must be the same as on an initial request for this view.
-     * <span class="changed_modified_5_0">This view contains what the view build produces, which includes the components
+     * <span class="changed_modified_5_0">This is the restoring build, and the view it produces holds the components
      * added, removed or moved while the view was being built. It does not reflect the manipulations the application
      * performed after the view was built: components added afterwards are absent, components removed afterwards are
-     * present, and components moved afterwards are at their declared position. All of these cases must be
-     * handled.</span>
+     * present, and components moved afterwards are at the position the markup declares for them. All of these cases
+     * must be handled.</span>
      * </p>
      *
      * <p class="changed_added_5_0">
-     * What the build produces also follows from the build time conditions it evaluates: the test of a conditional, the
-     * branch of a choice, the range or the items of an iteration, the path of a dynamic inclusion. Whether this build
-     * evaluates such a condition against the current state of the model, or reproduces the value it had in the build
-     * which rendered the view, is implementation dependent, and an application must not depend on either. It is
-     * responsible for a build time condition evaluating over a value which survives the postback.
+     * What the restoring build produces also follows from the build time conditions it evaluates. For those the
+     * implementation provides, it must reproduce the decision the rendering build reached, rather than evaluate the
+     * condition again. The rendering build that follows evaluates them again, and it is that build which produces the
+     * view the current state of the model asks for, and which is saved in turn.
      * </p>
      *
      * <p class="changed_added_5_0">
-     * A component this build does not produce is therefore not necessarily one the application removed. It may be one
-     * whose build time condition no longer holds, in which case the state saved for it has no node to be restored into
-     * and a value submitted for it is not decoded. Reproducing the view that was rendered is in particular not
-     * required: an iteration over items the model no longer holds cannot be reproduced at all, since the components it
-     * produced read their item from those items.
+     * Failing to reproduce a decision must not fail the request. An iteration over items which no longer hold the
+     * elements its rows were rendered over is the case which cannot be reproduced from saved state at all: this method
+     * returns the view it could build, and a component of that view which the model no longer backs is answered for by
+     * the phase which reads that model, not by Restore View.
      * </p>
      *
      *
@@ -176,17 +197,19 @@ public abstract class StateManagementStrategy {
      * <li>
      * <p>
      * <span class="changed_modified_5_0">Replay the manipulations recorded by {@link #saveView}, in the order in which
-     * the application performed them: ensure that removed components are removed, that added components are added, and
-     * that moved components are at the recorded parent, facet name and index among their siblings. A component that the
-     * view build already produced at its recorded position must not be added a second time.</span>
+     * the application performed them: ensure that removed components are removed, that added components are added with
+     * the state recorded for them, and that moved components are at the recorded parent, facet name and index among
+     * their siblings. A component that the restoring build already produced at its recorded position must not be added
+     * a second time.</span>
      * </p>
      * </li>
      *
      * </ol>
      *
      * <p>
-     * The implementation must ensure that the {@link jakarta.faces.component.UIComponent#restoreState} method is called for
-     * each node in the tree, except for those that were programmatically deleted on the previous run through the lifecycle.
+     * The implementation must ensure that the {@link jakarta.faces.component.UIComponent#restoreState} method is called
+     * for each node in the tree, <span class="changed_modified_5_0">except for those the application removed after the
+     * view was built.</span>
      * </p>
      *
      * </div>

--- a/api/src/main/java/jakarta/faces/view/StateManagementStrategy.java
+++ b/api/src/main/java/jakarta/faces/view/StateManagementStrategy.java
@@ -66,12 +66,27 @@ public abstract class StateManagementStrategy {
      * <p>
      * Visit the tree using {@link jakarta.faces.component.UIComponent#visitTree}. For each node, call
      * {@link jakarta.faces.component.UIComponent#saveState}, saving the returned <code>Object</code> in a way such that it
-     * can be restored given only its client id. Special care must be taken to handle the case of components that were added
-     * or deleted programmatically during this lifecycle traversal, rather than by the VDL.
+     * can be restored given only its client id. <span class="changed_modified_5_0">Record, in addition, every component
+     * that the application added to, removed from or moved within the view after the view was built, so that
+     * {@link #restoreView} can reproduce those manipulations. For a move, record the new parent, the facet name if the
+     * component is a facet, and the index among its siblings.</span>
      * </p>
      * </li>
      *
      * </ol>
+     *
+     * <p class="changed_added_5_0">
+     * The manipulations must be recorded in the order in which the application performed them, and the recorded position
+     * must travel with the manipulation rather than with the component it applies to. The view build recreates the
+     * components it created at their declared position on every build, so information kept on such a component may be
+     * lost before the manipulation is replayed.
+     * </p>
+     *
+     * <p class="changed_added_5_0">
+     * A component whose manipulation the view build performs again on the next request need not be recorded, since the
+     * build reproduces it. This is the case for components added, removed or moved while the view is being built, for
+     * example from a listener for {@link jakarta.faces.event.PostAddToViewEvent}.
+     * </p>
      *
      * <p>
      * The implementation must ensure that the {@link jakarta.faces.component.UIComponent#saveState} method is called for
@@ -116,9 +131,12 @@ public abstract class StateManagementStrategy {
      *
      * <p>
      * Build the view from the markup. For all components in the view that do not have an explicitly assigned id in the
-     * markup, the values of those ids must be the same as on an initial request for this view. This view will not contain
-     * any components programmatically added during the previous lifecycle run, and it <b>will</b> contain components that
-     * were programmatically deleted on the previous lifecycle run. Both of these cases must be handled.
+     * markup, the values of those ids must be the same as on an initial request for this view.
+     * <span class="changed_modified_5_0">This view contains what the view build produces, which includes the components
+     * added, removed or moved while the view was being built. It does not reflect the manipulations the application
+     * performed after the view was built: components added afterwards are absent, components removed afterwards are
+     * present, and components moved afterwards are at their declared position. All of these cases must be
+     * handled.</span>
      * </p>
      *
      *
@@ -141,13 +159,10 @@ public abstract class StateManagementStrategy {
      *
      * <li>
      * <p>
-     * Ensure that any programmatically deleted components are removed.
-     * </p>
-     * </li>
-     *
-     * <li>
-     * <p>
-     * Ensure any programmatically added components are added.
+     * <span class="changed_modified_5_0">Replay the manipulations recorded by {@link #saveView}, in the order in which
+     * the application performed them: ensure that removed components are removed, that added components are added, and
+     * that moved components are at the recorded parent, facet name and index among their siblings. A component that the
+     * view build already produced at its recorded position must not be added a second time.</span>
      * </p>
      * </li>
      *

--- a/spec/src/main/asciidoc/ApplicationIntegration.adoc
+++ b/spec/src/main/asciidoc/ApplicationIntegration.adoc
@@ -2459,10 +2459,9 @@ is no state to save.
 
 The returned object must represent the entire
 state of the view, such that a request processing lifecycle can be run
-against it on postback. It is paired with the view the restore builds from
-the markup, which supplies the structure that state is restored over, so it
-is the state of that structure rather than a serialization of the component
-tree (see the javadocs for _StateManagementStrategy.saveView()_ and
+against it on postback. It is the state of the structure that the restoring
+build produces from the markup, not a serialization of the component tree
+(see the javadocs for _StateManagementStrategy.saveView()_ and
 _StateManagementStrategy.restoreView()_).
 Special care must be taken to guarantee that
 objects attached to component instances, such as listeners, converters,

--- a/spec/src/main/asciidoc/ApplicationIntegration.adoc
+++ b/spec/src/main/asciidoc/ApplicationIntegration.adoc
@@ -2459,7 +2459,12 @@ is no state to save.
 
 The returned object must represent the entire
 state of the view, such that a request processing lifecycle can be run
-against it on postback. Special care must be taken to guarantee that
+against it on postback. It is paired with the view the restore builds from
+the markup, which supplies the structure that state is restored over, so it
+is the state of that structure rather than a serialization of the component
+tree (see the javadocs for _StateManagementStrategy.saveView()_ and
+_StateManagementStrategy.restoreView()_).
+Special care must be taken to guarantee that
 objects attached to component instances, such as listeners, converters,
 and validators, are also saved. The _StateHolder_ interface is provided
 for this reason.

--- a/spec/src/main/asciidoc/ChangeLog.adoc
+++ b/spec/src/main/asciidoc/ChangeLog.adoc
@@ -15,6 +15,9 @@ This release contains the following backwards compatible changes:
 * Issue ID {issue_tracker_url}2238[2238] +
 Spec: correct the VDL type of the tag attributes that name a variable, and document the unused c:if scope attribute
 
+* Issue ID {issue_tracker_url}2234[2234] +
+Spec: specify how component tree manipulations are saved and restored, including moves
+
 * Issue ID {issue_tracker_url}2227[2227] +
 Spec: correct h:doctype tag attributes and clarify rendering of the system identifier
 

--- a/spec/src/main/asciidoc/ChangeLog.adoc
+++ b/spec/src/main/asciidoc/ChangeLog.adoc
@@ -16,7 +16,7 @@ This release contains the following backwards compatible changes:
 Spec: correct the VDL type of the tag attributes that name a variable, and document the unused c:if scope attribute
 
 * Issue ID {issue_tracker_url}2234[2234] +
-Spec: specify how component tree manipulations are saved and restored, including moves
+Spec: specify that Restore View returns the view that was saved, including component tree moves and build time decisions
 
 * Issue ID {issue_tracker_url}2227[2227] +
 Spec: correct h:doctype tag attributes and clarify rendering of the system identifier

--- a/spec/src/main/asciidoc/RequestProcessingLifecycle.adoc
+++ b/spec/src/main/asciidoc/RequestProcessingLifecycle.adoc
@@ -632,10 +632,10 @@ that are unique within the scope of the closest parent _NamingContainer_
 component. The value of the _rendersChildren_ property is handled as
 expected, and may be either _true_ or __false__.
 
-* The build which precedes Render Response,
-the _rendering build_, produces the view that is saved. The build which
-recovers that view on the next request, the _restoring build_, produces it
-again from the same markup.
+* The build which this phase performs before
+publishing _PreRenderViewEvent_, the _rendering build_, produces the view
+that is saved. The build which recovers that view on the next request, the
+_restoring build_, produces it again from the same markup.
 
 * Manipulating the component tree while the
 view is being built is performed again by the restoring build, and
@@ -649,39 +649,6 @@ not performed again by a build, so the implementation carries every such
 addition, removal and move in the saved state (see the javadocs for
 _StateManagementStrategy.saveView()_), at a cost in both the size of that
 state and the work of every subsequent request.
-
-* Page authors are therefore recommended to
-express conditional content with the _rendered_ attribute on a statically
-built subtree, and, where the tree genuinely has to be manipulated, to do
-so while the view is being built: with the Jakarta Tags, such as _<c:if>_
-and _<c:forEach>_, or from a listener of _PostAddToViewEvent_, registered
-for example with _<f:event type="postAddToView">_. Binding a component to a
-bean property with the _binding_ attribute and manipulating it from there
-is the most common unintended way of manipulating it afterwards.
-
-* The two build time options differ in when
-they decide. A build time conditional or iteration is evaluated by the
-rendering build, so it observes whatever the request has done to the model
-by then; the cost is that such a view is built twice per postback. A
-listener of _PostAddToViewEvent_ runs once per request, in the restoring
-build, so it decides before the model is updated and before any action is
-invoked, and no later build of that view runs it again. A tag handler an
-application provides is run by both builds and decides again in each: one
-that decides from the model must reproduce in the restoring build the
-decision it reached in the rendering build, or it builds a different
-subtree from the one that was rendered.
-
-* For the build time conditions the
-implementation provides, the restoring build reproduces the decisions the
-rendering build reached, and the rendering build evaluates them again (see
-the javadocs for _StateManagementStrategy.restoreView()_). A page author
-therefore does not have to keep the value such a condition depends on alive
-across the postback. The items an iteration was rendered over are the
-exception, since its rows read their element from those items rather than
-from the state: where the items no longer hold them, the value submitted for
-such a row reaches nothing that outlives the request. Holding them in a
-_@ViewScoped_ bean, or recomputing them from the relevant request parameters
-in the _@PostConstruct_ of a _@RequestScoped_ one, is what keeps them.
 
 * After any dynamic component manipulations have
 been completed, any resources that have been added to the UIViewRoot,
@@ -715,6 +682,49 @@ _StateManager._ This state information must be made accessible on a
 subsequent request, so that the _Restore View_ can access it.
 For more on __StateManager__, see <<ApplicationIntegration.adoc#a4140,State
 Saving Methods>>.
+
+The following is guidance for page authors.
+It is not a requirement on the implementation.
+
+* Express conditional content with the
+_rendered_ attribute on a statically built subtree, and, where the tree
+genuinely has to be manipulated, do so while the view is being built: with
+the Jakarta Tags, such as _<c:if>_ and _<c:forEach>_, or from a listener
+of _PostAddToViewEvent_, registered for example with
+_<f:event type="postAddToView">_. Binding a component to a bean property
+with the _binding_ attribute and manipulating it from there is the most
+common unintended way of manipulating it afterwards.
+
+* The two build time options differ in when
+they decide. A _build time condition_ is an expression in a tag attribute
+that decides what components a build produces, such as the test of a
+conditional or the items of an iteration. It is evaluated by the rendering
+build, so it observes whatever the request has done to the model by then;
+the cost is that such a view is built twice per postback. A listener of
+_PostAddToViewEvent_ runs when the component it is registered on is added
+to the view, and a build which finds that component already there does not
+run it again. On a postback that is normally the restoring build, so it
+decides before the model is updated and before any action is invoked; on an
+initial request, and for a component a changed build time condition makes
+the rendering build the first to produce, it is the rendering build. A tag
+handler an application provides is run by both builds and decides again in
+each: one that decides from the model must reproduce in the restoring build
+the decision it reached in the rendering build, or it builds a different
+subtree from the one that was rendered.
+
+* For the build time conditions the
+implementation provides, the restoring build reproduces the decisions the
+rendering build reached (see the javadocs for
+_StateManagementStrategy.restoreView()_), so a page author does not have to
+keep the value such a condition depends on alive for the restore. The
+rendering build does evaluate it again, so a value that is gone by then
+changes the view that is rendered. The items an iteration was rendered over
+are a further exception, since its rows read their element from those items
+rather than from the state: where the items no longer hold them, the value
+submitted for such a row reaches nothing that outlives the request. Holding
+them in a _@ViewScoped_ bean, or recomputing them from the relevant request
+parameters in the _@PostConstruct_ of a _@RequestScoped_ one, is what keeps
+them.
 
 [[a480]]
 ===== Render Response Partial Processing

--- a/spec/src/main/asciidoc/RequestProcessingLifecycle.adoc
+++ b/spec/src/main/asciidoc/RequestProcessingLifecycle.adoc
@@ -632,46 +632,56 @@ that are unique within the scope of the closest parent _NamingContainer_
 component. The value of the _rendersChildren_ property is handled as
 expected, and may be either _true_ or __false__.
 
+* The build which precedes Render Response,
+the _rendering build_, produces the view that is saved. The build which
+recovers that view on the next request, the _restoring build_, produces it
+again from the same markup.
+
 * Manipulating the component tree while the
-view is being built is performed again by every subsequent build of that
-view, and therefore needs nothing in the saved state. This is the case for
-the templating system itself (such as Facelets), for tag handlers, for
+view is being built is performed again by the restoring build, and
+therefore needs nothing in the saved state. This is the case for the
+templating system itself (such as Facelets), for tag handlers, for
 listeners of _PostAddToViewEvent_, and for the relocations the
 implementation performs itself, such as moving component resources to the
 head of the view. Manipulating the tree after the view has been built, for
 example from an action listener or a listener of _PreRenderViewEvent_, is
-not performed again by the build, so the implementation carries every such
+not performed again by a build, so the implementation carries every such
 addition, removal and move in the saved state (see the javadocs for
 _StateManagementStrategy.saveView()_), at a cost in both the size of that
-state and the work of every subsequent request. Page authors are therefore
-recommended to express conditional content with the _rendered_ attribute on
-a statically built subtree, and, where the tree genuinely has to be
-manipulated, to do so while the view is being built: with the Jakarta Tags,
-such as _<c:if>_ and _<c:forEach>_, with a custom tag handler, or from a
-listener of _PostAddToViewEvent_, registered for example with
-_<f:event type="postAddToView">_. These two differ in when they decide. A
-build-time conditional or iteration is evaluated by the build that precedes
-rendering, so it observes whatever the request has done to the model by
-then; the cost is that such a view is built twice per postback. A listener
-of _PostAddToViewEvent_ runs once per request, while the view is restored,
-so it decides before the model is updated and before any action is invoked,
-and it is not run again by a later build of the same view. Binding a
-component to a bean property with the _binding_ attribute and manipulating
-it from there is the most common unintended way of manipulating it
-afterwards.
+state and the work of every subsequent request.
 
-* Whether the build which restores a view
-evaluates its build-time conditions again, or reproduces the values they had
-in the build which rendered that view, is left to the implementation (see the
-javadocs for _StateManagementStrategy.restoreView()_). A page author
-therefore has to ensure that such a condition evaluates over a value which
-survives the postback, by holding it in a _@ViewScoped_ bean or by
-recomputing it from the relevant request parameters in the _@PostConstruct_
-of a _@RequestScoped_ one, and that the items an iteration was rendered over
-still hold its rows. Where that does not hold, the restored view is not the
-view that was submitted: the state saved for a component the build does not
-produce is restored into nothing, and a value submitted for it is decoded by
-nothing.
+* Page authors are therefore recommended to
+express conditional content with the _rendered_ attribute on a statically
+built subtree, and, where the tree genuinely has to be manipulated, to do
+so while the view is being built: with the Jakarta Tags, such as _<c:if>_
+and _<c:forEach>_, or from a listener of _PostAddToViewEvent_, registered
+for example with _<f:event type="postAddToView">_. Binding a component to a
+bean property with the _binding_ attribute and manipulating it from there
+is the most common unintended way of manipulating it afterwards.
+
+* The two build time options differ in when
+they decide. A build time conditional or iteration is evaluated by the
+rendering build, so it observes whatever the request has done to the model
+by then; the cost is that such a view is built twice per postback. A
+listener of _PostAddToViewEvent_ runs once per request, in the restoring
+build, so it decides before the model is updated and before any action is
+invoked, and no later build of that view runs it again. A tag handler an
+application provides is run by both builds and decides again in each: one
+that decides from the model must reproduce in the restoring build the
+decision it reached in the rendering build, or it builds a different
+subtree from the one that was rendered.
+
+* For the build time conditions the
+implementation provides, the restoring build reproduces the decisions the
+rendering build reached, and the rendering build evaluates them again (see
+the javadocs for _StateManagementStrategy.restoreView()_). A page author
+therefore does not have to keep the value such a condition depends on alive
+across the postback. The items an iteration was rendered over are the
+exception, since its rows read their element from those items rather than
+from the state: where the items no longer hold them, the value submitted for
+such a row reaches nothing that outlives the request. Holding them in a
+_@ViewScoped_ bean, or recomputing them from the relevant request parameters
+in the _@PostConstruct_ of a _@RequestScoped_ one, is what keeps them.
 
 * After any dynamic component manipulations have
 been completed, any resources that have been added to the UIViewRoot,

--- a/spec/src/main/asciidoc/RequestProcessingLifecycle.adoc
+++ b/spec/src/main/asciidoc/RequestProcessingLifecycle.adoc
@@ -632,6 +632,34 @@ that are unique within the scope of the closest parent _NamingContainer_
 component. The value of the _rendersChildren_ property is handled as
 expected, and may be either _true_ or __false__.
 
+* Manipulating the component tree while the
+view is being built is performed again by every subsequent build of that
+view, and therefore needs nothing in the saved state. This is the case for
+the templating system itself (such as Facelets), for tag handlers, for
+listeners of _PostAddToViewEvent_, and for the relocations the
+implementation performs itself, such as moving component resources to the
+head of the view. Manipulating the tree after the view has been built, for
+example from an action listener or a listener of _PreRenderViewEvent_, is
+not performed again by the build, so the implementation carries every such
+addition, removal and move in the saved state (see the javadocs for
+_StateManagementStrategy.saveView()_), at a cost in both the size of that
+state and the work of every subsequent request. Page authors are therefore
+recommended to express conditional content with the _rendered_ attribute on
+a statically built subtree, and, where the tree genuinely has to be
+manipulated, to do so while the view is being built: with the Jakarta Tags,
+such as _<c:if>_ and _<c:forEach>_, with a custom tag handler, or from a
+listener of _PostAddToViewEvent_, registered for example with
+_<f:event type="postAddToView">_. These two differ in when they decide. A
+build-time conditional or iteration is evaluated again whenever the view is
+built, which includes the build that precedes rendering, so it observes
+whatever the request has done to the model by then; the cost is that such a
+view is built twice per postback. A listener of _PostAddToViewEvent_ runs
+once per request, while the view is restored, so it decides before the
+model is updated and before any action is invoked, and it is not run again
+by a later build of the same view. Binding a component to a bean property
+with the _binding_ attribute and manipulating it from there is the most
+common unintended way of manipulating it afterwards.
+
 * After any dynamic component manipulations have
 been completed, any resources that have been added to the UIViewRoot,
 such as scripts, images, or stylesheets, and any inline images, should be

--- a/spec/src/main/asciidoc/RequestProcessingLifecycle.adoc
+++ b/spec/src/main/asciidoc/RequestProcessingLifecycle.adoc
@@ -650,15 +650,28 @@ manipulated, to do so while the view is being built: with the Jakarta Tags,
 such as _<c:if>_ and _<c:forEach>_, with a custom tag handler, or from a
 listener of _PostAddToViewEvent_, registered for example with
 _<f:event type="postAddToView">_. These two differ in when they decide. A
-build-time conditional or iteration is evaluated again whenever the view is
-built, which includes the build that precedes rendering, so it observes
-whatever the request has done to the model by then; the cost is that such a
-view is built twice per postback. A listener of _PostAddToViewEvent_ runs
-once per request, while the view is restored, so it decides before the
-model is updated and before any action is invoked, and it is not run again
-by a later build of the same view. Binding a component to a bean property
-with the _binding_ attribute and manipulating it from there is the most
-common unintended way of manipulating it afterwards.
+build-time conditional or iteration is evaluated by the build that precedes
+rendering, so it observes whatever the request has done to the model by
+then; the cost is that such a view is built twice per postback. A listener
+of _PostAddToViewEvent_ runs once per request, while the view is restored,
+so it decides before the model is updated and before any action is invoked,
+and it is not run again by a later build of the same view. Binding a
+component to a bean property with the _binding_ attribute and manipulating
+it from there is the most common unintended way of manipulating it
+afterwards.
+
+* Whether the build which restores a view
+evaluates its build-time conditions again, or reproduces the values they had
+in the build which rendered that view, is left to the implementation (see the
+javadocs for _StateManagementStrategy.restoreView()_). A page author
+therefore has to ensure that such a condition evaluates over a value which
+survives the postback, by holding it in a _@ViewScoped_ bean or by
+recomputing it from the relevant request parameters in the _@PostConstruct_
+of a _@RequestScoped_ one, and that the items an iteration was rendered over
+still hold its rows. Where that does not hold, the restored view is not the
+view that was submitted: the state saved for a component the build does not
+produce is restored into nothing, and a value submitted for it is decoded by
+nothing.
 
 * After any dynamic component manipulations have
 been completed, any resources that have been added to the UIViewRoot,


### PR DESCRIPTION
Closes #2234.

Both Mojarra and MyFaces already handle manipulations made while the view is being built as intended, so this is a gap in the specification rather than a defect report against either implementation. The one exception is a Mojarra corner case, where additions made from a listener attached to the view root were recorded as dynamic actions and saved although the build reproduces them, fixed in eclipse-ee4j/mojarra#5959.

`StateManagementStrategy#restoreView` claimed the rebuilt view "will not contain any components programmatically added during the previous lifecycle run". That is false for anything added while the view was being built — the build runs the same tag handlers and `postAddToView` listeners again and produces those components with it — and an implementation following it literally adds such a component twice. The text conflated how a component was created, through the Java API rather than the VDL, with when; only the latter decides whether the build reproduces it.

Moves had no contract at all. A moved component is neither added nor deleted from the restore's point of view: it is in the rebuilt tree and in the saved state, only at a different parent, facet name or index. Nothing required the restore to reproduce its position, which made eclipse-ee4j/mojarra#5861 — a moved facelet-created child rendering in the wrong position after every postback — a judgment call rather than a violation.

What the contract now says:

- The rebuilt view reflects what the build produces, including manipulations made while the view was being built. Only manipulations made after the build come from the saved state: components added afterwards are absent, components removed afterwards are present, components moved afterwards are at their declared position.
- `saveView` records additions, removals and moves made after the build, a move carrying parent, facet name and index among siblings.
- Manipulations are replayed in the order the application performed them, and a component the build already produced at its recorded position is not added a second time.
- The recorded position travels with the manipulation, not with the component: the build recreates the components it created at their declared position on every build, so anything kept on such an instance can be lost between save and replay. That is the mechanism behind mojarra#5861.
- A manipulation the build performs again need not be recorded at all, which licenses skipping the state for build-time additions — see eclipse-ee4j/mojarra#5959.

`RequestProcessingLifecycle` gains the author-facing half, non-normative: prefer `rendered` on a statically built subtree; manipulate the tree during the build if it must be manipulated; and the two build-time options differ in when they decide — a Jakarta Tags conditional is re-evaluated by the build that precedes rendering, so it sees what the request did to the model, at the cost of two builds per postback, while a `postAddToView` listener runs once during Restore View and is not run again. `binding` is named as the common unintended way of landing in the expensive case.

`StateManagementStrategy#restoreView` now also states what the build time conditions of the build contribute, which is the second axis of #2234 and was unspecified in the same way. What the build produces follows from the test of a conditional, the branch of a choice, the range or the items of an iteration and the path of a dynamic inclusion, and nothing said whether the build which restores a view evaluates those against the current model or reproduces the values the render had. The implementations differ observably: Mojarra evaluates, MyFaces replays a decision it saved in a `FaceletState`, and eclipse-ee4j/mojarra#5965 adds the replay to Mojarra under a context parameter.

Restore View now returns the view that was saved: the build which restores a view reproduces what those conditions produced in the build which rendered it, and the build which precedes Render Response evaluates them again, so it is that build which produces the view the current state of the model asks for, and which is saved in turn. Leaving it open leaves the restore free to return another view than the one that was saved, and what that costs the application is a component the build does not produce which is not one the application removed: the state saved for it is restored into nothing, and a value submitted for it is decoded by nothing.

Failing to reproduce one must not fail the request. An iteration over items which no longer hold the elements its rows were rendered over is the case which cannot be reproduced from saved state at all — the components it produced read their item from those items, so full state saving materializing them out of the serialized tree fails the request rather than restoring anything. `restoreView` returns the view it could build, and a component of it which the model no longer backs is answered for by the phase which reads that model. Measurements for all four combinations of implementation and strategy are in #2234.

`RequestProcessingLifecycle` claimed that a build time conditional or iteration "is evaluated again whenever the view is built", which is false for the build which restores a view, and gains the author facing half: the items an iteration was rendered over remain theirs to keep, since its rows read their element from those items rather than from the state. The value a conditional tests is not, which is what the contract guarantees.

`ApplicationIntegration`'s "the returned object must represent the entire state of the view, such that a request processing lifecycle can be run against it on postback" is scoped to the structure the restore builds from the markup. #2232 re-pointed that sentence from the removed `StateManager.saveView` onto `StateManagementStrategy.saveView`, which turns the last of the legacy round trip text into live contract on a live method unless it says what it pairs with.

Verification: api builds, spec renders.

🤖 Generated with Claude Opus 5



