### PR TITLE
Give the body element the events only it supports

### DIFF
--- a/api/src/main/java/jakarta/faces/component/html/HtmlBody.java
+++ b/api/src/main/java/jakarta/faces/component/html/HtmlBody.java
@@ -18,7 +18,7 @@
 package jakarta.faces.component.html;
 
 import static jakarta.faces.component.html.HtmlComponentUtils.handleAttribute;
-import static jakarta.faces.component.html.HtmlEvents.getHtmlDocumentElementEventNames;
+import static jakarta.faces.component.html.HtmlEvents.getHtmlBodyEventNames;
 
 import java.util.Collection;
 
@@ -578,7 +578,7 @@ public class HtmlBody extends UIOutput implements ClientBehaviorHolder {
 
     @Override
     public Collection<String> getEventNames() {
-        return getHtmlDocumentElementEventNames(getFacesContext());
+        return getHtmlBodyEventNames(getFacesContext());
     }
 
     @Override

--- a/api/src/main/java/jakarta/faces/component/html/HtmlDataTable.java
+++ b/api/src/main/java/jakarta/faces/component/html/HtmlDataTable.java
@@ -18,7 +18,7 @@
 package jakarta.faces.component.html;
 
 import static jakarta.faces.component.html.HtmlComponentUtils.handleAttribute;
-import static jakarta.faces.component.html.HtmlEvents.getHtmlBodyElementEventNames;
+import static jakarta.faces.component.html.HtmlEvents.getHtmlElementEventNames;
 
 import java.util.Collection;
 
@@ -936,7 +936,7 @@ public class HtmlDataTable extends UIData implements ClientBehaviorHolder {
 
     @Override
     public Collection<String> getEventNames() {
-        return getHtmlBodyElementEventNames(getFacesContext()); 
+        return getHtmlElementEventNames(getFacesContext()); 
     }
 
     @Override

--- a/api/src/main/java/jakarta/faces/component/html/HtmlEvents.java
+++ b/api/src/main/java/jakarta/faces/component/html/HtmlEvents.java
@@ -24,12 +24,17 @@ import jakarta.faces.event.BehaviorEvent.FacesComponentEvent;
  * These can be used to supply {@link ClientBehaviorHolder#getEventNames()} and {@link ClientBehaviorHolder#getDefaultEventName()}.
  * </p>
  * <p>
- * The events are split into two enums: {@link HtmlDocumentElementEvent} lists the events that fire on the element itself,
- * while {@link HtmlBodyElementEvent} lists the events that are also part of the HTML spec's <code>GlobalEventHandlers</code>
- * but have special behavior on the HTML <code>&lt;body&gt;</code> element where they are forwarded to the <code>Window</code> object
- * instead of firing on the element. Components that represent the HTML <code>&lt;body&gt;</code> element should use
- * {@link #getHtmlDocumentElementEventNames(FacesContext)} to avoid exposing these window-level events as component behavior events,
- * while all other components should use {@link #getHtmlBodyElementEventNames(FacesContext)} or one of its supersets.
+ * The events are split into three enums, following the three tables of the HTML spec:
+ * {@link HtmlElementEvent} lists the events which are supported by all HTML elements and fire on the element itself,
+ * {@link HtmlBodyEvent} lists the events which are supported by all HTML elements as well, but are forwarded to the
+ * <code>Window</code> object when they are declared on the HTML <code>&lt;body&gt;</code> element, and
+ * {@link HtmlWindowEvent} lists the events which are supported by the HTML <code>&lt;body&gt;</code> element only and
+ * always fire on the <code>Window</code> object.
+ * </p>
+ * <p>
+ * Components which represent the HTML <code>&lt;body&gt;</code> element should therefore use
+ * {@link #getHtmlBodyEventNames(FacesContext)}, while all other components should use
+ * {@link #getHtmlElementEventNames(FacesContext)} or one of its supersets.
  * </p>
  *
  * @since 5.0
@@ -37,10 +42,9 @@ import jakarta.faces.event.BehaviorEvent.FacesComponentEvent;
 public final class HtmlEvents {
 
     /**
-     * Events supported by all HTML document elements that always fire on the element itself.
-     * See {@link HtmlBodyElementEvent} for events that are forwarded to the <code>Window</code> object on the HTML <code>&lt;body&gt;</code> element.
+     * Events supported by all HTML elements which fire on the element itself.
      */
-    public enum HtmlDocumentElementEvent {
+    public enum HtmlElementEvent {
         abort,
         auxclick,
         beforeinput,
@@ -93,6 +97,7 @@ public final class HtmlEvents {
         progress,
         ratechange,
         reset,
+        scrollend,
         securitypolicyviolation,
         seeked,
         seeking,
@@ -109,23 +114,46 @@ public final class HtmlEvents {
     }
 
     /**
-     * Events from the HTML spec's <code>GlobalEventHandlers</code> that have special behavior on the HTML body element:
-     * instead of firing on the element itself, they are forwarded to the <code>Window</code> object.
-     * These events are valid on all HTML elements, but are listed separately here because of this distinction.
+     * Events supported by all HTML elements which are forwarded to the <code>Window</code> object instead of firing on
+     * the element itself when they are declared on the HTML <code>&lt;body&gt;</code> element.
      */
-    public enum HtmlBodyElementEvent {
+    public enum HtmlBodyEvent {
         blur,
         error,
         focus,
         load,
         resize,
-        scroll,
-        scrollend;
+        scroll;
+    }
+
+    /**
+     * Events supported by the HTML <code>&lt;body&gt;</code> element only, which always fire on the
+     * <code>Window</code> object.
+     */
+    public enum HtmlWindowEvent {
+        afterprint,
+        beforeprint,
+        beforeunload,
+        hashchange,
+        languagechange,
+        message,
+        messageerror,
+        offline,
+        online,
+        pagehide,
+        pagereveal,
+        pageshow,
+        pageswap,
+        popstate,
+        rejectionhandled,
+        storage,
+        unhandledrejection,
+        unload;
     }
 
     /**
      * The name of the context-param whose value must represent a space-separated list of additional HTML event names.
-     * All supported HTML event names are defined in the enums {@link HtmlDocumentElementEvent} and {@link HtmlBodyElementEvent}.
+     * All supported HTML event names are defined in the enums {@link HtmlElementEvent}, {@link HtmlBodyEvent} and {@link HtmlWindowEvent}.
      * Any HTML event name which you wish to add to these enums can be supplied via this context-param.
      * Duplicates will be automatically filtered, case sensitive.
      */
@@ -133,8 +161,9 @@ public final class HtmlEvents {
 
     private enum CacheKey {
         ADDITIONAL_HTML_EVENT_NAMES,
-        HTML_DOCUMENT_ELEMENT_EVENT_NAMES,
-        HTML_BODY_ELEMENT_EVENT_NAMES,
+        HTML_ELEMENT_EVENT_NAMES,
+        HTML_WINDOW_EVENT_NAMES,
+        HTML_BODY_EVENT_NAMES,
         FACES_ACTION_SOURCE_EVENT_NAMES,
         FACES_EDITABLE_VALUE_HOLDER_EVENT_NAMES;
     }
@@ -157,34 +186,43 @@ public final class HtmlEvents {
 
     /**
      * @param context The involved faces context.
-     * @return All supported event names for HTML document elements, including additional HTML event names.
+     * @return All supported event names for HTML elements, including additional HTML event names.
      */
-    public static Collection<String> getHtmlDocumentElementEventNames(FacesContext context) {
-        return cache(context, CacheKey.HTML_DOCUMENT_ELEMENT_EVENT_NAMES, () -> merge(getAdditionalHtmlEventNames(context), HtmlDocumentElementEvent.values()));
+    public static Collection<String> getHtmlElementEventNames(FacesContext context) {
+        return cache(context, CacheKey.HTML_ELEMENT_EVENT_NAMES, () -> merge(merge(getAdditionalHtmlEventNames(context), HtmlElementEvent.values()), HtmlBodyEvent.values()));
     }
 
     /**
      * @param context The involved faces context.
-     * @return All supported event names for HTML body elements, including HTML document element event names.
+     * @return All supported event names for the <code>Window</code> object, including additional HTML event names.
      */
-    public static Collection<String> getHtmlBodyElementEventNames(FacesContext context) {
-        return cache(context, CacheKey.HTML_BODY_ELEMENT_EVENT_NAMES, () -> merge(getHtmlDocumentElementEventNames(context), HtmlBodyElementEvent.values()));
+    public static Collection<String> getHtmlWindowEventNames(FacesContext context) {
+        return cache(context, CacheKey.HTML_WINDOW_EVENT_NAMES, () -> merge(getAdditionalHtmlEventNames(context), HtmlWindowEvent.values()));
     }
 
     /**
      * @param context The involved faces context.
-     * @return All supported event names for HTML implementations of Faces {@link ActionSource} components, including HTML body element event names.
+     * @return All supported event names for the HTML body element, being all HTML element event names and all
+     *         <code>Window</code> event names.
+     */
+    public static Collection<String> getHtmlBodyEventNames(FacesContext context) {
+        return cache(context, CacheKey.HTML_BODY_EVENT_NAMES, () -> collect(Stream.concat(getHtmlElementEventNames(context).stream(), getHtmlWindowEventNames(context).stream())));
+    }
+
+    /**
+     * @param context The involved faces context.
+     * @return All supported event names for HTML implementations of Faces {@link ActionSource} components, including HTML element event names.
      */
     public static Collection<String> getFacesActionSourceEventNames(FacesContext context) {
-        return cache(context, CacheKey.FACES_ACTION_SOURCE_EVENT_NAMES, () -> merge(getHtmlBodyElementEventNames(context), FacesComponentEvent.action));
+        return cache(context, CacheKey.FACES_ACTION_SOURCE_EVENT_NAMES, () -> merge(getHtmlElementEventNames(context), FacesComponentEvent.action));
     }
 
     /**
      * @param context The involved faces context.
-     * @return All supported event names for HTML implementations of Faces {@link EditableValueHolder} components, including HTML body element event names.
+     * @return All supported event names for HTML implementations of Faces {@link EditableValueHolder} components, including HTML element event names.
      */
     public static Collection<String> getFacesEditableValueHolderEventNames(FacesContext context) {
-        return cache(context, CacheKey.FACES_EDITABLE_VALUE_HOLDER_EVENT_NAMES, () -> merge(getHtmlBodyElementEventNames(context), FacesComponentEvent.valueChange));
+        return cache(context, CacheKey.FACES_EDITABLE_VALUE_HOLDER_EVENT_NAMES, () -> merge(getHtmlElementEventNames(context), FacesComponentEvent.valueChange));
     }
 
     private static Collection<String> collect(Stream<String> stream) {

--- a/api/src/main/java/jakarta/faces/component/html/HtmlEvents.java
+++ b/api/src/main/java/jakarta/faces/component/html/HtmlEvents.java
@@ -1,14 +1,15 @@
 package jakarta.faces.component.html;
 
-import static java.util.Arrays.asList;
+import static java.util.Arrays.stream;
 import static java.util.Collections.emptyList;
 import static java.util.Optional.ofNullable;
+import static java.util.function.Predicate.not;
 import static java.util.stream.Collectors.toUnmodifiableList;
 
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.EnumMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 
@@ -173,7 +174,7 @@ public final class HtmlEvents {
     }
 
     private static Collection<String> getContextParam(FacesContext context) {
-        return ofNullable(context.getExternalContext().getInitParameter(ADDITIONAL_HTML_EVENT_NAMES_PARAM_NAME)).map(param -> asList(param.split("\\s+"))).orElse(emptyList());
+        return ofNullable(context.getExternalContext().getInitParameter(ADDITIONAL_HTML_EVENT_NAMES_PARAM_NAME)).map(param -> collect(stream(param.split("\\s+")).filter(not(String::isBlank)))).orElse(emptyList());
     }
 
     /**
@@ -235,8 +236,16 @@ public final class HtmlEvents {
 
     @SuppressWarnings("unchecked") // the event-name cache is stored under an Object-valued application-map entry.
     private static Collection<String> cache(FacesContext context, CacheKey key, Supplier<Collection<String>> supplier) {
-        return ((Map<CacheKey, Collection<String>>) context.getExternalContext().getApplicationMap()
-                .computeIfAbsent(ADDITIONAL_HTML_EVENT_NAMES_PARAM_NAME, $ -> new EnumMap<>(CacheKey.class)))
-                .computeIfAbsent(key, $ -> supplier.get());
+        Map<CacheKey, Collection<String>> cache = (Map<CacheKey, Collection<String>>) context.getExternalContext().getApplicationMap()
+                .computeIfAbsent(ADDITIONAL_HTML_EVENT_NAMES_PARAM_NAME, $ -> new ConcurrentHashMap<CacheKey, Collection<String>>());
+        Collection<String> eventNames = cache.get(key);
+
+        if (eventNames == null) {
+            // Deliberately no computeIfAbsent: the suppliers recursively populate this very map, which a ConcurrentHashMap rejects.
+            eventNames = supplier.get();
+            cache.put(key, eventNames);
+        }
+
+        return eventNames;
     }
 }

--- a/api/src/main/java/jakarta/faces/component/html/HtmlForm.java
+++ b/api/src/main/java/jakarta/faces/component/html/HtmlForm.java
@@ -18,7 +18,7 @@
 package jakarta.faces.component.html;
 
 import static jakarta.faces.component.html.HtmlComponentUtils.handleAttribute;
-import static jakarta.faces.component.html.HtmlEvents.getHtmlBodyElementEventNames;
+import static jakarta.faces.component.html.HtmlEvents.getHtmlElementEventNames;
 
 import java.util.Collection;
 
@@ -661,7 +661,7 @@ public class HtmlForm extends UIForm implements ClientBehaviorHolder {
 
     @Override
     public Collection<String> getEventNames() {
-        return getHtmlBodyElementEventNames(getFacesContext()); 
+        return getHtmlElementEventNames(getFacesContext()); 
     }
 
     @Override

--- a/api/src/main/java/jakarta/faces/component/html/HtmlGraphicImage.java
+++ b/api/src/main/java/jakarta/faces/component/html/HtmlGraphicImage.java
@@ -17,7 +17,7 @@
  */
 package jakarta.faces.component.html;
 import static jakarta.faces.component.html.HtmlComponentUtils.handleAttribute;
-import static jakarta.faces.component.html.HtmlEvents.getHtmlBodyElementEventNames;
+import static jakarta.faces.component.html.HtmlEvents.getHtmlElementEventNames;
 
 import java.util.Collection;
 
@@ -660,7 +660,7 @@ public class HtmlGraphicImage extends UIGraphic implements ClientBehaviorHolder 
 
     @Override
     public Collection<String> getEventNames() {
-        return getHtmlBodyElementEventNames(getFacesContext()); 
+        return getHtmlElementEventNames(getFacesContext()); 
     }
 
     @Override

--- a/api/src/main/java/jakarta/faces/component/html/HtmlOutcomeTargetButton.java
+++ b/api/src/main/java/jakarta/faces/component/html/HtmlOutcomeTargetButton.java
@@ -18,13 +18,13 @@
 package jakarta.faces.component.html;
 
 import static jakarta.faces.component.html.HtmlComponentUtils.handleAttribute;
-import static jakarta.faces.component.html.HtmlEvents.getHtmlBodyElementEventNames;
+import static jakarta.faces.component.html.HtmlEvents.getHtmlElementEventNames;
 
 import java.util.Collection;
 
 import jakarta.faces.component.UIOutcomeTarget;
 import jakarta.faces.component.behavior.ClientBehaviorHolder;
-import jakarta.faces.component.html.HtmlEvents.HtmlDocumentElementEvent;
+import jakarta.faces.component.html.HtmlEvents.HtmlElementEvent;
 
 /**
  * <p>
@@ -696,12 +696,12 @@ public class HtmlOutcomeTargetButton extends UIOutcomeTarget implements ClientBe
 
     @Override
     public Collection<String> getEventNames() {
-        return getHtmlBodyElementEventNames(getFacesContext()); 
+        return getHtmlElementEventNames(getFacesContext()); 
     }
 
     @Override
     public String getDefaultEventName() {
-        return HtmlDocumentElementEvent.click.name();
+        return HtmlElementEvent.click.name();
     }
 
 }

--- a/api/src/main/java/jakarta/faces/component/html/HtmlOutcomeTargetLink.java
+++ b/api/src/main/java/jakarta/faces/component/html/HtmlOutcomeTargetLink.java
@@ -18,13 +18,13 @@
 package jakarta.faces.component.html;
 
 import static jakarta.faces.component.html.HtmlComponentUtils.handleAttribute;
-import static jakarta.faces.component.html.HtmlEvents.getHtmlBodyElementEventNames;
+import static jakarta.faces.component.html.HtmlEvents.getHtmlElementEventNames;
 
 import java.util.Collection;
 
 import jakarta.faces.component.UIOutcomeTarget;
 import jakarta.faces.component.behavior.ClientBehaviorHolder;
-import jakarta.faces.component.html.HtmlEvents.HtmlDocumentElementEvent;
+import jakarta.faces.component.html.HtmlEvents.HtmlElementEvent;
 
 /**
  * <p>
@@ -845,12 +845,12 @@ public class HtmlOutcomeTargetLink extends UIOutcomeTarget implements ClientBeha
 
     @Override
     public Collection<String> getEventNames() {
-        return getHtmlBodyElementEventNames(getFacesContext()); 
+        return getHtmlElementEventNames(getFacesContext()); 
     }
 
     @Override
     public String getDefaultEventName() {
-        return HtmlDocumentElementEvent.click.name();
+        return HtmlElementEvent.click.name();
     }
 
 }

--- a/api/src/main/java/jakarta/faces/component/html/HtmlOutputLabel.java
+++ b/api/src/main/java/jakarta/faces/component/html/HtmlOutputLabel.java
@@ -18,7 +18,7 @@
 package jakarta.faces.component.html;
 
 import static jakarta.faces.component.html.HtmlComponentUtils.handleAttribute;
-import static jakarta.faces.component.html.HtmlEvents.getHtmlBodyElementEventNames;
+import static jakarta.faces.component.html.HtmlEvents.getHtmlElementEventNames;
 
 import java.util.Collection;
 
@@ -662,7 +662,7 @@ public class HtmlOutputLabel extends UIOutput implements ClientBehaviorHolder {
 
     @Override
     public Collection<String> getEventNames() {
-        return getHtmlBodyElementEventNames(getFacesContext()); 
+        return getHtmlElementEventNames(getFacesContext()); 
     }
 
     @Override

--- a/api/src/main/java/jakarta/faces/component/html/HtmlOutputLink.java
+++ b/api/src/main/java/jakarta/faces/component/html/HtmlOutputLink.java
@@ -18,13 +18,13 @@
 package jakarta.faces.component.html;
 
 import static jakarta.faces.component.html.HtmlComponentUtils.handleAttribute;
-import static jakarta.faces.component.html.HtmlEvents.getHtmlBodyElementEventNames;
+import static jakarta.faces.component.html.HtmlEvents.getHtmlElementEventNames;
 
 import java.util.Collection;
 
 import jakarta.faces.component.UIOutput;
 import jakarta.faces.component.behavior.ClientBehaviorHolder;
-import jakarta.faces.component.html.HtmlEvents.HtmlDocumentElementEvent;
+import jakarta.faces.component.html.HtmlEvents.HtmlElementEvent;
 
 /**
  * <p>
@@ -873,12 +873,12 @@ public class HtmlOutputLink extends UIOutput implements ClientBehaviorHolder {
 
     @Override
     public Collection<String> getEventNames() {
-        return getHtmlBodyElementEventNames(getFacesContext()); 
+        return getHtmlElementEventNames(getFacesContext()); 
     }
 
     @Override
     public String getDefaultEventName() {
-        return HtmlDocumentElementEvent.click.name();
+        return HtmlElementEvent.click.name();
     }
 
 }

--- a/api/src/main/java/jakarta/faces/component/html/HtmlPanelGrid.java
+++ b/api/src/main/java/jakarta/faces/component/html/HtmlPanelGrid.java
@@ -18,7 +18,7 @@
 package jakarta.faces.component.html;
 
 import static jakarta.faces.component.html.HtmlComponentUtils.handleAttribute;
-import static jakarta.faces.component.html.HtmlEvents.getHtmlBodyElementEventNames;
+import static jakarta.faces.component.html.HtmlEvents.getHtmlElementEventNames;
 
 import java.util.Collection;
 
@@ -961,7 +961,7 @@ public class HtmlPanelGrid extends UIPanel implements ClientBehaviorHolder {
 
     @Override
     public Collection<String> getEventNames() {
-        return getHtmlBodyElementEventNames(getFacesContext()); 
+        return getHtmlElementEventNames(getFacesContext()); 
     }
 
     @Override

--- a/api/src/main/java/jakarta/faces/component/html/HtmlPanelGroup.java
+++ b/api/src/main/java/jakarta/faces/component/html/HtmlPanelGroup.java
@@ -18,7 +18,7 @@
 package jakarta.faces.component.html;
 
 import static jakarta.faces.component.html.HtmlComponentUtils.handleAttribute;
-import static jakarta.faces.component.html.HtmlEvents.getHtmlBodyElementEventNames;
+import static jakarta.faces.component.html.HtmlEvents.getHtmlElementEventNames;
 
 import java.util.Collection;
 
@@ -415,7 +415,7 @@ public class HtmlPanelGroup extends UIPanel implements ClientBehaviorHolder {
 
     @Override
     public Collection<String> getEventNames() {
-        return getHtmlBodyElementEventNames(getFacesContext()); 
+        return getHtmlElementEventNames(getFacesContext()); 
     }
 
     @Override

--- a/api/src/test/java/jakarta/faces/component/html/HtmlEventsTest.java
+++ b/api/src/test/java/jakarta/faces/component/html/HtmlEventsTest.java
@@ -107,14 +107,25 @@ class HtmlEventsTest {
     }
 
     @Test
-    void additionalEventNamesAreMerged() {
-        when(externalContext.getInitParameter(ADDITIONAL_HTML_EVENT_NAMES_PARAM_NAME)).thenReturn("animationend transitionend");
+    void additionalEventNamesAreMergedAndContributeNoBlankName() {
+        when(externalContext.getInitParameter(ADDITIONAL_HTML_EVENT_NAMES_PARAM_NAME)).thenReturn("  animationend \t transitionend  ");
 
         Collection<String> eventNames = new HtmlPanelGroup().getEventNames();
 
         assertTrue(eventNames.contains("animationend"));
         assertTrue(eventNames.contains("transitionend"));
+        assertFalse(eventNames.contains(""));
         assertEquals(HtmlEvents.HtmlElementEvent.values().length + HtmlEvents.HtmlBodyEvent.values().length + 2, eventNames.size());
+    }
+
+    @Test
+    void blankAdditionalEventNamesParamContributesNothing() {
+        when(externalContext.getInitParameter(ADDITIONAL_HTML_EVENT_NAMES_PARAM_NAME)).thenReturn(" ");
+
+        Collection<String> eventNames = new HtmlPanelGroup().getEventNames();
+
+        assertFalse(eventNames.contains(""));
+        assertEquals(HtmlEvents.HtmlElementEvent.values().length + HtmlEvents.HtmlBodyEvent.values().length, eventNames.size());
     }
 
     @Test

--- a/api/src/test/java/jakarta/faces/component/html/HtmlEventsTest.java
+++ b/api/src/test/java/jakarta/faces/component/html/HtmlEventsTest.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) Contributors to Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.faces.component.html;
+
+import static jakarta.faces.component.html.HtmlEvents.ADDITIONAL_HTML_EVENT_NAMES_PARAM_NAME;
+import static java.util.Comparator.naturalOrder;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+
+import jakarta.faces.context.CurrentFacesContext;
+import jakarta.faces.context.ExternalContext;
+import jakarta.faces.context.FacesContext;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The HTML spec supports three sets of event handler content attributes: those which every element supports and which
+ * fire on the element itself, those which every element supports but which are forwarded to the window object when
+ * they are declared on the body element, and those which only the body element supports and which always fire on the
+ * window object. A component representing the body element therefore exposes all three of them as behavior events,
+ * while every other component exposes the first two.
+ */
+class HtmlEventsTest {
+
+    private ExternalContext externalContext;
+
+    @BeforeEach
+    void setUpCurrentFacesContext() {
+        externalContext = mock(ExternalContext.class);
+        when(externalContext.getApplicationMap()).thenReturn(new HashMap<>());
+
+        FacesContext facesContext = mock(FacesContext.class);
+        when(facesContext.getExternalContext()).thenReturn(externalContext);
+
+        CurrentFacesContext.set(facesContext);
+    }
+
+    @Test
+    void bodyExposesElementAndBodyAndWindowEvents() {
+        Collection<String> eventNames = new HtmlBody().getEventNames();
+
+        assertTrue(eventNames.contains("click"));
+        assertTrue(eventNames.contains("scrollend"));
+        assertTrue(eventNames.contains("load"));
+        assertTrue(eventNames.contains("unload"));
+        assertTrue(eventNames.contains("pagehide"));
+        assertEquals(HtmlEvents.HtmlElementEvent.values().length + HtmlEvents.HtmlBodyEvent.values().length + HtmlEvents.HtmlWindowEvent.values().length, eventNames.size());
+    }
+
+    @Test
+    void otherComponentsExposeElementAndBodyEventsButNoWindowEvents() {
+        Collection<String> eventNames = new HtmlPanelGroup().getEventNames();
+
+        assertTrue(eventNames.contains("click"));
+        assertTrue(eventNames.contains("scrollend"));
+        assertTrue(eventNames.contains("load"));
+        assertFalse(eventNames.contains("unload"));
+        assertFalse(eventNames.contains("pagehide"));
+    }
+
+    @Test
+    void windowEventNamesHoldTheWindowEventsOnly() {
+        Collection<String> eventNames = HtmlEvents.getHtmlWindowEventNames(FacesContext.getCurrentInstance());
+
+        assertTrue(eventNames.contains("unload"));
+        assertTrue(eventNames.contains("pagehide"));
+        assertFalse(eventNames.contains("click"));
+        assertFalse(eventNames.contains("load"));
+        assertEquals(HtmlEvents.HtmlWindowEvent.values().length, eventNames.size());
+    }
+
+    @Test
+    void actionSourceAndEditableValueHolderComponentsExposeTheirComponentEvent() {
+        Collection<String> commandEventNames = new HtmlCommandButton().getEventNames();
+        Collection<String> inputEventNames = new HtmlInputText().getEventNames();
+
+        assertTrue(commandEventNames.contains("action"));
+        assertTrue(commandEventNames.contains("input"));
+        assertFalse(commandEventNames.contains("valueChange"));
+
+        assertTrue(inputEventNames.contains("valueChange"));
+        assertTrue(inputEventNames.contains("input"));
+        assertFalse(inputEventNames.contains("action"));
+    }
+
+    @Test
+    void additionalEventNamesAreMerged() {
+        when(externalContext.getInitParameter(ADDITIONAL_HTML_EVENT_NAMES_PARAM_NAME)).thenReturn("animationend transitionend");
+
+        Collection<String> eventNames = new HtmlPanelGroup().getEventNames();
+
+        assertTrue(eventNames.contains("animationend"));
+        assertTrue(eventNames.contains("transitionend"));
+        assertEquals(HtmlEvents.HtmlElementEvent.values().length + HtmlEvents.HtmlBodyEvent.values().length + 2, eventNames.size());
+    }
+
+    @Test
+    void eventNamesAreSortedAndDistinct() {
+        List<String> eventNames = new ArrayList<>(new HtmlBody().getEventNames());
+        List<String> sortedAndDistinct = eventNames.stream().distinct().sorted(naturalOrder()).toList();
+
+        assertEquals(sortedAndDistinct, eventNames);
+    }
+}

--- a/spec/src/main/asciidoc/UserInterfaceComponentModel.adoc
+++ b/spec/src/main/asciidoc/UserInterfaceComponentModel.adoc
@@ -1406,9 +1406,12 @@ event names supported by HTML elements as per the
 https://html.spec.whatwg.org/multipage/webappapis.html#event-handlers-on-elements,-document-objects,-and-window-objects[current HTML spec].
 The concrete HTML component classes use _HtmlEvents_ to dynamically return
 the supported event names from _getEventNames()_.
-The _HtmlEvents.HtmlDocumentElementEvent_ enum defines the events supported
-by all HTML document elements, and the _HtmlEvents.HtmlBodyElementEvent_ enum
-defines additional events supported by the HTML body element.
+The _HtmlEvents.HtmlElementEvent_ enum defines the events supported by all
+HTML elements which fire on the element itself, the _HtmlEvents.HtmlBodyEvent_
+enum defines the events supported by all HTML elements which are forwarded to
+the _Window_ object when they are declared on the HTML body element, and the
+_HtmlEvents.HtmlWindowEvent_ enum defines the events supported by the HTML body
+element only, which always fire on the _Window_ object.
 The _BehaviorEvent.FacesComponentEvent_ enum defines the additional component-level
 events: _action_ for _ActionSource_ components and _valueChange_ for
 _EditableValueHolder_ components.
@@ -3562,8 +3565,8 @@ The standard HTML component classes use _HtmlEvents_ to return
 the appropriate set of event names. _ActionSource_ components use
 _HtmlEvents.getFacesActionSourceEventNames()_, _EditableValueHolder_ components use
 _HtmlEvents.getFacesEditableValueHolderEventNames()_, and other components use
-_HtmlEvents.getHtmlBodyElementEventNames()_ or _HtmlEvents.getHtmlDocumentElementEventNames()_
-as appropriate for the HTML element they represent.
+_HtmlEvents.getHtmlElementEventNames()_, or _HtmlEvents.getHtmlBodyEventNames()_
+when they represent the HTML body element.
 
 Here’s an example code snippet from one of
 the Html components:

--- a/spec/src/main/asciidoc/UsingFacesInWebApplications.adoc
+++ b/spec/src/main/asciidoc/UsingFacesInWebApplications.adoc
@@ -125,7 +125,8 @@ for the specification of this feature.
 If this param is set, the runtime must interpret its value as a
 space-separated list of additional HTML event names to be recognized by all
 _ClientBehaviorHolder_ components in addition to the event names defined in
-_HtmlEvents.HtmlDocumentElementEvent_ and _HtmlEvents.HtmlBodyElementEvent_.
+_HtmlEvents.HtmlElementEvent_, _HtmlEvents.HtmlBodyEvent_ and
+_HtmlEvents.HtmlWindowEvent_.
 This allows custom HTML event names to be used with _f:ajax_.
 See the javadocs for the constant
 _jakarta.faces.component.html.HtmlEvents.ADDITIONAL_HTML_EVENT_NAMES_PARAM_NAME_

--- a/tck/faces-signature-test/src/test/resources/ee/jakarta/tck/faces/signaturetest/jakarta.faces.sig_5.0.0
+++ b/tck/faces-signature-test/src/test/resources/ee/jakarta/tck/faces/signaturetest/jakarta.faces.sig_5.0.0
@@ -2274,99 +2274,125 @@ hfds toString
 
 CLSS public final jakarta.faces.component.html.HtmlEvents
 fld public final static java.lang.String ADDITIONAL_HTML_EVENT_NAMES_PARAM_NAME = "jakarta.faces.ADDITIONAL_HTML_EVENT_NAMES"
-innr public final static !enum HtmlBodyElementEvent
-innr public final static !enum HtmlDocumentElementEvent
+innr public final static !enum HtmlBodyEvent
+innr public final static !enum HtmlElementEvent
+innr public final static !enum HtmlWindowEvent
 meth public static java.util.Collection<java.lang.String> getAdditionalHtmlEventNames(jakarta.faces.context.FacesContext)
 meth public static java.util.Collection<java.lang.String> getFacesActionSourceEventNames(jakarta.faces.context.FacesContext)
 meth public static java.util.Collection<java.lang.String> getFacesEditableValueHolderEventNames(jakarta.faces.context.FacesContext)
-meth public static java.util.Collection<java.lang.String> getHtmlBodyElementEventNames(jakarta.faces.context.FacesContext)
-meth public static java.util.Collection<java.lang.String> getHtmlDocumentElementEventNames(jakarta.faces.context.FacesContext)
+meth public static java.util.Collection<java.lang.String> getHtmlBodyEventNames(jakarta.faces.context.FacesContext)
+meth public static java.util.Collection<java.lang.String> getHtmlElementEventNames(jakarta.faces.context.FacesContext)
+meth public static java.util.Collection<java.lang.String> getHtmlWindowEventNames(jakarta.faces.context.FacesContext)
 supr java.lang.Object
 hcls CacheKey
 
-CLSS public final static !enum jakarta.faces.component.html.HtmlEvents$HtmlBodyElementEvent
+CLSS public final static !enum jakarta.faces.component.html.HtmlEvents$HtmlBodyEvent
  outer jakarta.faces.component.html.HtmlEvents
-fld public final static jakarta.faces.component.html.HtmlEvents$HtmlBodyElementEvent blur
-fld public final static jakarta.faces.component.html.HtmlEvents$HtmlBodyElementEvent error
-fld public final static jakarta.faces.component.html.HtmlEvents$HtmlBodyElementEvent focus
-fld public final static jakarta.faces.component.html.HtmlEvents$HtmlBodyElementEvent load
-fld public final static jakarta.faces.component.html.HtmlEvents$HtmlBodyElementEvent resize
-fld public final static jakarta.faces.component.html.HtmlEvents$HtmlBodyElementEvent scroll
-fld public final static jakarta.faces.component.html.HtmlEvents$HtmlBodyElementEvent scrollend
-meth public static jakarta.faces.component.html.HtmlEvents$HtmlBodyElementEvent valueOf(java.lang.String)
-meth public static jakarta.faces.component.html.HtmlEvents$HtmlBodyElementEvent[] values()
-supr java.lang.Enum<jakarta.faces.component.html.HtmlEvents$HtmlBodyElementEvent>
+fld public final static jakarta.faces.component.html.HtmlEvents$HtmlBodyEvent blur
+fld public final static jakarta.faces.component.html.HtmlEvents$HtmlBodyEvent error
+fld public final static jakarta.faces.component.html.HtmlEvents$HtmlBodyEvent focus
+fld public final static jakarta.faces.component.html.HtmlEvents$HtmlBodyEvent load
+fld public final static jakarta.faces.component.html.HtmlEvents$HtmlBodyEvent resize
+fld public final static jakarta.faces.component.html.HtmlEvents$HtmlBodyEvent scroll
+meth public static jakarta.faces.component.html.HtmlEvents$HtmlBodyEvent valueOf(java.lang.String)
+meth public static jakarta.faces.component.html.HtmlEvents$HtmlBodyEvent[] values()
+supr java.lang.Enum<jakarta.faces.component.html.HtmlEvents$HtmlBodyEvent>
 
-CLSS public final static !enum jakarta.faces.component.html.HtmlEvents$HtmlDocumentElementEvent
+CLSS public final static !enum jakarta.faces.component.html.HtmlEvents$HtmlElementEvent
  outer jakarta.faces.component.html.HtmlEvents
-fld public final static jakarta.faces.component.html.HtmlEvents$HtmlDocumentElementEvent abort
-fld public final static jakarta.faces.component.html.HtmlEvents$HtmlDocumentElementEvent auxclick
-fld public final static jakarta.faces.component.html.HtmlEvents$HtmlDocumentElementEvent beforeinput
-fld public final static jakarta.faces.component.html.HtmlEvents$HtmlDocumentElementEvent beforematch
-fld public final static jakarta.faces.component.html.HtmlEvents$HtmlDocumentElementEvent beforetoggle
-fld public final static jakarta.faces.component.html.HtmlEvents$HtmlDocumentElementEvent cancel
-fld public final static jakarta.faces.component.html.HtmlEvents$HtmlDocumentElementEvent canplay
-fld public final static jakarta.faces.component.html.HtmlEvents$HtmlDocumentElementEvent canplaythrough
-fld public final static jakarta.faces.component.html.HtmlEvents$HtmlDocumentElementEvent change
-fld public final static jakarta.faces.component.html.HtmlEvents$HtmlDocumentElementEvent click
-fld public final static jakarta.faces.component.html.HtmlEvents$HtmlDocumentElementEvent close
-fld public final static jakarta.faces.component.html.HtmlEvents$HtmlDocumentElementEvent command
-fld public final static jakarta.faces.component.html.HtmlEvents$HtmlDocumentElementEvent contextlost
-fld public final static jakarta.faces.component.html.HtmlEvents$HtmlDocumentElementEvent contextmenu
-fld public final static jakarta.faces.component.html.HtmlEvents$HtmlDocumentElementEvent contextrestored
-fld public final static jakarta.faces.component.html.HtmlEvents$HtmlDocumentElementEvent copy
-fld public final static jakarta.faces.component.html.HtmlEvents$HtmlDocumentElementEvent cuechange
-fld public final static jakarta.faces.component.html.HtmlEvents$HtmlDocumentElementEvent cut
-fld public final static jakarta.faces.component.html.HtmlEvents$HtmlDocumentElementEvent dblclick
-fld public final static jakarta.faces.component.html.HtmlEvents$HtmlDocumentElementEvent drag
-fld public final static jakarta.faces.component.html.HtmlEvents$HtmlDocumentElementEvent dragend
-fld public final static jakarta.faces.component.html.HtmlEvents$HtmlDocumentElementEvent dragenter
-fld public final static jakarta.faces.component.html.HtmlEvents$HtmlDocumentElementEvent dragleave
-fld public final static jakarta.faces.component.html.HtmlEvents$HtmlDocumentElementEvent dragover
-fld public final static jakarta.faces.component.html.HtmlEvents$HtmlDocumentElementEvent dragstart
-fld public final static jakarta.faces.component.html.HtmlEvents$HtmlDocumentElementEvent drop
-fld public final static jakarta.faces.component.html.HtmlEvents$HtmlDocumentElementEvent durationchange
-fld public final static jakarta.faces.component.html.HtmlEvents$HtmlDocumentElementEvent emptied
-fld public final static jakarta.faces.component.html.HtmlEvents$HtmlDocumentElementEvent ended
-fld public final static jakarta.faces.component.html.HtmlEvents$HtmlDocumentElementEvent formdata
-fld public final static jakarta.faces.component.html.HtmlEvents$HtmlDocumentElementEvent input
-fld public final static jakarta.faces.component.html.HtmlEvents$HtmlDocumentElementEvent invalid
-fld public final static jakarta.faces.component.html.HtmlEvents$HtmlDocumentElementEvent keydown
-fld public final static jakarta.faces.component.html.HtmlEvents$HtmlDocumentElementEvent keypress
-fld public final static jakarta.faces.component.html.HtmlEvents$HtmlDocumentElementEvent keyup
-fld public final static jakarta.faces.component.html.HtmlEvents$HtmlDocumentElementEvent loadeddata
-fld public final static jakarta.faces.component.html.HtmlEvents$HtmlDocumentElementEvent loadedmetadata
-fld public final static jakarta.faces.component.html.HtmlEvents$HtmlDocumentElementEvent loadstart
-fld public final static jakarta.faces.component.html.HtmlEvents$HtmlDocumentElementEvent mousedown
-fld public final static jakarta.faces.component.html.HtmlEvents$HtmlDocumentElementEvent mouseenter
-fld public final static jakarta.faces.component.html.HtmlEvents$HtmlDocumentElementEvent mouseleave
-fld public final static jakarta.faces.component.html.HtmlEvents$HtmlDocumentElementEvent mousemove
-fld public final static jakarta.faces.component.html.HtmlEvents$HtmlDocumentElementEvent mouseout
-fld public final static jakarta.faces.component.html.HtmlEvents$HtmlDocumentElementEvent mouseover
-fld public final static jakarta.faces.component.html.HtmlEvents$HtmlDocumentElementEvent mouseup
-fld public final static jakarta.faces.component.html.HtmlEvents$HtmlDocumentElementEvent paste
-fld public final static jakarta.faces.component.html.HtmlEvents$HtmlDocumentElementEvent pause
-fld public final static jakarta.faces.component.html.HtmlEvents$HtmlDocumentElementEvent play
-fld public final static jakarta.faces.component.html.HtmlEvents$HtmlDocumentElementEvent playing
-fld public final static jakarta.faces.component.html.HtmlEvents$HtmlDocumentElementEvent progress
-fld public final static jakarta.faces.component.html.HtmlEvents$HtmlDocumentElementEvent ratechange
-fld public final static jakarta.faces.component.html.HtmlEvents$HtmlDocumentElementEvent reset
-fld public final static jakarta.faces.component.html.HtmlEvents$HtmlDocumentElementEvent securitypolicyviolation
-fld public final static jakarta.faces.component.html.HtmlEvents$HtmlDocumentElementEvent seeked
-fld public final static jakarta.faces.component.html.HtmlEvents$HtmlDocumentElementEvent seeking
-fld public final static jakarta.faces.component.html.HtmlEvents$HtmlDocumentElementEvent select
-fld public final static jakarta.faces.component.html.HtmlEvents$HtmlDocumentElementEvent slotchange
-fld public final static jakarta.faces.component.html.HtmlEvents$HtmlDocumentElementEvent stalled
-fld public final static jakarta.faces.component.html.HtmlEvents$HtmlDocumentElementEvent submit
-fld public final static jakarta.faces.component.html.HtmlEvents$HtmlDocumentElementEvent suspend
-fld public final static jakarta.faces.component.html.HtmlEvents$HtmlDocumentElementEvent timeupdate
-fld public final static jakarta.faces.component.html.HtmlEvents$HtmlDocumentElementEvent toggle
-fld public final static jakarta.faces.component.html.HtmlEvents$HtmlDocumentElementEvent volumechange
-fld public final static jakarta.faces.component.html.HtmlEvents$HtmlDocumentElementEvent waiting
-fld public final static jakarta.faces.component.html.HtmlEvents$HtmlDocumentElementEvent wheel
-meth public static jakarta.faces.component.html.HtmlEvents$HtmlDocumentElementEvent valueOf(java.lang.String)
-meth public static jakarta.faces.component.html.HtmlEvents$HtmlDocumentElementEvent[] values()
-supr java.lang.Enum<jakarta.faces.component.html.HtmlEvents$HtmlDocumentElementEvent>
+fld public final static jakarta.faces.component.html.HtmlEvents$HtmlElementEvent abort
+fld public final static jakarta.faces.component.html.HtmlEvents$HtmlElementEvent auxclick
+fld public final static jakarta.faces.component.html.HtmlEvents$HtmlElementEvent beforeinput
+fld public final static jakarta.faces.component.html.HtmlEvents$HtmlElementEvent beforematch
+fld public final static jakarta.faces.component.html.HtmlEvents$HtmlElementEvent beforetoggle
+fld public final static jakarta.faces.component.html.HtmlEvents$HtmlElementEvent cancel
+fld public final static jakarta.faces.component.html.HtmlEvents$HtmlElementEvent canplay
+fld public final static jakarta.faces.component.html.HtmlEvents$HtmlElementEvent canplaythrough
+fld public final static jakarta.faces.component.html.HtmlEvents$HtmlElementEvent change
+fld public final static jakarta.faces.component.html.HtmlEvents$HtmlElementEvent click
+fld public final static jakarta.faces.component.html.HtmlEvents$HtmlElementEvent close
+fld public final static jakarta.faces.component.html.HtmlEvents$HtmlElementEvent command
+fld public final static jakarta.faces.component.html.HtmlEvents$HtmlElementEvent contextlost
+fld public final static jakarta.faces.component.html.HtmlEvents$HtmlElementEvent contextmenu
+fld public final static jakarta.faces.component.html.HtmlEvents$HtmlElementEvent contextrestored
+fld public final static jakarta.faces.component.html.HtmlEvents$HtmlElementEvent copy
+fld public final static jakarta.faces.component.html.HtmlEvents$HtmlElementEvent cuechange
+fld public final static jakarta.faces.component.html.HtmlEvents$HtmlElementEvent cut
+fld public final static jakarta.faces.component.html.HtmlEvents$HtmlElementEvent dblclick
+fld public final static jakarta.faces.component.html.HtmlEvents$HtmlElementEvent drag
+fld public final static jakarta.faces.component.html.HtmlEvents$HtmlElementEvent dragend
+fld public final static jakarta.faces.component.html.HtmlEvents$HtmlElementEvent dragenter
+fld public final static jakarta.faces.component.html.HtmlEvents$HtmlElementEvent dragleave
+fld public final static jakarta.faces.component.html.HtmlEvents$HtmlElementEvent dragover
+fld public final static jakarta.faces.component.html.HtmlEvents$HtmlElementEvent dragstart
+fld public final static jakarta.faces.component.html.HtmlEvents$HtmlElementEvent drop
+fld public final static jakarta.faces.component.html.HtmlEvents$HtmlElementEvent durationchange
+fld public final static jakarta.faces.component.html.HtmlEvents$HtmlElementEvent emptied
+fld public final static jakarta.faces.component.html.HtmlEvents$HtmlElementEvent ended
+fld public final static jakarta.faces.component.html.HtmlEvents$HtmlElementEvent formdata
+fld public final static jakarta.faces.component.html.HtmlEvents$HtmlElementEvent input
+fld public final static jakarta.faces.component.html.HtmlEvents$HtmlElementEvent invalid
+fld public final static jakarta.faces.component.html.HtmlEvents$HtmlElementEvent keydown
+fld public final static jakarta.faces.component.html.HtmlEvents$HtmlElementEvent keypress
+fld public final static jakarta.faces.component.html.HtmlEvents$HtmlElementEvent keyup
+fld public final static jakarta.faces.component.html.HtmlEvents$HtmlElementEvent loadeddata
+fld public final static jakarta.faces.component.html.HtmlEvents$HtmlElementEvent loadedmetadata
+fld public final static jakarta.faces.component.html.HtmlEvents$HtmlElementEvent loadstart
+fld public final static jakarta.faces.component.html.HtmlEvents$HtmlElementEvent mousedown
+fld public final static jakarta.faces.component.html.HtmlEvents$HtmlElementEvent mouseenter
+fld public final static jakarta.faces.component.html.HtmlEvents$HtmlElementEvent mouseleave
+fld public final static jakarta.faces.component.html.HtmlEvents$HtmlElementEvent mousemove
+fld public final static jakarta.faces.component.html.HtmlEvents$HtmlElementEvent mouseout
+fld public final static jakarta.faces.component.html.HtmlEvents$HtmlElementEvent mouseover
+fld public final static jakarta.faces.component.html.HtmlEvents$HtmlElementEvent mouseup
+fld public final static jakarta.faces.component.html.HtmlEvents$HtmlElementEvent paste
+fld public final static jakarta.faces.component.html.HtmlEvents$HtmlElementEvent pause
+fld public final static jakarta.faces.component.html.HtmlEvents$HtmlElementEvent play
+fld public final static jakarta.faces.component.html.HtmlEvents$HtmlElementEvent playing
+fld public final static jakarta.faces.component.html.HtmlEvents$HtmlElementEvent progress
+fld public final static jakarta.faces.component.html.HtmlEvents$HtmlElementEvent ratechange
+fld public final static jakarta.faces.component.html.HtmlEvents$HtmlElementEvent reset
+fld public final static jakarta.faces.component.html.HtmlEvents$HtmlElementEvent scrollend
+fld public final static jakarta.faces.component.html.HtmlEvents$HtmlElementEvent securitypolicyviolation
+fld public final static jakarta.faces.component.html.HtmlEvents$HtmlElementEvent seeked
+fld public final static jakarta.faces.component.html.HtmlEvents$HtmlElementEvent seeking
+fld public final static jakarta.faces.component.html.HtmlEvents$HtmlElementEvent select
+fld public final static jakarta.faces.component.html.HtmlEvents$HtmlElementEvent slotchange
+fld public final static jakarta.faces.component.html.HtmlEvents$HtmlElementEvent stalled
+fld public final static jakarta.faces.component.html.HtmlEvents$HtmlElementEvent submit
+fld public final static jakarta.faces.component.html.HtmlEvents$HtmlElementEvent suspend
+fld public final static jakarta.faces.component.html.HtmlEvents$HtmlElementEvent timeupdate
+fld public final static jakarta.faces.component.html.HtmlEvents$HtmlElementEvent toggle
+fld public final static jakarta.faces.component.html.HtmlEvents$HtmlElementEvent volumechange
+fld public final static jakarta.faces.component.html.HtmlEvents$HtmlElementEvent waiting
+fld public final static jakarta.faces.component.html.HtmlEvents$HtmlElementEvent wheel
+meth public static jakarta.faces.component.html.HtmlEvents$HtmlElementEvent valueOf(java.lang.String)
+meth public static jakarta.faces.component.html.HtmlEvents$HtmlElementEvent[] values()
+supr java.lang.Enum<jakarta.faces.component.html.HtmlEvents$HtmlElementEvent>
+
+CLSS public final static !enum jakarta.faces.component.html.HtmlEvents$HtmlWindowEvent
+ outer jakarta.faces.component.html.HtmlEvents
+fld public final static jakarta.faces.component.html.HtmlEvents$HtmlWindowEvent afterprint
+fld public final static jakarta.faces.component.html.HtmlEvents$HtmlWindowEvent beforeprint
+fld public final static jakarta.faces.component.html.HtmlEvents$HtmlWindowEvent beforeunload
+fld public final static jakarta.faces.component.html.HtmlEvents$HtmlWindowEvent hashchange
+fld public final static jakarta.faces.component.html.HtmlEvents$HtmlWindowEvent languagechange
+fld public final static jakarta.faces.component.html.HtmlEvents$HtmlWindowEvent message
+fld public final static jakarta.faces.component.html.HtmlEvents$HtmlWindowEvent messageerror
+fld public final static jakarta.faces.component.html.HtmlEvents$HtmlWindowEvent offline
+fld public final static jakarta.faces.component.html.HtmlEvents$HtmlWindowEvent online
+fld public final static jakarta.faces.component.html.HtmlEvents$HtmlWindowEvent pagehide
+fld public final static jakarta.faces.component.html.HtmlEvents$HtmlWindowEvent pagereveal
+fld public final static jakarta.faces.component.html.HtmlEvents$HtmlWindowEvent pageshow
+fld public final static jakarta.faces.component.html.HtmlEvents$HtmlWindowEvent pageswap
+fld public final static jakarta.faces.component.html.HtmlEvents$HtmlWindowEvent popstate
+fld public final static jakarta.faces.component.html.HtmlEvents$HtmlWindowEvent rejectionhandled
+fld public final static jakarta.faces.component.html.HtmlEvents$HtmlWindowEvent storage
+fld public final static jakarta.faces.component.html.HtmlEvents$HtmlWindowEvent unhandledrejection
+fld public final static jakarta.faces.component.html.HtmlEvents$HtmlWindowEvent unload
+meth public static jakarta.faces.component.html.HtmlEvents$HtmlWindowEvent valueOf(java.lang.String)
+meth public static jakarta.faces.component.html.HtmlEvents$HtmlWindowEvent[] values()
+supr java.lang.Enum<jakarta.faces.component.html.HtmlEvents$HtmlWindowEvent>
 
 CLSS public jakarta.faces.component.html.HtmlForm
 cons public init()


### PR DESCRIPTION
HTML supports three sets of event handler content attributes, and `HtmlEvents` modeled two of them with the assignment inverted: the component rendering the body element got the plain element events, while every other component got those plus the six the body element forwards to the `Window` object. Two consequences, both raised by @tandraschko in #1507 while porting the feature to MyFaces: `<f:ajax event="load">` on `<h:body>` was supported in 4.x but no longer builds, and `unload` sits in neither enum, so it is unreachable on any component.

The model now follows the three tables of the [HTML spec section](https://html.spec.whatwg.org/multipage/webappapis.html#event-handlers-on-elements,-document-objects,-and-window-objects) verbatim:

| enum | count | HTML |
| --- | --- | --- |
| `HtmlElementEvent` | 66 | supported by all elements, fire on the element itself |
| `HtmlBodyEvent` | 6 | supported by all elements, forwarded to `Window` when declared on `body` — the *Window-reflecting body element event handler set* |
| `HtmlWindowEvent` | 18 | supported by `body` and `frameset` only, always fire on `Window` — the `WindowEventHandlers` mixin |

`scrollend` moves to `HtmlElementEvent`: it is a plain element event, not one the body element forwards, so it was the odd one out in the old body enum.

Each enum gets an accessor — `getHtmlElementEventNames()` (element + body + additional), `getHtmlWindowEventNames()` (window + additional), `getHtmlBodyEventNames()` (element ∪ window) — and `HtmlBody` returns the last one. Every other component keeps exactly the set it already had, so nothing else changes.

Effect for page authors: `<f:ajax event="load">` and `event="unload"` on `<h:body>` work again, and the remaining window events — `pagehide`, `pageshow`, `popstate`, `hashchange`, `storage` and the rest — become available there for the first time.

The second commit fixes two defects in the same class, independent of the model change: the event-name cache lives in the application map and is built on demand from request threads, so it is a `ConcurrentHashMap` rather than an `EnumMap` (populated with get/put, since the suppliers recursively populate the very map being computed); and a blank or whitespace-padded `jakarta.faces.ADDITIONAL_HTML_EVENT_NAMES` no longer contributes an empty event name to `getEventNames()`.

Also updated: both spec passages, the changed context-param documentation, the TCK signature baseline (regenerated with `faces-signature-generator`, and byte-identical to the hand-written entries), and a new `HtmlEventsTest` covering the three sets, the additional-names merging and the sorted-distinct contract of the returned collection.

Verified with the full TCK, green. The mojarra side is eclipse-ee4j/mojarra#5966, which needs the submodule pin bumped to this branch's merge commit.

One question left open deliberately, worth deciding before 5.0 freezes: the *Rendering Behavior Event Attributes* rule states only the positive case — what must happen when the substring after `on` is contained in `getEventNames()`. It is silent on the negative case, which is why one implementation rendered `onclck` as an inline attribute and the other rendered nothing. Happy to add the sentence here if we agree on it.

Refs #1507

🤖 Generated with Claude Opus 5
