### PR TITLE
Assert what a build time conditional does across a postback

### DIFF
--- a/tck/faces20/jstl/src/main/java/ee/jakarta/tck/faces/faces20/jstl/ChoosePostbackBean.java
+++ b/tck/faces20/jstl/src/main/java/ee/jakarta/tck/faces/faces20/jstl/ChoosePostbackBean.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2026 Contributors to Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.faces.faces20.jstl;
+
+import java.io.Serializable;
+
+import jakarta.enterprise.context.SessionScoped;
+import jakarta.inject.Named;
+
+/**
+ * Backs the {@code c:when} tests of {@code cwo/choose-postback.xhtml}. Session scoped so the branch an action
+ * selected outlives the postback that selected it; a branch no {@code c:when} matches selects the
+ * {@code c:otherwise}.
+ */
+@Named
+@SessionScoped
+public class ChoosePostbackBean implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private String branch = "alpha";
+    private int postbacks;
+
+    public void setBranch(String branch) {
+        this.branch = branch;
+        postbacks++;
+    }
+
+    public String getBranch() {
+        return branch;
+    }
+
+    public void submit() {
+        postbacks++;
+    }
+
+    public int getPostbacks() {
+        return postbacks;
+    }
+}

--- a/tck/faces20/jstl/src/main/java/ee/jakarta/tck/faces/faces20/jstl/IfPostbackBean.java
+++ b/tck/faces20/jstl/src/main/java/ee/jakarta/tck/faces/faces20/jstl/IfPostbackBean.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2026 Contributors to Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.faces.faces20.jstl;
+
+import java.io.Serializable;
+
+import jakarta.enterprise.context.SessionScoped;
+import jakarta.inject.Named;
+
+/**
+ * Backs the {@code c:if} test of {@code iftag/if-postback.xhtml}. Session scoped so the condition an action set
+ * outlives the postback that set it, and every action counts itself so a postback is observable in the response
+ * even when it changes nothing else.
+ */
+@Named
+@SessionScoped
+public class IfPostbackBean implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private boolean shown = true;
+    private int postbacks;
+
+    public void setShown(boolean shown) {
+        this.shown = shown;
+        postbacks++;
+    }
+
+    public boolean isShown() {
+        return shown;
+    }
+
+    public void submit() {
+        postbacks++;
+    }
+
+    public int getPostbacks() {
+        return postbacks;
+    }
+}

--- a/tck/faces20/jstl/src/main/webapp/cwo/choose-postback.xhtml
+++ b/tck/faces20/jstl/src/main/webapp/cwo/choose-postback.xhtml
@@ -1,0 +1,49 @@
+<!--
+
+    Copyright (c) 2026 Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+<html
+      xmlns:h="jakarta.faces.html"
+      xmlns:c="jakarta.tags.core">
+
+    <h:head>
+        <title>ChoosePostback</title>
+    </h:head>
+    <h:body>
+        <h:form id="form">
+            <c:choose>
+                <c:when test="#{choosePostbackBean.branch eq 'alpha'}">
+                    <h:outputText id="alpha" value="alpha" />
+                    <h:inputText id="alphaInput" />
+                </c:when>
+                <c:when test="#{choosePostbackBean.branch eq 'bravo'}">
+                    <h:outputText id="bravo" value="bravo" />
+                    <h:inputText id="bravoInput" />
+                </c:when>
+                <c:otherwise>
+                    <h:outputText id="otherwise" value="otherwise" />
+                </c:otherwise>
+            </c:choose>
+
+            <h:commandButton id="alphaButton" value="alpha" action="#{choosePostbackBean.setBranch('alpha')}" />
+            <h:commandButton id="bravoButton" value="bravo" action="#{choosePostbackBean.setBranch('bravo')}" />
+            <h:commandButton id="zuluButton" value="zulu" action="#{choosePostbackBean.setBranch('zulu')}" />
+            <h:commandButton id="submit" value="submit" action="#{choosePostbackBean.submit}" />
+
+            <h:outputText id="count" value="postbacks=#{choosePostbackBean.postbacks}" />
+        </h:form>
+    </h:body>
+</html>

