### PR TITLE
Correct the VDL type of the tag attributes that name a variable

### DIFF
--- a/api/src/main/vdldoc/faces.core.taglib.xml
+++ b/api/src/main/vdldoc/faces.core.taglib.xml
@@ -897,7 +897,6 @@ for <code>@NamedEvent</code>.</p>
             ]]></description>
             <name>var</name>
             <required>true</required>
-            <type>java.lang.String</type>
         </attribute>
     </tag>
     <tag>

--- a/api/src/main/vdldoc/faces.facelets.taglib.xml
+++ b/api/src/main/vdldoc/faces.facelets.taglib.xml
@@ -805,7 +805,6 @@ attribute must be an absolute path starting with "/".</span>
             ]]></description>
             <name>name</name>
             <required>true</required>
-            <type>java.lang.String</type>
         </attribute>
         <attribute>
             <description><![CDATA[
@@ -965,7 +964,6 @@ attribute must be an absolute path starting with "/".</span>
             </description>
             <name>var</name>
             <required>true</required>
-            <type>java.lang.String</type>
         </attribute>
         <attribute>
             <description>
@@ -990,7 +988,6 @@ attribute must be an absolute path starting with "/".</span>
             </description>
             <name>varStatus</name>
             <required>false</required>
-            <type>java.lang.String</type>
         </attribute>
         <attribute>
             <description>

--- a/api/src/main/vdldoc/tags.core.taglib.xml
+++ b/api/src/main/vdldoc/tags.core.taglib.xml
@@ -42,7 +42,6 @@
             ]]></description>
             <name>var</name>
             <required>false</required>
-            <type>java.lang.String</type>
         </attribute>
     </tag>
     <tag>
@@ -79,15 +78,13 @@
             ]]></description>
             <name>var</name>
             <required>false</required>
-            <type>java.lang.String</type>
         </attribute>
         <attribute>
             <description><![CDATA[
-                Scope for var.
+                Scope for var. <span class="changed_added_5_0">This attribute is not used: the variable is always exported into the facelet scope.</span>
             ]]></description>
             <name>scope</name>
             <required>false</required>
-            <type>java.lang.String</type>
         </attribute>
     </tag>
     <tag>
@@ -151,7 +148,6 @@
             ]]></description>
             <name>var</name>
             <required>false</required>
-            <type>java.lang.String</type>
         </attribute>
         <attribute>
             <description><![CDATA[
@@ -163,7 +159,6 @@
             ]]></description>
             <name>varStatus</name>
             <required>false</required>
-            <type>java.lang.String</type>
         </attribute>
     </tag>
     <tag>
@@ -212,7 +207,6 @@
             ]]></description>
             <name>var</name>
             <required>false</required>
-            <type>java.lang.String</type>
         </attribute>
         <attribute>
             <description><![CDATA[
@@ -246,7 +240,6 @@
             ]]></description>
             <name>scope</name>
             <required>false</required>
-            <type>java.lang.String</type>
         </attribute>
     </tag>
     <tag>

--- a/spec/src/main/asciidoc/ChangeLog.adoc
+++ b/spec/src/main/asciidoc/ChangeLog.adoc
@@ -12,6 +12,9 @@ pre-Jakarta Faces specification under the JCP.
 
 This release contains the following backwards compatible changes:
 
+* Issue ID {issue_tracker_url}2238[2238] +
+Spec: correct the VDL type of the tag attributes that name a variable, and document the unused c:if scope attribute
+
 * Issue ID {issue_tracker_url}2227[2227] +
 Spec: correct h:doctype tag attributes and clarify rendering of the system identifier
 


### PR DESCRIPTION
A tag library declares an attribute literal-only by omitting the type: vdldoc renders an attribute that has a `<type>` as `jakarta.el.ValueExpression` *(must evaluate to X)*, and one that has neither `<type>` nor `<method-signature>` as a plain `java.lang.String`.

Ten attributes that name a variable the page then resolves by that name declared a type, and were therefore documented as value expressions:

| taglib | tag | attributes |
| - | - | - |
| faces.facelets.taglib.xml | `ui:repeat` | `var`, `varStatus` |
| faces.facelets.taglib.xml | `ui:param` | `name` |
| faces.core.taglib.xml | `f:loadBundle` | `var` |
| tags.core.taglib.xml | `c:catch` | `var` |
| tags.core.taglib.xml | `c:if` | `var`, `scope` |
| tags.core.taglib.xml | `c:forEach` | `var`, `varStatus` |
| tags.core.taglib.xml | `c:set` | `var`, `scope` |

For the Jakarta Tags core tags this also contradicted Jakarta Tags itself, whose TLD declares `var` and `scope` with `rtexprvalue="false"`. The attributes that are `rtexprvalue="true"` there — `value`, `target`, `property`, `items`, `begin`, `end`, `step`, `test` — keep their type and are untouched.

The comparable attributes were already declared without a type, each rejected at runtime by a `setValueExpression` that throws `IllegalArgumentException`: `h:dataTable var`, `f:selectItems var`, `f:selectItemGroups var`, `f:importConstants var`, `f:websocket channel` and `f:websocket scope`.

`f:facet name` deliberately keeps its type: `jakarta.faces.view.facelets.FacetHandler` declares `getFacetName(FaceletContext)`, so evaluating that name is contemplated by the API.

`c:if scope` gains a note rather than a deprecation. The attribute belongs to Jakarta Tags rather than to this specification, so it stays declared; the documentation now says what it does here, which is nothing — Mojarra's and MyFaces' `IfHandler` both export the variable into the facelet scope and neither has a `scope` field at all.

Verified by generating the VDL documentation with vdldoc standalone: the corrected attributes now render Type `java.lang.String`, and the `c:if scope` row carries its note with the `changed_added_5_0` highlighting.

The implementation side of `ui:repeat` is eclipse-ee4j/mojarra#5962, where an expression in `var` is accepted and then silently ignored rather than rejected.

Closes #2238

🤖 Generated with Claude Opus 5