### PR TITLE
Assert what a build time conditional inside a composite component does

### DIFF
--- a/tck/faces22/composite-component/src/main/java/ee/jakarta/tck/faces/faces22/composite_component/CompositeIfPostbackBean.java
+++ b/tck/faces22/composite-component/src/main/java/ee/jakarta/tck/faces/faces22/composite_component/CompositeIfPostbackBean.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2026 Contributors to Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.faces.faces22.composite_component;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+
+import jakarta.enterprise.context.SessionScoped;
+import jakarta.inject.Named;
+
+/**
+ * Backs the composite component of {@code composite-if-postback.xhtml}, whose {@code c:if} tests the list this passes
+ * as a composite component attribute. Session scoped so the list an action filled outlives the postback that filled it.
+ */
+@Named
+@SessionScoped
+public class CompositeIfPostbackBean implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private List<String> items = new ArrayList<>();
+
+    public List<String> getItems() {
+        return items;
+    }
+
+    public void load() {
+        items = List.of("alpha", "bravo", "charlie");
+    }
+
+    public void clear() {
+        items = new ArrayList<>();
+    }
+}

--- a/tck/faces22/composite-component/src/main/webapp/composite-if-postback.xhtml
+++ b/tck/faces22/composite-component/src/main/webapp/composite-if-postback.xhtml
@@ -1,0 +1,33 @@
+<!--
+
+    Copyright (c) 2026 Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+<html
+      xmlns:h="jakarta.faces.html"
+      xmlns:my="jakarta.faces.composite/compositeIfPostback">
+
+    <h:head>
+        <title>CompositeIfPostback</title>
+    </h:head>
+    <h:body>
+        <h:form id="form">
+            <my:panel id="panel" items="#{compositeIfPostbackBean.items}" />
+
+            <h:commandButton id="load" value="load" action="#{compositeIfPostbackBean.load}" />
+            <h:commandButton id="clear" value="clear" action="#{compositeIfPostbackBean.clear}" />
+        </h:form>
+    </h:body>
+</html>

--- a/tck/faces22/composite-component/src/main/webapp/resources/compositeIfPostback/panel.xhtml
+++ b/tck/faces22/composite-component/src/main/webapp/resources/compositeIfPostback/panel.xhtml
@@ -1,0 +1,33 @@
+<!--
+
+    Copyright (c) 2026 Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+<html
+      xmlns:h="jakarta.faces.html"
+      xmlns:c="jakarta.tags.core"
+      xmlns:composite="jakarta.faces.composite">
+
+    <composite:interface>
+        <composite:attribute name="items" required="true"/>
+    </composite:interface>
+
+    <composite:implementation>
+        <c:if test="#{not empty cc.attrs.items}">
+            <h:outputText id="conditional" value="items=#{cc.attrs.items.size()}" />
+        </c:if>
+    </composite:implementation>
+
+</html>

--- a/tck/faces22/composite-component/src/test/java/ee/jakarta/tck/faces/faces22/composite_component/CompositeIfPostbackIT.java
+++ b/tck/faces22/composite-component/src/test/java/ee/jakarta/tck/faces/faces22/composite_component/CompositeIfPostbackIT.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2026 Contributors to Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.faces.faces22.composite_component;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.By;
+
+import ee.jakarta.tck.faces.util.selenium.BaseITNG;
+import ee.jakarta.tck.faces.util.selenium.WebPage;
+
+/**
+ * A {@code c:if} inside a composite component follows a test over that component's own attributes on every postback,
+ * as one over any other expression does. The subtree it builds must appear on the very postback whose action made the
+ * test hold, and disappear on the one that made it stop holding.
+ */
+class CompositeIfPostbackIT extends BaseITNG {
+
+    /**
+     * The action fills the list the composite component attribute resolves to, so the subtree the {@code c:if} guards
+     * must be built into the response of that same postback.
+     *
+     * @see jakarta.faces.component.UIComponent#getCurrentCompositeComponent(jakarta.faces.context.FacesContext)
+     */
+    @Test
+    void conditionalOnCompositeAttributeIsBuiltOnTheSamePostbackThatMakesItHold() {
+        WebPage page = emptied();
+
+        page.guardHttp(page.findElement(By.id("form:load"))::click);
+
+        assertEquals("items=3", page.findElement(By.id("form:panel:conditional")).getText(), "the subtree is built");
+    }
+
+    /**
+     * Building the view from scratch with the list already filled must build that same subtree, which is what tells a
+     * failure of the postback tests apart from a composite component that does not render at all.
+     */
+    @Test
+    void conditionalOnCompositeAttributeIsBuiltOnAGetWithAFilledList() {
+        WebPage page = emptied();
+        page.guardHttp(page.findElement(By.id("form:load"))::click);
+
+        WebPage rebuilt = getPage("composite-if-postback.xhtml");
+
+        assertEquals("items=3", rebuilt.findElement(By.id("form:panel:conditional")).getText(), "the subtree is built");
+    }
+
+    /**
+     * The action empties that list, so the subtree must be gone from the response of that same postback.
+     */
+    @Test
+    void conditionalOnCompositeAttributeIsRemovedOnTheSamePostbackThatMakesItStopHolding() {
+        WebPage page = emptied();
+
+        page.guardHttp(page.findElement(By.id("form:load"))::click);
+        assertEquals("items=3", page.findElement(By.id("form:panel:conditional")).getText(), "the subtree is built");
+
+        page.guardHttp(page.findElement(By.id("form:clear"))::click);
+        assertTrue(page.findElements(By.id("form:panel:conditional")).isEmpty(), "the subtree is gone");
+    }
+
+    /**
+     * The page with the list emptied by an action rather than by its initial value, so the outcome does not depend on
+     * what an earlier test left in the session.
+     */
+    private WebPage emptied() {
+        WebPage page = getPage("composite-if-postback.xhtml");
+        page.guardHttp(page.findElement(By.id("form:clear"))::click);
+        assertTrue(page.findElements(By.id("form:panel:conditional")).isEmpty(), "nothing is built for an empty list");
+        return page;
+    }
+}


### PR DESCRIPTION
A `c:if` in the implementation of a composite component tests that component's own attributes, and the subtree it guards must follow that test on every postback: built into the response of the postback whose action made the test hold, and gone from the one whose action made it stop holding.

`conditionalOnCompositeAttributeIsBuiltOnAGetWithAFilledList` builds the same view from scratch with the test already holding, so a failure of the two postback tests is told apart from a composite component that does not render at all.

The distinction matters because `#{cc.attrs.items}` resolves from the composite component stack rather than from a variable. An implementation re-evaluating such an expression outside a view build resolves `cc` to null, and `not empty null` is a plain `false` rather than a failure — so a `c:if` that should have opened after an action can silently stay closed, and only open on the second submit. Verified: these two tests fail on mojarra without eclipse-ee4j/mojarra#5960 and pass with it, while the third passes either way.

🤖 Generated with Claude Opus 5