--- a/tck/faces20/jstl/src/main/webapp/iftag/if-postback.xhtml
+++ b/tck/faces20/jstl/src/main/webapp/iftag/if-postback.xhtml
@@ -1,0 +1,39 @@
+<!--
+
+    Copyright (c) 2026 Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+<html
+      xmlns:h="jakarta.faces.html"
+      xmlns:c="jakarta.tags.core">
+
+    <h:head>
+        <title>IfPostback</title>
+    </h:head>
+    <h:body>
+        <h:form id="form">
+            <c:if test="#{ifPostbackBean.shown}">
+                <h:outputText id="conditional" value="conditional" />
+                <h:inputText id="input" />
+            </c:if>
+
+            <h:commandButton id="show" value="show" action="#{ifPostbackBean.setShown(true)}" />
+            <h:commandButton id="hide" value="hide" action="#{ifPostbackBean.setShown(false)}" />
+            <h:commandButton id="submit" value="submit" action="#{ifPostbackBean.submit}" />
+
+            <h:outputText id="count" value="postbacks=#{ifPostbackBean.postbacks}" />
+        </h:form>
+    </h:body>
+</html>

--- a/tck/faces20/jstl/src/test/java/ee/jakarta/tck/faces/faces20/jstl/ChoosePostbackIT.java
+++ b/tck/faces20/jstl/src/test/java/ee/jakarta/tck/faces/faces20/jstl/ChoosePostbackIT.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2026 Contributors to Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.faces.faces20.jstl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.By;
+
+import ee.jakarta.tck.faces.util.selenium.BaseITNG;
+import ee.jakarta.tck.faces.util.selenium.WebPage;
+
+/**
+ * The branch a {@code c:choose} builds follows its tests on every postback: it stays in place with its state intact
+ * for as long as the same {@code c:when} matches, and is replaced by the branch that matches once one does not,
+ * including the {@code c:otherwise} when none matches.
+ */
+class ChoosePostbackIT extends BaseITNG {
+
+    /**
+     * A postback that leaves the matching {@code c:when} matching must leave the branch it built in place, with each
+     * component keeping its client id and the value submitted to it.
+     *
+     * @see jakarta.faces.component.UIComponent#getClientId()
+     */
+    @Test
+    void unchangedTestRetainsBranchAndItsState() {
+        WebPage page = alpha();
+        int postbacks = postbacks(page);
+
+        page.findElement(By.id("form:alphaInput")).sendKeys("typed");
+        page.guardHttp(page.findElement(By.id("form:submit"))::click);
+
+        assertEquals(postbacks + 1, postbacks(page), "the postback executed");
+        assertEquals("alpha", page.findElement(By.id("form:alpha")).getText(), "the branch survived");
+        assertEquals("typed", page.findElement(By.id("form:alphaInput")).getAttribute("value"), "the submitted value survived");
+    }
+
+    /**
+     * A postback whose action makes another {@code c:when} match must build that branch instead, and one whose
+     * action leaves no {@code c:when} matching must build the {@code c:otherwise}.
+     */
+    @Test
+    void changedTestSwitchesBranch() {
+        WebPage page = alpha();
+
+        page.guardHttp(page.findElement(By.id("form:bravoButton"))::click);
+        assertEquals("bravo", page.findElement(By.id("form:bravo")).getText(), "the second when matches");
+        assertTrue(page.findElements(By.id("form:alpha")).isEmpty(), "the first branch is gone");
+
+        page.guardHttp(page.findElement(By.id("form:zuluButton"))::click);
+        assertEquals("otherwise", page.findElement(By.id("form:otherwise")).getText(), "no when matches");
+        assertTrue(page.findElements(By.id("form:bravo")).isEmpty(), "the second branch is gone");
+
+        page.guardHttp(page.findElement(By.id("form:alphaButton"))::click);
+        assertEquals("alpha", page.findElement(By.id("form:alpha")).getText(), "the first when matches again");
+        assertEquals(1, page.findElements(By.id("form:alphaInput")).size(), "its input is back, exactly once");
+    }
+
+    /**
+     * The page under the first matching {@code c:when}, reached by an action rather than by the initial value, so the
+     * outcome does not depend on what an earlier test left in the session.
+     */
+    private WebPage alpha() {
+        WebPage page = getPage("cwo/choose-postback.xhtml");
+        page.guardHttp(page.findElement(By.id("form:alphaButton"))::click);
+        assertEquals("alpha", page.findElement(By.id("form:alpha")).getText(), "the first branch is built");
+        return page;
+    }
+
+    private static int postbacks(WebPage page) {
+        return Integer.parseInt(page.findElement(By.id("form:count")).getText().replace("postbacks=", ""));
+    }
+}

--- a/tck/faces20/jstl/src/test/java/ee/jakarta/tck/faces/faces20/jstl/IfPostbackIT.java
+++ b/tck/faces20/jstl/src/test/java/ee/jakarta/tck/faces/faces20/jstl/IfPostbackIT.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2026 Contributors to Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.faces.faces20.jstl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.By;
+
+import ee.jakarta.tck.faces.util.selenium.BaseITNG;
+import ee.jakarta.tck.faces.util.selenium.WebPage;
+
+/**
+ * The subtree a {@code c:if} builds follows its test on every postback: it stays in place with its state intact for
+ * as long as the test holds, and appears and disappears as the test changes.
+ */
+class IfPostbackIT extends BaseITNG {
+
+    /**
+     * A postback that leaves the test true must leave the subtree it built in place, with each component keeping its
+     * client id and the value submitted to it.
+     *
+     * @see jakarta.faces.component.UIComponent#getClientId()
+     */
+    @Test
+    void unchangedTestRetainsSubtreeAndItsState() {
+        WebPage page = shown();
+        int postbacks = postbacks(page);
+
+        page.findElement(By.id("form:input")).sendKeys("typed");
+        page.guardHttp(page.findElement(By.id("form:submit"))::click);
+
+        assertEquals(postbacks + 1, postbacks(page), "the postback executed");
+        assertEquals("conditional", page.findElement(By.id("form:conditional")).getText(), "the subtree survived");
+        assertEquals("typed", page.findElement(By.id("form:input")).getAttribute("value"), "the submitted value survived");
+    }
+
+    /**
+     * A postback whose action makes the test false must remove the subtree, and one that makes it true again must
+     * build it back exactly once.
+     */
+    @Test
+    void changedTestRebuildsSubtree() {
+        WebPage page = shown();
+
+        page.guardHttp(page.findElement(By.id("form:hide"))::click);
+        assertTrue(page.findElements(By.id("form:conditional")).isEmpty(), "the subtree is gone");
+        assertTrue(page.findElements(By.id("form:input")).isEmpty(), "including its input");
+
+        page.guardHttp(page.findElement(By.id("form:show"))::click);
+        assertEquals("conditional", page.findElement(By.id("form:conditional")).getText(), "the subtree is back");
+        assertEquals(1, page.findElements(By.id("form:input")).size(), "including its input, exactly once");
+    }
+
+    /**
+     * The page under a true test, reached by an action rather than by the initial value, so the outcome does not
+     * depend on what an earlier test left in the session.
+     */
+    private WebPage shown() {
+        WebPage page = getPage("iftag/if-postback.xhtml");
+        page.guardHttp(page.findElement(By.id("form:show"))::click);
+        assertEquals("conditional", page.findElement(By.id("form:conditional")).getText(), "the subtree is built");
+        return page;
+    }
+
+    private static int postbacks(WebPage page) {
+        return Integer.parseInt(page.findElement(By.id("form:count")).getText().replace("postbacks=", ""));
+    }
+}


### PR DESCRIPTION
A `c:if` whose test still holds keeps the subtree it built, with each component keeping its client id and the value submitted to it, and builds that subtree back once the test holds again. A `c:choose` does the same for the branch its matching `c:when` built, switches to another branch when another `c:when` matches, and falls to the `c:otherwise` when none does.

faces20/jstl covered both tags with literal tests on an initial GET only, so neither the retention nor the rebuild had coverage across a postback. Each test drives the page into its starting branch with an action rather than relying on the initial value, so it does not depend on what an earlier test left in the session.

Green against mojarra master: `faces20/jstl` 27 tests.

Part of eclipse-ee4j/mojarra#5856

🤖 Generated with Claude Opus 5